### PR TITLE
Shortcircuit MPI lazy operations in the absence of MPI Environment

### DIFF
--- a/c++/nda/mpi/gather.hpp
+++ b/c++/nda/mpi/gather.hpp
@@ -50,6 +50,11 @@ struct mpi::lazy<mpi::tag::gather, A> {
     static_assert(std::decay_t<A>::layout_t::stride_order_encoded == std::decay_t<T>::layout_t::stride_order_encoded,
                   "Array types for rhs and target have incompatible stride order");
 
+    if (not mpi::has_env) {
+      target = rhs;
+      return;
+    }
+
     auto recvcounts = std::vector<int>(c.size());
     auto displs     = std::vector<int>(c.size() + 1, 0);
     int sendcount   = rhs.size();

--- a/c++/nda/mpi/reduce.hpp
+++ b/c++/nda/mpi/reduce.hpp
@@ -43,6 +43,11 @@ struct mpi::lazy<mpi::tag::reduce, A> {
     static_assert(std::decay_t<A>::layout_t::stride_order_encoded == std::decay_t<T>::layout_t::stride_order_encoded,
                   "Array types for rhs and target have incompatible stride order");
 
+    if (not mpi::has_env) {
+      target = rhs;
+      return;
+    }
+
     if constexpr (not mpi::has_mpi_type<value_type>) {
       target = nda::map([this](auto const &x) { return mpi::reduce(x, this->c, this->root, this->all, this->op); })(rhs);
     } else {

--- a/c++/nda/mpi/scatter.hpp
+++ b/c++/nda/mpi/scatter.hpp
@@ -46,6 +46,11 @@ struct mpi::lazy<mpi::tag::scatter, A> {
     static_assert(std::decay_t<A>::layout_t::stride_order_encoded == std::decay_t<T>::layout_t::stride_order_encoded,
                   "Array types for rhs and target have incompatible stride order");
 
+    if (not mpi::has_env) {
+      target = rhs;
+      return;
+    }
+
     auto sha = shape(); // WARNING : Keep this out of any if condition (shape USES MPI) !
     resize_or_check_if_view(target, sha);
 

--- a/test/c++/test_common.hpp
+++ b/test/c++/test_common.hpp
@@ -49,7 +49,7 @@ using nda::matrix_view;
 #define MAKE_MAIN_MPI                                                                                                                                \
   int main(int argc, char **argv) {                                                                                                                  \
     ::testing::InitGoogleTest(&argc, argv);                                                                                                          \
-    if (mpi::check_mpi_env() == mpi::MPI_ENV::True) {                                                                                                \
+    if (mpi::has_env) {                                                                                                                              \
       mpi::environment env(argc, argv);                                                                                                              \
       std::cout << "MPI environment detected\n";                                                                                                     \
       return RUN_ALL_TESTS();                                                                                                                        \

--- a/test/c++/test_common.hpp
+++ b/test/c++/test_common.hpp
@@ -48,9 +48,13 @@ using nda::matrix_view;
 
 #define MAKE_MAIN_MPI                                                                                                                                \
   int main(int argc, char **argv) {                                                                                                                  \
-    ::mpi::environment env(argc, argv);                                                                                                              \
     ::testing::InitGoogleTest(&argc, argv);                                                                                                          \
-    return RUN_ALL_TESTS();                                                                                                                          \
+    if (mpi::check_mpi_env() == mpi::MPI_ENV::True) {                                                                                                \
+      mpi::environment env(argc, argv);                                                                                                              \
+      std::cout << "MPI environment detected\n";                                                                                                     \
+      return RUN_ALL_TESTS();                                                                                                                        \
+    } else                                                                                                                                           \
+      return RUN_ALL_TESTS();                                                                                                                        \
   }
 
 #define MAKE_MAIN                                                                                                                                    \


### PR DESCRIPTION
This PR adds minor adjustments necessary in relation with https://github.com/TRIQS/mpi/pull/6
The mpi lazy operations should circuit whenever the code is run outside of `mpirun`