### PR TITLE
Enable contiguous memory traversal for array iteration

### DIFF
--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -238,8 +238,6 @@ private:
 template <typename Iterator>
 [[nodiscard]] auto make_iterator(bool at_end) const noexcept {
   if constexpr (iterator_rank == Rank) {
-    // FIXME : remove optimziation becasue of a TRIQS bug
-    return Iterator{indexmap().lengths(), indexmap().strides(), sto.data(), at_end};
     if constexpr (layout_t::is_stride_order_C())
       return Iterator{indexmap().lengths(), indexmap().strides(), sto.data(), at_end};
     else

--- a/c++/nda/layout/permutation.hpp
+++ b/c++/nda/layout/permutation.hpp
@@ -118,12 +118,12 @@ namespace nda::permutations {
   }
 
   // cyclic permutation, p times. Forward
-  // n = 1 :  0 1 2 3 ---->   3 0 1 2
-  // P[n] = (Rank + n - p) % Rank
+  // p = 1 :  0 1 2 3 ---->   3 0 1 2
+  // P[i] = (Rank + i - p) % Rank
   // 4 + 0 -1 = 3, 4 + 1 -1 = 0, 4 +2 -1 = 1, etc...
   // if pos < Rank, the cycle is partial
   // cycle<5> (1, 3) --> 2 0 1 3 4
-  // pos ==0 --> identity
+  // pos == 0 --> identity
   template <size_t Rank>
   constexpr std::array<int, Rank> cycle(int p, int pos = Rank) {
     auto result = stdutil::make_initialized_array<Rank>(0);

--- a/test/c++/nda_permutation.cpp
+++ b/test/c++/nda_permutation.cpp
@@ -92,14 +92,17 @@ TEST(Permutation, Iterator) { //NOLINT
           for (int l = 0; l < a.extent(3); ++l) { EXPECT_EQ(a(i, j, k, l), (*it++)); }
   }
 
+  // Rotate indices ijkl -> kijl
+  // New stride order will be 1203
   auto v = nda::rotate_index_view<2>(a);
+
 PRINT(v.iterator_rank);
   {
     auto it = v.begin();
 
-    for (int i = 0; i < v.extent(0); ++i)
-      for (int j = 0; j < v.extent(1); ++j)
-        for (int k = 0; k < v.extent(2); ++k)
+    for (int j = 0; j < v.extent(1); ++j)
+      for (int k = 0; k < v.extent(2); ++k)
+        for (int i = 0; i < v.extent(0); ++i)
           for (int l = 0; l < v.extent(3); ++l) { EXPECT_EQ(v(i, j, k, l), (*it++)); }
   }
 }


### PR DESCRIPTION
@parcollet You had previously disabled this "because of a TRIQS bug".
For me it seems all TRIQS/unstable tests are passing with this change.
Can you remind me what the issue was here?