### PR TITLE
Enable bound-checking for range-based array slicing

### DIFF
--- a/test/c++/nda_bound_check.cpp
+++ b/test/c++/nda_bound_check.cpp
@@ -24,9 +24,8 @@ TEST(Array, BoundCheck) { //NOLINT
 
   EXPECT_THROW(A(0, 3), std::runtime_error); //NOLINT
 
-  // FIXME : SHOULD WE REALLY THROW ?
-  //EXPECT_THROW(A(nda::range(0, 4), 2), std::runtime_error);
-  //EXPECT_THROW(A(nda::range(10, 14), 2), std::runtime_error);
+  EXPECT_THROW(A(nda::range(0, 4), 2), std::runtime_error);   //NOLINT
+  EXPECT_THROW(A(nda::range(10, 14), 2), std::runtime_error); //NOLINT
 
   EXPECT_THROW(A(nda::range(), 5), std::runtime_error); //NOLINT
   EXPECT_THROW(A(0, 3), std::runtime_error);            //NOLINT


### PR DESCRIPTION
This is a fix to https://github.com/TRIQS/nda/issues/22