### PR TITLE
Fix overflow

### DIFF
--- a/c++/nda/layout/idx_map.hpp
+++ b/c++/nda/layout/idx_map.hpp
@@ -113,7 +113,7 @@ namespace nda {
 
     /// Total number of elements (products of lengths in each dimension).
     // NB recomputed at each call (FIXME Optimize this ?)
-    [[nodiscard]] long size() const noexcept { return std::accumulate(len.cbegin(), len.cend(), 1, std::multiplies<>{}); }
+    [[nodiscard]] long size() const noexcept { return std::accumulate(len.cbegin(), len.cend(), 1L, std::multiplies<>{}); }
 
     /// Compile time size, 0 means "dynamical"
     static constexpr long ce_size() noexcept {


### PR DESCRIPTION
The template [`std::accumulate`](https://en.cppreference.com/w/cpp/algorithm/accumulate) is defined as
```c++
template< class InputIt, class T, class BinaryOperation >
T accumulate( InputIt first, InputIt last, T init,
              BinaryOperation op );
```
where the return type is determined by the initializer. However, a literal `1` has type `int`, so everything is narrowed from `long` to `int` and overflow ensues.

Originally we noticed this when the allocations in `triqs_ctint::measures::M4_iw` started crashing mysteriously.

Co-authored-by: @marcel-klett @mmalcolms