### PR TITLE
Fast small matrix inversions

### DIFF
--- a/benchmarks/small_inv.cpp
+++ b/benchmarks/small_inv.cpp
@@ -5,11 +5,13 @@ static void inv(benchmark::State &state) {
 
   nda::matrix<double> W(N, N), Wi(N, N);
   for (int i = 0; i < N; ++i)
-    for (int j = 0; j < N; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+    for (int j = 0; j < N; ++j) W(i, j) = (i > j ? 0.5 + i + 2.5 * j : i * 0.8 - j - 0.5);
 
   while (state.KeepRunning()) {
     benchmark::DoNotOptimize(Wi = inverse(W));
   }
 }
+
+BENCHMARK_TEMPLATE(inv, 1);
 BENCHMARK_TEMPLATE(inv, 2);
 BENCHMARK_TEMPLATE(inv, 3);

--- a/benchmarks/small_inv.cpp
+++ b/benchmarks/small_inv.cpp
@@ -1,0 +1,30 @@
+#include "./bench_common.hpp"
+
+static void inv_2x2(benchmark::State &state) {
+
+    nda::matrix<double> W(2, 2);
+    nda::matrix<double> Wi(2, 2);
+    for (int i = 0; i < 2; ++i)
+        for (int j = 0; j < 2; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+
+    while (state.KeepRunning()) {
+        benchmark::DoNotOptimize(Wi = inverse(W));
+    }
+}
+
+BENCHMARK(inv_2x2);
+
+static void inv_3x3(benchmark::State &state) {
+
+    nda::matrix<double> W(3, 3);
+    nda::matrix<double> Wi(3, 3);
+
+    for (int i = 0; i < 3; ++i)
+        for (int j = 0; j < 3; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+    
+    while (state.KeepRunning()) {
+        benchmark::DoNotOptimize(Wi = inverse(W));
+    }
+}
+
+BENCHMARK(inv_3x3);

--- a/benchmarks/small_inv.cpp
+++ b/benchmarks/small_inv.cpp
@@ -1,30 +1,15 @@
 #include "./bench_common.hpp"
 
-static void inv_2x2(benchmark::State &state) {
+template <int N>
+static void inv(benchmark::State &state) {
 
-    nda::matrix<double> W(2, 2);
-    nda::matrix<double> Wi(2, 2);
-    for (int i = 0; i < 2; ++i)
-        for (int j = 0; j < 2; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+  nda::matrix<double> W(N, N), Wi(N, N);
+  for (int i = 0; i < N; ++i)
+    for (int j = 0; j < N; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
 
-    while (state.KeepRunning()) {
-        benchmark::DoNotOptimize(Wi = inverse(W));
-    }
+  while (state.KeepRunning()) {
+    benchmark::DoNotOptimize(Wi = inverse(W));
+  }
 }
-
-BENCHMARK(inv_2x2);
-
-static void inv_3x3(benchmark::State &state) {
-
-    nda::matrix<double> W(3, 3);
-    nda::matrix<double> Wi(3, 3);
-
-    for (int i = 0; i < 3; ++i)
-        for (int j = 0; j < 3; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
-    
-    while (state.KeepRunning()) {
-        benchmark::DoNotOptimize(Wi = inverse(W));
-    }
-}
-
-BENCHMARK(inv_3x3);
+BENCHMARK_TEMPLATE(inv, 2);
+BENCHMARK_TEMPLATE(inv, 3);

--- a/c++/nda/linalg/det_and_inverse.hpp
+++ b/c++/nda/linalg/det_and_inverse.hpp
@@ -34,17 +34,16 @@ namespace nda {
   // ----------  Determinant -------------------------
 
   template <typename M>
-  auto determinant_in_place(M &m)
-    requires(is_matrix_or_view_v<M>)
-  {
+  auto determinant_in_place(M &m) requires(is_matrix_or_view_v<M>) {
     using value_t = get_value_t<M>;
     static_assert(std::is_convertible_v<value_t, double> or std::is_convertible_v<value_t, std::complex<double>>,
-                  "determinant requires a matrix of values that can be implicitly converted to double or std::complex<double>");
+	"determinant requires a matrix of values that can be implicitly converted to double or std::complex<double>");
     static_assert(not std::is_const_v<M>, "determinant_in_place can not be const. It destroys its argument");
 
-    if (m.empty()) return value_t{1};
+    if(m.empty()) return value_t{1};
 
-    if (m.extent(0) != m.extent(1)) NDA_RUNTIME_ERROR << "Error in determinant. Matrix is not square but has shape " << m.shape();
+    if(m.extent(0) != m.extent(1))
+      NDA_RUNTIME_ERROR << "Error in determinant. Matrix is not square but has shape " << m.shape();
     const int dim = m.extent(0);
 
     // Calculate the LU decomposition using lapack getrf
@@ -53,12 +52,12 @@ namespace nda {
     if (info < 0) NDA_RUNTIME_ERROR << "Error in determinant. Info lapack is " << info;
 
     // Calculate the determinant from the LU decomposition
-    auto det    = value_t{1};
+    auto det = value_t{1};
     int n_flips = 0;
-    for (int i = 0; i < dim; i++) {
+    for (int i = 0; i < dim; i++){
       det *= m(i, i);
       // Count the number of column interchanges performed by getrf
-      if (ipiv(i) != i + 1) ++n_flips;
+      if(ipiv(i) != i + 1) ++n_flips;
     }
 
     return ((n_flips % 2 == 1) ? -det : det);
@@ -88,14 +87,14 @@ namespace nda {
     std::swap(a(0,0), a(1,1));
 
     // calculate the inverse determinant of the matrix
-    auto detinv = (a(0, 0) * a(1, 1) - a(0, 1) * a(1, 0));
-    detinv = 1.0/detinv;
+    auto det = (a(0, 0) * a(1, 1) - a(0, 1) * a(1, 0));
+    if (det == 0.0) NDA_RUNTIME_ERROR << "Inverse/Det error : matrix is not invertible.";
+    auto detinv = 1.0/det;
 
     a(0,0) *= +detinv; 
     a(1,1) *= +detinv;
     a(1,0) *= -detinv;
     a(0,1) *= -detinv;
-
   }
 
   // ----------  inverse (3x3) ---------------------
@@ -114,14 +113,14 @@ namespace nda {
     auto b22 = +a(0, 0) * a(1, 1) - a(0, 1) * a(1, 0);
 
     // calculate the inverse determinant of the matrix
-    auto detinv  =  a(0,0)*b00 + a(0,1)*b10 + a(0,2)*b20;
-    detinv = 1.0/detinv;
+    auto det = a(0,0)*b00 + a(0,1)*b10 + a(0,2)*b20;
+    if (det == 0.0) NDA_RUNTIME_ERROR << "Inverse/Det error : matrix is not invertible.";
+    auto detinv = 1.0/det;
 
     // fill the matrix
     a(0,0) = detinv * b00; a(0,1) = detinv * b01; a(0,2) = detinv * b02;
     a(1,0) = detinv * b10; a(1,1) = detinv * b11; a(1,2) = detinv * b12;
     a(2,0) = detinv * b20; a(2,1) = detinv * b21; a(2,2) = detinv * b22;
-
   }
 
   // ----------  inverse ----------------
@@ -153,9 +152,7 @@ namespace nda {
   }
 
   template <Array A>
-  auto inverse(A const &a)
-    requires(get_algebra<A> == 'M')
-  {
+  auto inverse(A const &a) requires(get_algebra<A> == 'M') {
     static_assert(get_rank<A> == 2, "inverse: array must have rank two");
     EXPECTS(is_matrix_square(a, true));
     auto r = make_regular(a);

--- a/c++/nda/linalg/det_and_inverse.hpp
+++ b/c++/nda/linalg/det_and_inverse.hpp
@@ -84,8 +84,7 @@ namespace nda {
   template <typename T, typename L, typename AP, typename OP>
   void inverse1_in_place(basic_array_view<T, 2, L, 'M', AP, OP> a) {
     if (a(0,0) == 0.0) NDA_RUNTIME_ERROR << "Inverse/Det error : matrix is not invertible.";
-    a(0,0) = 1.0/a(0.0);
-    a(0,0) = b;
+    a(0,0) = 1.0/a(0,0);
   }
   
   // ----------  inverse (2x2) ---------------------

--- a/c++/nda/linalg/det_and_inverse.hpp
+++ b/c++/nda/linalg/det_and_inverse.hpp
@@ -76,8 +76,17 @@ namespace nda {
   //          Run on (16 X 2400 MHz CPUs) (see benchmarks/small_inv.cpp)
   // ---------------------------------------------
   // Matrix Size      Time (old)        Time (new)
+  //     1             502 ns            59.0 ns
   //     2             595 ns            61.7 ns
   //     3             701 ns            67.5 ns
+  
+  // ----------  inverse (1x1) ---------------------
+  template <typename T, typename L, typename AP, typename OP>
+  void inverse1_in_place(basic_array_view<T, 2, L, 'M', AP, OP> a) {
+    if (a(0,0) == 0.0) NDA_RUNTIME_ERROR << "Inverse/Det error : matrix is not invertible.";
+    a(0,0) = 1.0/a(0.0);
+    a(0,0) = b;
+  }
   
   // ----------  inverse (2x2) ---------------------
   template <typename T, typename L, typename AP, typename OP>
@@ -128,6 +137,11 @@ namespace nda {
   void inverse_in_place(basic_array_view<T, 2, L, 'M', AP, OP> a) {
     EXPECTS(is_matrix_square(a, true));
     if (a.empty()) return;
+
+    if (a.shape()[0] == 1) {
+      inverse1_in_place(a);
+      return;
+    }
 
     if (a.shape()[0] == 2) {
       inverse2_in_place(a);

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -306,6 +306,52 @@ TEST(Inverse, slice) { //NOLINT
   }
 }
 
+//-------------------------------------------------------------
+
+TEST(Inverse, Small2) { //NOLINT
+
+  using matrix_t = matrix<double>;
+
+  matrix_t W(2, 2), Wi(2, 2), A;
+  for (int i = 0; i < 2; ++i)
+    for (int j = 0; j < 2; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+
+  auto Wkeep = W;
+
+  Wi = inverse(W);
+  EXPECT_NEAR(determinant(Wi), 1.0, 1.e-12);
+
+  matrix<double> should_be_one(W * Wi);
+  for (int i = 0; i < 2; ++i)
+    for (int j = 0; j < 2; ++j) EXPECT_NEAR(std::abs(should_be_one(i, j)), (i == j ? 1 : 0), 1.e-13);
+
+  Wi = inverse(Wi);
+  EXPECT_ARRAY_NEAR(Wi, Wkeep, 1.e-12);
+}
+
+//-------------------------------------------------------------
+
+TEST(Inverse, Small3) { //NOLINT
+
+  using matrix_t = matrix<double, F_layout>;
+
+  matrix_t W(3, 3), Wi(3, 3), A;
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+
+  auto Wkeep = W;
+
+  Wi = inverse(W);
+  EXPECT_NEAR(determinant(Wi), -1 / 7.8, 1.e-12);
+
+  matrix<double> should_be_one(W * Wi);
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 3; ++j) EXPECT_NEAR(std::abs(should_be_one(i, j)), (i == j ? 1 : 0), 1.e-13);
+
+  Wi = inverse(Wi);
+  EXPECT_ARRAY_NEAR(Wi, Wkeep, 1.e-12);
+}
+
 // ==============================================================
 
 TEST(Matvecmul, Promotion) { //NOLINT

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -308,48 +308,21 @@ TEST(Inverse, slice) { //NOLINT
 
 //-------------------------------------------------------------
 
-TEST(Inverse, Small2) { //NOLINT
+TEST(Inverse, Small) { //NOLINT
 
-  using matrix_t = matrix<double>;
+  for (auto N: {2, 3}) {
 
-  matrix_t W(2, 2), Wi(2, 2), A;
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 2; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+    matrix<double> W(N, N);
+    for (int i = 0; i < N; ++i)
+      for (int j = 0; j < N; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
 
-  auto Wkeep = W;
+    auto Wi = inverse(W);
+    EXPECT_NEAR(determinant(Wi), 1.0/determinant(W), 1.e-12);
+    EXPECT_ARRAY_NEAR(W * Wi, nda::eye<double>(N), 1.e-13);
 
-  Wi = inverse(W);
-  EXPECT_NEAR(determinant(Wi), 1.0, 1.e-12);
-
-  matrix<double> should_be_one(W * Wi);
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 2; ++j) EXPECT_NEAR(std::abs(should_be_one(i, j)), (i == j ? 1 : 0), 1.e-13);
-
-  Wi = inverse(Wi);
-  EXPECT_ARRAY_NEAR(Wi, Wkeep, 1.e-12);
-}
-
-//-------------------------------------------------------------
-
-TEST(Inverse, Small3) { //NOLINT
-
-  using matrix_t = matrix<double, F_layout>;
-
-  matrix_t W(3, 3), Wi(3, 3), A;
-  for (int i = 0; i < 3; ++i)
-    for (int j = 0; j < 3; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
-
-  auto Wkeep = W;
-
-  Wi = inverse(W);
-  EXPECT_NEAR(determinant(Wi), -1 / 7.8, 1.e-12);
-
-  matrix<double> should_be_one(W * Wi);
-  for (int i = 0; i < 3; ++i)
-    for (int j = 0; j < 3; ++j) EXPECT_NEAR(std::abs(should_be_one(i, j)), (i == j ? 1 : 0), 1.e-13);
-
-  Wi = inverse(Wi);
-  EXPECT_ARRAY_NEAR(Wi, Wkeep, 1.e-12);
+    auto Wii = inverse(Wi);
+    EXPECT_ARRAY_NEAR(Wii, W, 1.e-12);
+  }
 }
 
 // ==============================================================

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -310,11 +310,11 @@ TEST(Inverse, slice) { //NOLINT
 
 TEST(Inverse, Small) { //NOLINT
 
-  for (auto N: {2, 3}) {
+  for (auto N: {1, 2, 3}) {
 
     matrix<double> W(N, N);
     for (int i = 0; i < N; ++i)
-      for (int j = 0; j < N; ++j) W(i, j) = (i > j ? i + 2.5 * j : i * 0.8 - j);
+      for (int j = 0; j < N; ++j) W(i, j) = (i > j ? 0.5 + i + 2.5 * j : i * 0.8 - j - 0.5);
 
     auto Wi = inverse(W);
     EXPECT_NEAR(determinant(Wi), 1.0/determinant(W), 1.e-12);


### PR DESCRIPTION
This PR implements analytic expressions for the inversion of square matrices of size 2 and 3. In TRIQS, one often has to do many small matrix inversions when summing over the Brillouin zone. Attached are benchmarks for a matrix of size 3 (Nk denotes the number of points that are being summed).

Here, ``inverse_in_place`` refers to the corresponding LAPACK matrix inversion routine and ``inverse3_in_place`` is the new matrix inversion implementation for a square matrix of size 3.

[sumk_nda_small_inv_benchmark.pdf](https://github.com/TRIQS/nda/files/9965693/sumk_nda_small_inv_benchmark.pdf)