### PR TITLE
fixed lapack/gelss.hpp and added lapack/gels.hpp

### DIFF
--- a/c++/nda/blas/tools.hpp
+++ b/c++/nda/blas/tools.hpp
@@ -93,4 +93,27 @@ namespace nda::blas {
   //return a.indexmap().min_stride() == 1;
   //}v
 
+  // ================================================
+
+  template<typename T>
+  struct remove_complex
+  {
+    using type = T;
+  };
+
+  template<>
+  struct remove_complex<std::complex<float>>
+  {
+    using type = float;
+  };
+
+  template<>
+  struct remove_complex<std::complex<double>>
+  {
+    using type = double;
+  };
+
+  template <typename T>
+  using remove_complex_t = typename remove_complex<T>::type;
+
 } // namespace nda::blas

--- a/c++/nda/lapack.hpp
+++ b/c++/nda/lapack.hpp
@@ -37,6 +37,7 @@ namespace nda::lapack {
 } // namespace nda::lapack
 
 #include "lapack/gelss.hpp"
+#include "lapack/gels.hpp"
 #include "lapack/gesvd.hpp"
 #include "lapack/getrf.hpp"
 #include "lapack/getri.hpp"

--- a/c++/nda/lapack/gels.hpp
+++ b/c++/nda/lapack/gels.hpp
@@ -1,0 +1,104 @@
+// Copyright (c) 2020-2021 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Olivier Parcollet, Nils Wentzell
+
+#pragma once
+
+namespace nda::lapack {
+
+  ///
+  template <MatrixView A, MatrixView B>
+  int gels(const char TRANS, A &a, B &b) requires(nda::blas::have_same_element_type_and_it_is_blas_type_v<A, B>) 
+  {
+    int info = 0;
+    using T = typename A::value_type;
+    if constexpr (std::is_same_v<T, double>) {
+      if (not(TRANS=='N' or TRANS=='T')) 
+	NDA_RUNTIME_ERROR << "Error in gels : Incorrect parameter TRANS = " << TRANS;
+    } else if constexpr (std::is_same_v<T, dcomplex>) {
+      if (not(TRANS=='N' or TRANS=='C')) 
+	NDA_RUNTIME_ERROR << "Error in gels : Incorrect parameter TRANS = " << TRANS;
+    } else
+      static_assert(false and always_true<A>, "Internal logic error");
+
+    // We enforce Fortran order on B by making a copy if necessary.
+    if constexpr (not B::layout_t::is_stride_order_Fortran()) {
+
+      auto bf = matrix<T, F_layout>{b};
+      info    = gels(TRANS,a, bf);
+      b = bf;	
+      return info;
+
+    } else { // do not compile useless code !
+
+      // Must be lapack compatible
+      EXPECTS(a.indexmap().min_stride() == 1);
+      EXPECTS(b.indexmap().min_stride() == 1);
+
+      int nrhs = get_n_cols(b);
+
+      // first call to get the optimal lwork
+      T work1[1];
+
+      if constexpr (A::layout_t::is_stride_order_Fortran()) {
+  
+        f77::gels(TRANS,get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), work1, -1, info); 
+
+        int lwork = int(real(work1[0]));
+        array<T, 1> work(lwork);
+
+        f77::gels(TRANS,get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), work.data(), lwork, info);
+
+      } else {
+
+        if constexpr (std::is_same_v<T, double>) {
+
+          const char TRANS_T = ((TRANS=='N')?'T':'N');
+        
+          f77::gels(TRANS_T,get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), work1, -1, info);
+
+          int lwork = int(work1[0]);
+          array<T, 1> work(lwork);
+
+          f77::gels(TRANS_T,get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), work.data(), lwork, info);
+
+        } else if constexpr (std::is_same_v<T, dcomplex>) {
+
+          const char TRANS_T = ((TRANS=='N')?'C':'N');
+
+	  // conjugate a
+	  for( auto& v: a ) v = std::conj(v);
+
+          f77::gels(TRANS_T,get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), work1, -1, info);
+
+          int lwork = int(real(work1[0]));
+          array<T, 1> work(lwork);
+
+          f77::gels(TRANS_T,get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), work.data(), lwork, info);
+
+	  // conjugate a back
+	  for( auto& v: a ) v = std::conj(v);
+
+        } else
+          static_assert(false and always_true<A>, "Internal logic error");
+
+      }
+
+      if (info) NDA_RUNTIME_ERROR << "Error in gels : info = " << info;
+      return info;
+    }
+  }
+
+} // namespace nda::lapack

--- a/c++/nda/lapack/gelss.hpp
+++ b/c++/nda/lapack/gelss.hpp
@@ -15,12 +15,13 @@
 // Authors: Olivier Parcollet, Nils Wentzell
 
 #pragma once
+#include <type_traits>
 
 namespace nda::lapack {
 
   ///
-  template <MatrixView A, MatrixView B, MatrixView C>
-  int gelss(A &a, B &b, C &c, double rcond, int &rank) requires(nda::blas::have_same_element_type_and_it_is_blas_type_v<A, B, C>) {
+  template <MatrixView A, MatrixView B, VectorView C>
+  int gelss(A &a, B &b, C &c, double rcond, int &rank) requires(nda::blas::have_same_element_type_and_it_is_blas_type_v<A, B> && std::is_same_v<nda::blas::remove_complex_t<get_value_t<A>>,get_value_t<C>>) {
 
     int info = 0;
 
@@ -31,12 +32,14 @@ namespace nda::lapack {
     if constexpr (not A::layout_t::is_stride_order_Fortran()) {
       auto af = matrix<T, F_layout>{a};
       info    = gelss(af, b, c, rcond, rank);
+      a = af;
       return info;
 
     } else if constexpr (not B::layout_t::is_stride_order_Fortran()) {
 
       auto bf = matrix<T, F_layout>{b};
       info    = gelss(a, bf, c, rcond, rank);
+      b = bf;
       return info;
 
     } else { // do not compile useless code !
@@ -46,10 +49,7 @@ namespace nda::lapack {
       EXPECTS(b.indexmap().min_stride() == 1);
       EXPECTS(c.indexmap().min_stride() == 1);
 
-      // Copy since it is altered by gelss
-      auto a2 = a;
-
-      auto dm = std::min(get_n_rows(a2), get_n_cols(a2));
+      auto dm = std::min(get_n_rows(a), get_n_cols(a));
       if (c.size() < dm) c.resize(dm);
       int nrhs = get_n_cols(b);
 
@@ -57,12 +57,13 @@ namespace nda::lapack {
 
         // first call to get the optimal lwork
         T work1[1];
-        f77::gelss(get_n_rows(a2), get_n_cols(a2), nrhs, a2.data(), get_ld(a2), b.data(), get_ld(b), c.data(), rcond, rank, work1, -1, info);
+        f77::gelss(get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), c.data(), rcond, rank, work1, -1, info);
 
-        int lwork = r_round(work1[0]);
+        //int lwork = r_round(work1[0]);
+        int lwork = int(work1[0]);
         array<T, 1> work(lwork);
 
-        f77::gelss(get_n_rows(a2), get_n_cols(a2), nrhs, a2.data(), get_ld(a2), b.data(), get_ld(b), c.data(), rcond, rank, work.data(), lwork, info);
+        f77::gelss(get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), c.data(), rcond, rank, work.data(), lwork, info);
 
       } else if constexpr (std::is_same_v<T, dcomplex>) {
 
@@ -70,13 +71,14 @@ namespace nda::lapack {
 
         // first call to get the optimal lwork
         T work1[1];
-        f77::gelss(get_n_rows(a2), get_n_cols(a2), nrhs, a2.data(), get_ld(a2), b.data(), get_ld(b), c.data(), rcond, rank, work1, -1, rwork.data(),
+        f77::gelss(get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), c.data(), rcond, rank, work1, -1, rwork.data(),
                    info);
 
-        int lwork = r_round(work1[0]);
+        //int lwork = r_round(work1[0]);
+        int lwork = int(real(work1[0]));
         array<T, 1> work(lwork);
 
-        f77::gelss(get_n_rows(a2), get_n_cols(a2), nrhs, a2.data(), get_ld(a2), b.data(), get_ld(b), c.data(), rcond, rank, work.data(), lwork,
+        f77::gelss(get_n_rows(a), get_n_cols(a), nrhs, a.data(), get_ld(a), b.data(), get_ld(b), c.data(), rcond, rank, work.data(), lwork,
                    rwork.data(), info);
       } else
         static_assert(false and always_true<A>, "Internal logic error");

--- a/c++/nda/lapack/interface/lapack_cxx_interface.cpp
+++ b/c++/nda/lapack/interface/lapack_cxx_interface.cpp
@@ -12,6 +12,15 @@ namespace nda::lapack::f77 {
     LAPACK_zgelss(&M, &N, &NRHS, A, &LDA, B, &LDB, S, &RCOND, &RANK, WORK, &LWORK, RWORK, &INFO);
   }
 
+  void gels(const char TRANS, int M, int N, int NRHS, double *A, int LDA, double *B, int LDB,
+             double *WORK, int LWORK, int &INFO) {
+    LAPACK_dgels(&TRANS,&M, &N, &NRHS, A, &LDA, B, &LDB, WORK, &LWORK, &INFO);
+  }
+  void gels(const char TRANS, int M, int N, int NRHS, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB,
+             std::complex<double> *WORK, int LWORK, int &INFO) {
+    LAPACK_zgels(&TRANS,&M, &N, &NRHS, A, &LDA, B, &LDB, WORK, &LWORK, &INFO);
+  }
+
   void gesvd(const char &JOBU, const char &JOBVT, int M, int N, double *A, int LDA, double *S, double *U, int LDU, double *VT, int LDVT, double *WORK,
              int LWORK, int &INFO) {
     LAPACK_dgesvd(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU, VT, &LDVT, WORK, &LWORK, &INFO);

--- a/c++/nda/lapack/interface/lapack_cxx_interface.hpp
+++ b/c++/nda/lapack/interface/lapack_cxx_interface.hpp
@@ -24,6 +24,11 @@ namespace nda::lapack::f77 {
   void gelss(int M, int N, int NRHS, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB, double *S, double RCOND, int &RANK,
              std::complex<double> *WORK, int LWORK, double *RWORK, int &INFO);
 
+  void gels(const char TRANS, int M, int N, int NRHS, double *A, int LDA, double *B, int LDB,
+             double *WORK, int LWORK, int &INFO);
+  void gels(const char TRANS, int M, int N, int NRHS, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB,
+             std::complex<double> *WORK, int LWORK, int &INFO);
+
   void gesvd(const char &JOBU, const char &JOBVT, int M, int N, double *A, int LDA, double *S, double *U, int LDU, double *VT, int LDVT, double *WORK,
              int LWORK, int &INFO);
   void gesvd(const char &JOBU, const char &JOBVT, int M, int N, std::complex<double> *A, int LDA, double *S, std::complex<double> *U, int LDU,

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -150,7 +150,7 @@ TEST(lapack, gelss) { //NOLINT
 
   int M = A.extent(0);
   int N = A.extent(1);
-  //int NRHS = B.extent(1);
+  int NRHS = B.extent(1);
 
   auto x_exact = matrix<dcomplex>{{2, 1}, {1, 1}, {1, 2}};
   auto S       = array<double, 1>(std::min(M, N));
@@ -159,11 +159,74 @@ TEST(lapack, gelss) { //NOLINT
   auto [x_1, eps_1] = gelss_new(B);
   EXPECT_ARRAY_NEAR(x_exact, x_1, 1e-14);
 
-  //int i;
-  //lapack::gelss(A, B, S, 1e-18, i);
-  //auto x_2 = B(range(N), range(NRHS));
+  int rank;
+  lapack::gelss(A, B, S, -1, rank);
+  auto x_2 = B(range(N), range(NRHS));
 
-  //EXPECT_ARRAY_NEAR(x_exact, x_2, 1e-14);
+  EXPECT_ARRAY_NEAR(x_exact, x_2, 1e-14);
+}
+
+// =================================== gels =======================================
+
+TEST(lapack, gels) { //NOLINT
+
+  {
+    // Cf. http://www.netlib.org/lapack/explore-html/d3/d77/example___d_g_e_l_s__colmajor_8c_source.html
+    auto A = matrix<dcomplex>{{1, 1, 1}, {2, 3, 4}, {3, 5, 2}, {4, 2, 5}, {5, 4, 3}};
+    auto B = matrix<dcomplex>{{-10, -3}, {12, 14}, {14, 12}, {16, 16}, {18, 16}};
+
+    int N = A.extent(1);
+    int NRHS = B.extent(1);
+
+    auto x_exact = matrix<dcomplex>{{2, 1}, {1, 1}, {1, 2}};
+    lapack::gels('N', A, B);
+    auto x_2 = B(range(N), range(NRHS));
+
+    EXPECT_ARRAY_NEAR(x_exact, x_2, 1e-14);
+  }
+
+  {
+    auto A = matrix<double>{{1, 1, 1}, {2, 3, 4}, {3, 5, 2}, {4, 2, 5}, {5, 4, 3}};
+    auto B = matrix<double>{{-10, -3}, {12, 14}, {14, 12}, {16, 16}, {18, 16}};
+  
+    int N = A.extent(1);
+    int NRHS = B.extent(1);
+  
+    auto x_exact = matrix<double>{{2, 1}, {1, 1}, {1, 2}};
+    lapack::gels('N', A, B);
+    auto x_2 = B(range(N), range(NRHS));
+  
+    EXPECT_ARRAY_NEAR(x_exact, x_2, 1e-14);
+  }
+
+  {
+    auto A = matrix<dcomplex,F_layout>{{1, 1, 1}, {2, 3, 4}, {3, 5, 2}, {4, 2, 5}, {5, 4, 3}};
+    auto B = matrix<dcomplex,F_layout>{{-10, -3}, {12, 14}, {14, 12}, {16, 16}, {18, 16}};
+
+    int N = A.extent(1);
+    int NRHS = B.extent(1);
+
+    auto x_exact = matrix<dcomplex,F_layout>{{2, 1}, {1, 1}, {1, 2}};
+    lapack::gels('N', A, B);
+    auto x_2 = B(range(N), range(NRHS));
+
+    EXPECT_ARRAY_NEAR(x_exact, x_2, 1e-14);
+  }
+
+  {
+    auto A = matrix<dcomplex>{{1, 2, 3, 4, 5}, {1, 3, 5, 2, 4}, {1, 4, 2, 5, 3}};
+    auto B = matrix<dcomplex>{{-10, -3}, {12, 14}, {14, 12}, {16, 16}, {18, 16}};
+    
+    int N = A.extent(0);
+    int NRHS = B.extent(1);
+
+    auto x_exact = matrix<dcomplex>{{2, 1}, {1, 1}, {1, 2}};
+    lapack::gels('C', A, B);
+    auto x_2 = B(range(N), range(NRHS));
+
+    EXPECT_ARRAY_NEAR(x_exact, x_2, 1e-14);
+  }
+
 }
 
 // =================================== getrs =======================================


### PR DESCRIPTION
1) Fixed several issues with lapack/gelss.hpp
  - type of C parameter, changed from MatrixView to VectorView.
  - C type should always be of non-complex type, change associated constrain in require clause
  - propagated changes in A and B function arguments when column major temporary arrays are used.
  - Calls to underlying f77::gelss routine is not performed directly on input A array.
2) Added lapack/gels.hpp following modified convention for gelss.hpp.