### PR TITLE
Implementation of symmetry reduction for nda arrays

### DIFF
--- a/c++/nda/CMakeLists.txt
+++ b/c++/nda/CMakeLists.txt
@@ -37,6 +37,10 @@ target_link_libraries(${PROJECT_NAME}_c PUBLIC h5::h5_c)
 # Link against MPI C++ Interface
 target_link_libraries(${PROJECT_NAME}_c PUBLIC mpi::mpi_c)
 
+# OpenMP
+find_package(OpenMP REQUIRED COMPONENTS CXX)
+target_link_libraries(${PROJECT_NAME}_c PUBLIC OpenMP::OpenMP_CXX)
+
 # ========= Blas / Lapack ==========
 
 message(STATUS "-------- Lapack detection -------------")

--- a/c++/nda/blas/ger.hpp
+++ b/c++/nda/blas/ger.hpp
@@ -83,7 +83,8 @@ namespace nda::blas {
     if constexpr (Scalar<A> or Scalar<B>) {
       return a * b;
     } else {
-      static_assert(has_contiguous_layout<A> and has_contiguous_layout<B>);
+      if (not a.is_contiguous()) NDA_RUNTIME_ERROR << "First argument to outer_product call has non-contiguous layout";
+      if (not b.is_contiguous()) NDA_RUNTIME_ERROR << "Second argument to outer_product call has non-contiguous layout";
       auto res = zeros<get_value_t<A>, mem::get_addr_space<A>>(stdutil::join(a.shape(), b.shape()));
 
       auto a_vec = reshape(a, std::array{a.size()});

--- a/c++/nda/layout/idx_map.hpp
+++ b/c++/nda/layout/idx_map.hpp
@@ -376,6 +376,34 @@ namespace nda {
       return call_impl(std::make_index_sequence<sizeof...(Args)>{}, args...);
     }
 
+    /**
+     * Stride order agnostic mapping to index
+     * 
+     * @return : 
+     *       indices corresponding to linear index
+     *
+     */
+    std::array<long, Rank> to_idx(long lin_idx) const {
+
+      // compute stride residues starting from slowest index 
+      std::array<long, Rank> residues;
+      residues[0] = lin_idx;
+      
+      for (auto i : range(1, Rank)) {
+        residues[i] = residues[i - 1] % str[stride_order[i - 1]];
+      } // residues[Rank - 1] is now the value of the fastest index times the corresponding stride 
+
+      // convert residues to indices, ordered from slowest to fastest
+      std::array<long, Rank> idx;
+      idx[Rank - 1] = residues[Rank - 1] / str[stride_order[Rank - 1]];
+
+      for (auto i : range(Rank - 2, -1, -1)) {
+        idx[i] = (residues[i] - residues[i + 1]) / str[stride_order[i]];
+      }
+
+      return permutations::apply_inverse(stride_order, idx);
+    }
+
     // ----------------  Slice -------------------------
 
     template <typename... Args>

--- a/c++/nda/sym_grp.hpp
+++ b/c++/nda/sym_grp.hpp
@@ -1,100 +1,105 @@
 #pragma once
 
-struct operation {
-  // members
-  bool sgn = false; // change sign?
-  bool cc  = false; // complex conjugation?
+namespace nda {
+  struct operation {
+    // members
+    bool sgn = false; // change sign?
+    bool cc  = false; // complex conjugation?
 
-  // define multiplication to chain operations together
-  operation operator*(operation const &x) { return operation{bool(sgn xor x.sgn), bool(cc xor x.cc)}; }
+    // define multiplication to chain operations together
+    operation operator*(operation const &x) { return operation{bool(sgn xor x.sgn), bool(cc xor x.cc)}; }
 
-  // define how operator acts on given value
-  template <typename T> std::complex<double> operator()(T const &x) {
-    if (sgn) return cc ? -conj(x) : -x;
-    return cc ? conj(x) : x;
-  }
-};
+    // define how operator acts on given value
+    template <typename T>
+    std::complex<double> operator()(T const &x) {
+      if (sgn) return cc ? -conj(x) : -x;
+      return cc ? conj(x) : x;
+    }
+  };
 
-template <nda::Array A> FORCEINLINE bool is_valid(A const &x, std::array<long, static_cast<std::size_t>(nda::get_rank<A>)> const &idxs) {
+  template <nda::Array A>
+  FORCEINLINE bool is_valid(A const &x, std::array<long, static_cast<std::size_t>(nda::get_rank<A>)> const &idxs) {
 
-  // check that indices are valid for each dimension
-  for (auto i = 0; i < nda::get_rank<A>; ++i) {
-    if (not(0 <= idxs[i] && idxs[i] < x.shape()[i])) { return false; }
-  }
+    // check that indices are valid for each dimension
+    for (auto i = 0; i < nda::get_rank<A>; ++i) {
+      if (not(0 <= idxs[i] && idxs[i] < x.shape()[i])) { return false; }
+    }
 
-  return true;
-}
-
-template <nda::Array A> class sym_grp {
-  public:
-  // aliases
-  static constexpr int ndims = nda::get_rank<A>;
-  using idx_t                = std::array<long, static_cast<std::size_t>(ndims)>;
-  using sym_idx_t            = std::pair<idx_t, operation>;
-  using sym_func_t           = std::function<operation(idx_t &)>; // symmetry mutates index and returns operation
-  using sym_class_t          = std::vector<sym_idx_t>;            // symmetry class
-
-  private:
-  // members
-  std::vector<sym_func_t> sym_list;     // list of symmetries defining the symmetry group
-  std::vector<sym_class_t> sym_classes; // list of symmetric elements
-
-  public:
-  // getter methods (no setter methods, members should not be modified)
-  [[nodiscard]] std::vector<sym_func_t> const &get_sym_list() const { return sym_list; }
-  [[nodiscard]] std::vector<sym_class_t> const &get_sym_classes() const { return sym_classes; }
-
-  // constructor
-  sym_grp(A const &x, std::vector<sym_func_t> const &sym_list_) : sym_list(sym_list_) {
-
-    // array to check whether index has been sorted into a symmetry class already
-    nda::array<bool, ndims> checked(x.shape());
-    checked() = false;
-
-    // loop over array elements and sort them into symmetry classes
-    nda::for_each(checked.shape(), [&checked, this](auto... i) {
-      if (not checked(i...)) {
-        // this index is now checked and generates a new symmetry class
-        checked(i...) = true;
-        sym_class_t sym_class;
-        auto idx = std::array{i...};
-        operation op;
-        sym_class.push_back({idx, op});
-
-        // apply all symmetries to current index
-        iterate(idx, op, checked, sym_class);
-
-        // add new symmetry class to list
-        this->sym_classes.push_back(sym_class);
-      }
-    });
+    return true;
   }
 
-  private:
-  void iterate(idx_t const &idx, operation const &op, nda::array<bool, ndims> &checked, sym_class_t &sym_class, long path_length = 0) {
-    // loop over all symmetry operations
-    for (auto sym : sym_list) {
-      // copy the index before mutating it
-      auto idxp = idx;
+  template <nda::Array A>
+  class sym_grp {
+    public:
+    // aliases
+    static constexpr int ndims = nda::get_rank<A>;
+    using idx_t                = std::array<long, static_cast<std::size_t>(ndims)>;
+    using sym_idx_t            = std::pair<idx_t, operation>;
+    using sym_func_t           = std::function<operation(idx_t &)>; // symmetry mutates index and returns operation
+    using sym_class_t          = std::vector<sym_idx_t>;            // symmetry class
 
-      // apply the symmetry operation (mutates idxp)
-      auto opp = sym(idxp) * op;
+    private:
+    // members
+    std::vector<sym_func_t> sym_list;     // list of symmetries defining the symmetry group
+    std::vector<sym_class_t> sym_classes; // list of symmetric elements
 
-      // check if index is valid, reset path_length iff we start from valid & unchecked index
-      if (is_valid(checked, idxp)) {
-        // check if index has been used already
-        if (not std::apply(checked, idxp)) {
-          // this index is now checked
-          std::apply(checked, idxp) = true;
+    public:
+    // getter methods (no setter methods, members should not be modified)
+    [[nodiscard]] std::vector<sym_func_t> const &get_sym_list() const { return sym_list; }
+    [[nodiscard]] std::vector<sym_class_t> const &get_sym_classes() const { return sym_classes; }
 
-          // add to symmetry class and keep going
-          sym_class.push_back({idxp, opp});
-          iterate(idxp, opp, checked, sym_class);
+    // constructor
+    sym_grp(A const &x, std::vector<sym_func_t> const &sym_list_) : sym_list(sym_list_) {
+
+      // array to check whether index has been sorted into a symmetry class already
+      nda::array<bool, ndims> checked(x.shape());
+      checked() = false;
+
+      // loop over array elements and sort them into symmetry classes
+      nda::for_each(checked.shape(), [&checked, this](auto... i) {
+        if (not checked(i...)) {
+          // this index is now checked and generates a new symmetry class
+          checked(i...) = true;
+          sym_class_t sym_class;
+          auto idx = std::array{i...};
+          operation op;
+          sym_class.push_back({idx, op});
+
+          // apply all symmetries to current index
+          iterate(idx, op, checked, sym_class);
+
+          // add new symmetry class to list
+          this->sym_classes.push_back(sym_class);
         }
-      } else if (path_length < 10) {
-        // increment path_length and keep going
-        iterate(idxp, opp, checked, sym_class, ++path_length);
+      });
+    }
+
+    private:
+    void iterate(idx_t const &idx, operation const &op, nda::array<bool, ndims> &checked, sym_class_t &sym_class, long path_length = 0) {
+      // loop over all symmetry operations
+      for (auto sym : sym_list) {
+        // copy the index before mutating it
+        auto idxp = idx;
+
+        // apply the symmetry operation (mutates idxp)
+        auto opp = sym(idxp) * op;
+
+        // check if index is valid, reset path_length iff we start from valid & unchecked index
+        if (is_valid(checked, idxp)) {
+          // check if index has been used already
+          if (not std::apply(checked, idxp)) {
+            // this index is now checked
+            std::apply(checked, idxp) = true;
+
+            // add to symmetry class and keep going
+            sym_class.push_back({idxp, opp});
+            iterate(idxp, opp, checked, sym_class);
+          }
+        } else if (path_length < 10) {
+          // increment path_length and keep going
+          iterate(idxp, opp, checked, sym_class, ++path_length);
+        }
       }
     }
-  }
-};
+  };
+} // namespace nda

--- a/c++/nda/sym_grp.hpp
+++ b/c++/nda/sym_grp.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+struct operation {
+  // members
+  bool sgn = false; // change sign?
+  bool cc  = false; // complex conjugation?
+
+  // define multiplication to chain operations together
+  operation operator*(operation const &x) { return operation{bool(sgn xor x.sgn), bool(cc xor x.cc)}; }
+
+  // define how operator acts on given value
+  template <typename T> std::complex<double> operator()(T const &x) {
+    if (sgn) return cc ? -conj(x) : -x;
+    return cc ? conj(x) : x;
+  }
+};
+
+template <nda::Array A> FORCEINLINE bool is_valid(A const &x, std::array<long, static_cast<std::size_t>(nda::get_rank<A>)> const &idxs) {
+
+  // check that indices are valid for each dimension
+  for (auto i = 0; i < nda::get_rank<A>; ++i) {
+    if (not(0 <= idxs[i] && idxs[i] < x.shape()[i])) { return false; }
+  }
+
+  return true;
+}
+
+template <nda::Array A> class sym_grp {
+  public:
+  // aliases
+  static constexpr int ndims = nda::get_rank<A>;
+  using idx_t                = std::array<long, static_cast<std::size_t>(ndims)>;
+  using sym_idx_t            = std::pair<idx_t, operation>;
+  using sym_func_t           = std::function<operation(idx_t &)>; // symmetry mutates index and returns operation
+  using sym_class_t          = std::vector<sym_idx_t>;            // symmetry class
+
+  private:
+  // members
+  std::vector<sym_func_t> sym_list;     // list of symmetries defining the symmetry group
+  std::vector<sym_class_t> sym_classes; // list of symmetric elements
+
+  public:
+  // getter methods (no setter methods, members should not be modified)
+  [[nodiscard]] std::vector<sym_func_t> const &get_sym_list() const { return sym_list; }
+  [[nodiscard]] std::vector<sym_class_t> const &get_sym_classes() const { return sym_classes; }
+
+  // constructor
+  sym_grp(A const &x, std::vector<sym_func_t> const &sym_list_) : sym_list(sym_list_) {
+
+    // array to check whether index has been sorted into a symmetry class already
+    nda::array<bool, ndims> checked(x.shape());
+    checked() = false;
+
+    // loop over array elements and sort them into symmetry classes
+    nda::for_each(checked.shape(), [&checked, this](auto... i) {
+      if (not checked(i...)) {
+        // this index is now checked and generates a new symmetry class
+        checked(i...) = true;
+        sym_class_t sym_class;
+        auto idx = std::array{i...};
+        operation op;
+        sym_class.push_back({idx, op});
+
+        // apply all symmetries to current index
+        iterate(idx, op, checked, sym_class);
+
+        // add new symmetry class to list
+        this->sym_classes.push_back(sym_class);
+      }
+    });
+  }
+
+  private:
+  void iterate(idx_t const &idx, operation const &op, nda::array<bool, ndims> &checked, sym_class_t &sym_class, long path_length = 0) {
+    // loop over all symmetry operations
+    for (auto sym : sym_list) {
+      // copy the index before mutating it
+      auto idxp = idx;
+
+      // apply the symmetry operation (mutates idxp)
+      auto opp = sym(idxp) * op;
+
+      // check if index is valid, reset path_length iff we start from valid & unchecked index
+      if (is_valid(checked, idxp)) {
+        // check if index has been used already
+        if (not std::apply(checked, idxp)) {
+          // this index is now checked
+          std::apply(checked, idxp) = true;
+
+          // add to symmetry class and keep going
+          sym_class.push_back({idxp, opp});
+          iterate(idxp, opp, checked, sym_class);
+        }
+      } else if (path_length < 10) {
+        // increment path_length and keep going
+        iterate(idxp, opp, checked, sym_class, ++path_length);
+      }
+    }
+  }
+};

--- a/c++/nda/sym_grp.hpp
+++ b/c++/nda/sym_grp.hpp
@@ -50,6 +50,7 @@ namespace nda {
     static constexpr int ndims = get_rank<A>;
     using sym_idx_t            = std::pair<long, operation>;
     using sym_class_t          = std::span<sym_idx_t>;
+    using arr_idx_t            = std::array<long, static_cast<std::size_t>(ndims)>;
 
     private:
     std::vector<sym_class_t> sym_classes; // list of classes
@@ -89,13 +90,13 @@ namespace nda {
       }
     }
 
-    // symmetrization method, returns maximum symmetry violation and corresponding linear index
+    // symmetrization method, returns maximum symmetry violation and corresponding array index
     // NOTE: this actually requires the definition of an inverse operation, but with the current implementation
     //       operations are anyways self-inverse
-    std::pair<double, long> symmetrize(A &x) const {
+    std::pair<double, arr_idx_t> symmetrize(A &x) const {
 
       double max_diff = 0.0;
-      long max_idx    = -1;
+      auto max_idx    = arr_idx_t{};
 
       for (auto const &sym_class : sym_classes) {
         get_value_t<A> ref_val = 0.0;
@@ -112,7 +113,7 @@ namespace nda {
 
           if (diff > max_diff) {
             max_diff = diff;
-            max_idx  = lin_idx;
+            max_idx  = mapped_idx;
           };
 
           std::apply(x, mapped_idx) = mapped_val;

--- a/c++/nda/sym_grp.hpp
+++ b/c++/nda/sym_grp.hpp
@@ -109,7 +109,7 @@ namespace nda {
                  sym_class_t &sym_class, long path_length = 0) {
 
       // loop over all symmetry operations
-      for (auto sym : sym_list) {
+      for (auto const &sym : sym_list) {
         // apply the symmetry
         auto [idxp, opp] = sym(idx);
         opp              = opp * op;

--- a/share/cmake/nda-config.cmake.in
+++ b/share/cmake/nda-config.cmake.in
@@ -14,6 +14,9 @@ set(@PROJECT_NAME@_GIT_HASH @PROJECT_GIT_HASH@ CACHE STRING "@PROJECT_NAME@ git 
 # Root of the installation
 set(@PROJECT_NAME@_ROOT @CMAKE_INSTALL_PREFIX@ CACHE STRING "@PROJECT_NAME@ root directory")
 
+# Find OpenMP
+find_package(OpenMP REQUIRED COMPONENTS CXX)
+
 # Find CUDAToolkit
 if(@CudaSupport@)
   find_package(CUDAToolkit REQUIRED)

--- a/test/c++/nda_functions.cpp
+++ b/test/c++/nda_functions.cpp
@@ -202,6 +202,25 @@ TEST(Array, Permuted_view1) { //NOLINT
 
 // ----------------------------------------------
 
+TEST(Array, Permuted_view_matmul) { //NOLINT
+
+  // generate some dummy data
+  nda::array<double, 3> A = nda::rand(3, 3, 3);
+  nda::vector<double> v   = nda::rand(3);
+
+  // build permuted array
+  auto B = nda::array<double, 3>{nda::permuted_indices_view<nda::encode(std::array<int, 3>{1, 2, 0})>(A)};
+
+  for (auto k : range(3)) {
+    auto Amat = matrix<double>{A(_, _, k)};
+    auto Bmat = matrix_view<double>{B(k, _, _)};
+    EXPECT_EQ_ARRAY(Amat, Bmat);
+    EXPECT_EQ_ARRAY(Amat * v, Bmat * v);
+  }
+}
+
+// ----------------------------------------------
+
 TEST(Array, Permuted_view) { //NOLINT
 
   nda::array<long, 4> A(1, 2, 3, 4);

--- a/test/c++/nda_functions.cpp
+++ b/test/c++/nda_functions.cpp
@@ -210,12 +210,15 @@ TEST(Array, Permuted_view_matmul) { //NOLINT
 
   // build permuted array
   auto B = nda::array<double, 3>{nda::permuted_indices_view<nda::encode(std::array<int, 3>{1, 2, 0})>(A)};
+  auto C = make_regular(nda::permuted_indices_view<nda::encode(std::array<int, 3>{1, 2, 0})>(A));
 
   for (auto k : range(3)) {
     auto Amat = matrix<double>{A(_, _, k)};
     auto Bmat = matrix_view<double>{B(k, _, _)};
+    auto Cmat = matrix_view<double>{C(k, _, _)};
     EXPECT_EQ_ARRAY(Amat, Bmat);
     EXPECT_EQ_ARRAY(Amat * v, Bmat * v);
+    EXPECT_DEBUG_DEATH(Cmat * v, "gemv");
   }
 }
 

--- a/test/c++/nda_idx_map.cpp
+++ b/test/c++/nda_idx_map.cpp
@@ -51,6 +51,28 @@ TEST(idxstat, eval) { // NOLINT
   EXPECT_EQ(i1(1, 3, 2), 21 * 1 + 3 * 3 + 2 * 1); //NOLINT
 }
 
+//-------------------------
+
+TEST(idxstat, to_idx) {
+
+  idx_map<3, 0, C_stride_order<3>, layout_prop_e::none> iC{{2, 7, 3}};
+  idx_map<3, 0, Fortran_stride_order<3>, layout_prop_e::none> iF{{2, 7, 3}};
+  auto iP = iF.transpose<encode(std::array{0, 2, 1})>();
+
+  for (auto idx0 : range(2)) {
+    auto iPv = iP.slice(idx0, _, _).second;
+
+    for (auto idx1 : range(7)) {
+      for (auto idx2 : range(3)) {
+        EXPECT_TRUE(iPv.to_idx(iPv(idx2, idx1)) == ma(idx2, idx1));
+        EXPECT_TRUE(iC.to_idx(iC(idx0, idx1, idx2)) == ma(idx0, idx1, idx2));
+        EXPECT_TRUE(iF.to_idx(iF(idx0, idx1, idx2)) == ma(idx0, idx1, idx2));
+        EXPECT_TRUE(iP.to_idx(iP(idx0, idx2, idx1)) == ma(idx0, idx2, idx1));
+      }
+    }
+  }
+}
+
 //-----------------------
 
 //TEST(idxstat, boundcheck) { // NOLINT

--- a/test/c++/nda_sym_grp.cpp
+++ b/test/c++/nda_sym_grp.cpp
@@ -23,31 +23,31 @@ TEST(SymGrp, MatrixPermutation) { //NOLINT
 
   nda::array<std::complex<double>, 2> A(4, 4);
 
-  auto a  = std::rand() / RAND_MAX;
+  auto a  = nda::rand();
   A(0, 0) = a;
   A(2, 0) = a;
   A(0, 3) = a;
   A(2, 3) = a;
 
-  auto b  = std::rand() / RAND_MAX;
+  auto b  = nda::rand();
   A(1, 0) = b;
   A(1, 3) = b;
 
-  auto c  = std::rand() / RAND_MAX;
+  auto c  = nda::rand();
   A(3, 0) = c;
   A(3, 3) = c;
 
-  auto d  = std::rand() / RAND_MAX;
+  auto d  = nda::rand();
   A(0, 1) = d;
   A(2, 1) = d;
   A(0, 2) = d;
   A(2, 2) = d;
 
-  auto e  = std::rand() / RAND_MAX;
+  auto e  = nda::rand();
   A(1, 1) = e;
   A(1, 2) = e;
 
-  auto f  = std::rand() / RAND_MAX;
+  auto f  = nda::rand();
   A(3, 1) = f;
   A(3, 2) = f;
 

--- a/test/c++/nda_sym_grp.cpp
+++ b/test/c++/nda_sym_grp.cpp
@@ -81,7 +81,7 @@ TEST(SymGrp, MatrixPermutation) { //NOLINT
   // test symmetrization
   auto const &[max_diff, max_idx] = grp.symmetrize(A);
   EXPECT_EQ(max_diff, 0.0);
-  EXPECT_EQ(max_idx, -1);
+  for (auto const x : max_idx) EXPECT_EQ(x, 0);
 }
 
 // -------------------------------------
@@ -129,7 +129,7 @@ TEST(SymGrp, MatrixFlipShift) { //NOLINT
   // test symmetrization
   auto const &[max_diff, max_idx] = grp.symmetrize(A);
   EXPECT_EQ(max_diff, 0.0);
-  EXPECT_EQ(max_idx, -1);
+  for (auto const x : max_idx) EXPECT_EQ(x, 0);
 }
 
 // -------------------------------------
@@ -177,5 +177,5 @@ TEST(SymGrp, TensorCylicTriplet) { //NOLINT
   // test symmetrization
   auto const &[max_diff, max_idx] = grp.symmetrize(A);
   EXPECT_EQ(max_diff, 0.0);
-  EXPECT_EQ(max_idx, -1);
+  for (auto const x : max_idx) EXPECT_EQ(x, 0);
 }

--- a/test/c++/nda_sym_grp.cpp
+++ b/test/c++/nda_sym_grp.cpp
@@ -77,6 +77,11 @@ TEST(SymGrp, MatrixPermutation) { //NOLINT
   auto init_func = [&A](idx_t const &x) { return std::apply(A, x); };
   grp.init(B, init_func);
   EXPECT_EQ_ARRAY(A, B);
+
+  // test symmetrization
+  auto const &[max_diff, max_idx] = grp.symmetrize(A);
+  EXPECT_EQ(max_diff, 0.0);
+  EXPECT_EQ(max_idx, -1);
 }
 
 // -------------------------------------
@@ -120,6 +125,11 @@ TEST(SymGrp, MatrixFlipShift) { //NOLINT
   auto init_func = [&A](idx_t const &x) { return std::apply(A, x); };
   grp.init(B, init_func);
   EXPECT_EQ_ARRAY(A, B);
+
+  // test symmetrization
+  auto const &[max_diff, max_idx] = grp.symmetrize(A);
+  EXPECT_EQ(max_diff, 0.0);
+  EXPECT_EQ(max_idx, -1);
 }
 
 // -------------------------------------
@@ -163,4 +173,9 @@ TEST(SymGrp, TensorCylicTriplet) { //NOLINT
   auto init_func = [&A](idx_t const &x) { return std::apply(A, x); };
   grp.init(B, init_func);
   EXPECT_EQ_ARRAY(A, B);
+
+  // test symmetrization
+  auto const &[max_diff, max_idx] = grp.symmetrize(A);
+  EXPECT_EQ(max_diff, 0.0);
+  EXPECT_EQ(max_idx, -1);
 }

--- a/test/c++/nda_sym_grp.cpp
+++ b/test/c++/nda_sym_grp.cpp
@@ -54,20 +54,20 @@ TEST(SymGrp, MatrixPermutation) { //NOLINT
   // 1) {0, 1, 2, 3} -> {2, 1, 0, 3}
   auto p0 = [](idx_t const &x) {
     auto p   = std::array<long, 4>{2, 1, 0, 3};
-    idx_t xp = {p[x[0]], x[1]}; 
+    idx_t xp = {p[x[0]], x[1]};
     return sym_t{xp, nda::operation{false, false}};
   };
 
   // 2) {0, 1, 2, 3} -> {3, 2, 1, 0}
   auto p1 = [](idx_t const &x) {
-    auto p  = std::array<long, 4>{3, 2, 1, 0};
-    idx_t xp = {x[0], p[x[1]]}; 
+    auto p   = std::array<long, 4>{3, 2, 1, 0};
+    idx_t xp = {x[0], p[x[1]]};
     return sym_t{xp, nda::operation{false, false}};
   };
 
   // compute symmetry classes
   std::vector<sym_func_t> sym_list = {p0, p1};
-  auto grp = nda::sym_grp{A, sym_list};
+  auto grp                         = nda::sym_grp{A, sym_list};
 
   // test if number of classes matches expectation
   EXPECT_EQ(grp.get_sym_classes().size(), 6);
@@ -110,7 +110,7 @@ TEST(SymGrp, MatrixFlipShift) { //NOLINT
 
   // compute symmetry classes
   std::vector<sym_func_t> sym_list = {p0, p1};
-  auto grp = nda::sym_grp{A, sym_list};
+  auto grp                         = nda::sym_grp{A, sym_list};
 
   // test if number of classes matches expectation
   EXPECT_EQ(grp.get_sym_classes().size(), 1);
@@ -153,7 +153,7 @@ TEST(SymGrp, TensorCylicTriplet) { //NOLINT
 
   // compute symmetry classes
   std::vector<sym_func_t> sym_list = {p0, p1};
-  auto grp = nda::sym_grp{A, sym_list};
+  auto grp                         = nda::sym_grp{A, sym_list};
 
   // test if number of classes matches expectation
   EXPECT_EQ(grp.get_sym_classes().size(), pow((pow(2, 3) + 2 * 2) / 3, 2));
@@ -164,5 +164,3 @@ TEST(SymGrp, TensorCylicTriplet) { //NOLINT
   grp.init(B, init_func);
   EXPECT_EQ_ARRAY(A, B);
 }
-
-// -------------------------------------

--- a/test/c++/sym_grp.cpp
+++ b/test/c++/sym_grp.cpp
@@ -1,0 +1,113 @@
+#include "./test_common.hpp"
+#include <nda/sym_grp.hpp>
+
+// -------------------------------------
+/*
+    Consider the permutations: 1) {0, 1, 2, 3} -> {2, 1, 0, 3} and 
+    2) {0, 1, 2, 3} -> {3, 2, 1, 0}. We assume 4x4 matrix A is invariant 
+    when 1) is applied as a row and 2) as a column index transformation. 
+    Thus, there should be 6 groups (a to f) of equivalent elements in A:
+
+                    0   1   2   3
+                0   a   d   d   a
+                1   b   e   e   b
+                2   a   d   d   a
+                3   c   f   f   c
+*/
+
+TEST(SymGrp, MatrixPermutation) { //NOLINT
+  // the 4x4 matrix
+  nda::array<std::complex<double>, 2> A(4, 4);
+ 
+  // 1) {0, 1, 2, 3} -> {2, 1, 0, 3}
+  std::function<operation(std::array<long, 2> &)> p0 = [](std::array<long, 2> &x) {
+    auto p = std::array<long, 4>{2, 1, 0, 3};
+    x[0]   = p[x[0]];
+    return operation{false, false};
+  };
+
+  // 2) {0, 1, 2, 3} -> {3, 2, 1, 0}
+  std::function<operation(std::array<long, 2> &)> p1 = [](std::array<long, 2> &x) {
+    auto p = std::array<long, 4>{3, 2, 1, 0};
+    x[1]   = p[x[1]];
+    return operation{false, false};
+  };
+
+  // compute symmetry classes
+  std::vector<std::function<operation(std::array<long, 2> &)>> sym_list = {p0, p1};
+  sym_grp grp(A, sym_list);
+  EXPECT_EQ(grp.get_sym_classes().size(), 6);
+}
+
+// -------------------------------------
+
+// -------------------------------------
+/*
+    Consider the transformations 1) A_ij -> A_ji and 2) A_ij -> A_(i+1)j.
+    If matrix A is supposed to be invariant, then all its elements should fall 
+    into one symmetry class.
+*/
+
+TEST(SymGrp, MatrixFlipShift) { //NOLINT
+  // the 4x4 matrix
+  nda::array<std::complex<double>, 2> A(4, 4);
+ 
+  // 1) A_ij -> A_ji
+  std::function<operation(std::array<long, 2> &)> p0 = [](std::array<long, 2> &x) {
+    auto idx = x[0];
+    x[0]     = x[1];
+    x[1]     = idx;
+    return operation{false, false};
+  };
+
+  // 2) A_ij -> A_(i+1)j
+  std::function<operation(std::array<long, 2> &)> p1 = [](std::array<long, 2> &x) {
+    ++x[0];
+    return operation{false, false};
+  };
+
+  // compute symmetry classes
+  std::vector<std::function<operation(std::array<long, 2> &)>> sym_list = {p0, p1};
+  sym_grp grp(A, sym_list);
+  EXPECT_EQ(grp.get_sym_classes().size(), 1);
+}
+
+// -------------------------------------
+
+// -------------------------------------
+/*
+    Consider the transformations 1) A_ijklmn -> A_jkilmn and
+    2) A_ijklmn -> A_ijkmnl for a rank 6 tensor A. With N elements per dimension
+    this should result in ((N^3 + 2N) / 3)^2 symmetry classes.
+*/
+
+TEST(SymGrp, TensorCylicTriplet) { //NOLINT
+  // the rank 6 tensor
+  int N = 2;
+  nda::array<std::complex<double>, 6> A(2, 2, 2, 2, 2, 2);
+ 
+  // 1) A_ijklmn -> A_jkilmn
+  std::function<operation(std::array<long, 6> &)> p0 = [](std::array<long, 6> &x) {
+    auto idx = x[0];
+    x[0]     = x[1];
+    x[1]     = x[2];
+    x[2]     = idx;
+    return operation{false, false};
+  };
+
+  // 2) A_ijklmn -> A_ijkmnl
+  std::function<operation(std::array<long, 6> &)> p1 = [](std::array<long, 6> &x) {
+    auto idx = x[3];
+    x[3]     = x[4];
+    x[4]     = x[5];
+    x[5]     = idx;
+    return operation{false, false};
+  };
+
+  // compute symmetry classes
+  std::vector<std::function<operation(std::array<long, 6> &)>> sym_list = {p0, p1};
+  sym_grp grp(A, sym_list);
+  EXPECT_EQ(grp.get_sym_classes().size(), pow((pow(N, 3) + 2 * N) / 3, 2));
+}
+
+// -------------------------------------

--- a/test/c++/sym_grp.cpp
+++ b/test/c++/sym_grp.cpp
@@ -20,22 +20,22 @@ TEST(SymGrp, MatrixPermutation) { //NOLINT
   nda::array<std::complex<double>, 2> A(4, 4);
  
   // 1) {0, 1, 2, 3} -> {2, 1, 0, 3}
-  std::function<operation(std::array<long, 2> &)> p0 = [](std::array<long, 2> &x) {
+  std::function<nda::operation(std::array<long, 2> &)> p0 = [](std::array<long, 2> &x) {
     auto p = std::array<long, 4>{2, 1, 0, 3};
     x[0]   = p[x[0]];
-    return operation{false, false};
+    return nda::operation{false, false};
   };
 
   // 2) {0, 1, 2, 3} -> {3, 2, 1, 0}
-  std::function<operation(std::array<long, 2> &)> p1 = [](std::array<long, 2> &x) {
+  std::function<nda::operation(std::array<long, 2> &)> p1 = [](std::array<long, 2> &x) {
     auto p = std::array<long, 4>{3, 2, 1, 0};
     x[1]   = p[x[1]];
-    return operation{false, false};
+    return nda::operation{false, false};
   };
 
   // compute symmetry classes
-  std::vector<std::function<operation(std::array<long, 2> &)>> sym_list = {p0, p1};
-  sym_grp grp(A, sym_list);
+  std::vector<std::function<nda::operation(std::array<long, 2> &)>> sym_list = {p0, p1};
+  nda::sym_grp grp(A, sym_list);
   EXPECT_EQ(grp.get_sym_classes().size(), 6);
 }
 
@@ -53,22 +53,22 @@ TEST(SymGrp, MatrixFlipShift) { //NOLINT
   nda::array<std::complex<double>, 2> A(4, 4);
  
   // 1) A_ij -> A_ji
-  std::function<operation(std::array<long, 2> &)> p0 = [](std::array<long, 2> &x) {
+  std::function<nda::operation(std::array<long, 2> &)> p0 = [](std::array<long, 2> &x) {
     auto idx = x[0];
     x[0]     = x[1];
     x[1]     = idx;
-    return operation{false, false};
+    return nda::operation{false, false};
   };
 
   // 2) A_ij -> A_(i+1)j
-  std::function<operation(std::array<long, 2> &)> p1 = [](std::array<long, 2> &x) {
+  std::function<nda::operation(std::array<long, 2> &)> p1 = [](std::array<long, 2> &x) {
     ++x[0];
-    return operation{false, false};
+    return nda::operation{false, false};
   };
 
   // compute symmetry classes
-  std::vector<std::function<operation(std::array<long, 2> &)>> sym_list = {p0, p1};
-  sym_grp grp(A, sym_list);
+  std::vector<std::function<nda::operation(std::array<long, 2> &)>> sym_list = {p0, p1};
+  nda::sym_grp grp(A, sym_list);
   EXPECT_EQ(grp.get_sym_classes().size(), 1);
 }
 
@@ -87,26 +87,26 @@ TEST(SymGrp, TensorCylicTriplet) { //NOLINT
   nda::array<std::complex<double>, 6> A(2, 2, 2, 2, 2, 2);
  
   // 1) A_ijklmn -> A_jkilmn
-  std::function<operation(std::array<long, 6> &)> p0 = [](std::array<long, 6> &x) {
+  std::function<nda::operation(std::array<long, 6> &)> p0 = [](std::array<long, 6> &x) {
     auto idx = x[0];
     x[0]     = x[1];
     x[1]     = x[2];
     x[2]     = idx;
-    return operation{false, false};
+    return nda::operation{false, false};
   };
 
   // 2) A_ijklmn -> A_ijkmnl
-  std::function<operation(std::array<long, 6> &)> p1 = [](std::array<long, 6> &x) {
+  std::function<nda::operation(std::array<long, 6> &)> p1 = [](std::array<long, 6> &x) {
     auto idx = x[3];
     x[3]     = x[4];
     x[4]     = x[5];
     x[5]     = idx;
-    return operation{false, false};
+    return nda::operation{false, false};
   };
 
   // compute symmetry classes
-  std::vector<std::function<operation(std::array<long, 6> &)>> sym_list = {p0, p1};
-  sym_grp grp(A, sym_list);
+  std::vector<std::function<nda::operation(std::array<long, 6> &)>> sym_list = {p0, p1};
+  nda::sym_grp grp(A, sym_list);
   EXPECT_EQ(grp.get_sym_classes().size(), pow((pow(N, 3) + 2 * N) / 3, 2));
 }
 


### PR DESCRIPTION
Added new types `nda::operation` and `nda::sym_grp`. The latter can be constructed from a list of callable objects `F` modelling the `NdaSymmetry` concept (_take the indices of an `nda::array`, mutate them and return an `nda::operation`_) and an `nda::array.` Instances of `nda::sym_grp` contain a list of orbits (with associated operations) traversed by recursively applying `F` to non-equivalent elements of the array. Given a set of symmetries, this allows one to restrict the calculation of array elements to an irreducible subset instead of the whole object.