### PR TITLE
implemented vector rhs for gelss

### DIFF
--- a/c++/nda/lapack/gelss.hpp
+++ b/c++/nda/lapack/gelss.hpp
@@ -86,21 +86,19 @@ namespace nda::lapack {
 
     // First call to get the optimal bufferSize
     T bufferSize_T{};
-    int info = 0, nrhs = 1, ldb;
+    int info = 0;
+    int nrhs = 1, ldb = b.size(); // Defaults for B MemoryVector
     if constexpr (MemoryMatrix<B>) {
       nrhs = b.extent(1);
-      ldb = get_ld(b);
-    } else { // MemoryVector
-      ldb = b.size();
+      ldb  = get_ld(b);
     }
-    f77::gelss(a.extent(0), a.extent(1), nrhs, a.data(), get_ld(a), b.data(), ldb, s.data(), rcond, rank, &bufferSize_T, -1, rwork.data(),
-               info);
+    f77::gelss(a.extent(0), a.extent(1), nrhs, a.data(), get_ld(a), b.data(), ldb, s.data(), rcond, rank, &bufferSize_T, -1, rwork.data(), info);
     int bufferSize = static_cast<int>(std::ceil(std::real(bufferSize_T)));
 
     // Allocate work buffer and perform actual library call
     array<T, 1> work(bufferSize);
-    f77::gelss(a.extent(0), a.extent(1), nrhs, a.data(), get_ld(a), b.data(), ldb, s.data(), rcond, rank, work.data(), bufferSize,
-               rwork.data(), info);
+    f77::gelss(a.extent(0), a.extent(1), nrhs, a.data(), get_ld(a), b.data(), ldb, s.data(), rcond, rank, work.data(), bufferSize, rwork.data(),
+               info);
 
     if (info) NDA_RUNTIME_ERROR << "Error in gesvd : info = " << info;
     return info;

--- a/c++/nda/lapack/gelss.hpp
+++ b/c++/nda/lapack/gelss.hpp
@@ -68,10 +68,11 @@ namespace nda::lapack {
    *                 if INFO = i, i off-diagonal elements of an intermediate
    *                 bidiagonal form did not converge to zero.
    */
-  template <MemoryMatrix A, MemoryMatrix B, MemoryVector S>
+  template <MemoryMatrix A, MemoryArray B, MemoryVector S>
     requires(have_same_value_type_v<A, B> and mem::on_host<A, B, S> and is_blas_lapack_v<get_value_t<A>>)
   int gelss(A &&a, B &&b, S &&s, double rcond, int &rank) {
     static_assert(has_F_layout<A> and has_F_layout<B>, "C order not implemented");
+    static_assert(MemoryVector<B> or MemoryMatrix<B>, "B must be vector or matrix");
 
     using T    = get_value_t<A>;
     auto dm    = std::min(a.extent(0), a.extent(1));
@@ -85,14 +86,15 @@ namespace nda::lapack {
 
     // First call to get the optimal bufferSize
     T bufferSize_T{};
-    int info = 0;
-    f77::gelss(a.extent(0), a.extent(1), b.extent(1), a.data(), get_ld(a), b.data(), get_ld(b), s.data(), rcond, rank, &bufferSize_T, -1,
-               rwork.data(), info);
+    int info = 0, nrhs = 1;
+    if (MemoryMatrix<B>) { nrhs = b.extent(1); }
+    f77::gelss(a.extent(0), a.extent(1), nrhs, a.data(), get_ld(a), b.data(), b.extent(0), s.data(), rcond, rank, &bufferSize_T, -1, rwork.data(),
+               info);
     int bufferSize = static_cast<int>(std::ceil(std::real(bufferSize_T)));
 
     // Allocate work buffer and perform actual library call
     array<T, 1> work(bufferSize);
-    f77::gelss(a.extent(0), a.extent(1), b.extent(1), a.data(), get_ld(a), b.data(), get_ld(b), s.data(), rcond, rank, work.data(), bufferSize,
+    f77::gelss(a.extent(0), a.extent(1), nrhs, a.data(), get_ld(a), b.data(), b.extent(0), s.data(), rcond, rank, work.data(), bufferSize,
                rwork.data(), info);
 
     if (info) NDA_RUNTIME_ERROR << "Error in gesvd : info = " << info;

--- a/c++/nda/lapack/gelss_worker.hpp
+++ b/c++/nda/lapack/gelss_worker.hpp
@@ -19,6 +19,7 @@
 #include <optional>
 
 #include "./gesvd.hpp"
+#include "../linalg.hpp"
 
 namespace nda::lapack {
 
@@ -83,6 +84,13 @@ namespace nda::lapack {
         for (int i : range(B.shape()[1])) err_vec.push_back(frobenius_norm(UT_NULL * B(range::all, range(i, i + 1))) / sqrt(B.shape()[0]));
         err = *std::max_element(err_vec.begin(), err_vec.end());
       }
+      return std::make_pair(V_x_InvS_x_UT * B, err);
+    }
+
+    std::pair<vector<T>, double> operator()(vector_const_view<T> B, std::optional<long> /*inner_matrix_dim*/ = {}) const {
+      using std::sqrt;
+      double err = 0.0;
+      if (M != N) { err = norm(UT_NULL * B) / sqrt(B.size()); }
       return std::make_pair(V_x_InvS_x_UT * B, err);
     }
   };


### PR DESCRIPTION
Previously, nda::lapack::gelss would not take a vector right hand side, which is inconvenient if you want to solve a least squares problem with a single right hand side. This PR should fix this.