### PR TITLE
in geqp3, made jpvt output 0-indexed

### DIFF
--- a/c++/nda/lapack/geqp3.hpp
+++ b/c++/nda/lapack/geqp3.hpp
@@ -80,6 +80,7 @@ namespace nda::lapack {
     // Allocate work buffer and perform actual library call
     nda::array<T, 1, C_layout, heap<mem::get_addr_space<A>>> work(bufferSize);
     lapack::f77::geqp3(m, n, a.data(), get_ld(a), jpvt.data(), tau.data(), work.data(), bufferSize, rwork.data(), info);
+    jpvt -= 1; // Shift to 0-based indexing
 
     if (info) NDA_RUNTIME_ERROR << "Error in geqp3 : info = " << info;
     return info;

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -159,7 +159,7 @@ void test_geqp3() { //NOLINT
 
   // Compute A*P by permuting columns of A
   auto AP = matrix_t{A};
-  for (int j = 0; j < N; ++j) { AP(_, j) = A(_, jpvt(j) - 1); }
+  for (int j = 0; j < N; ++j) { AP(_, j) = A(_, jpvt(j)); }
 
   // Extract upper triangular matrix R
   auto R = nda::matrix<value_t, F_layout>::zeros(std::min(M, N), N);


### PR DESCRIPTION
Output jpvt of geqp3, taken directly from fortran, was 1-indexed. I converted it to 0-indexing to avoid confusion.