### PR TITLE
Fix two bugs and add corresponding tests

### DIFF
--- a/c++/nda/layout/permutation.hpp
+++ b/c++/nda/layout/permutation.hpp
@@ -65,7 +65,10 @@ namespace nda {
   template <size_t N>
   constexpr uint64_t encode(std::array<int, N> const &a) {
     uint64_t result = 0;
-    for (int i = 0; i < N; ++i) result += (static_cast<uint64_t>(a[i]) << (4 * i));
+    for (int i = 0; i < N; ++i) {
+      EXPECTS(0 <= a[i] and a[i] <= 15);
+      result += (static_cast<uint64_t>(a[i]) << (4 * i));
+    }
     return result;
   }
 
@@ -118,7 +121,7 @@ namespace nda::permutations {
   /**
    * @brief Inverse of a permutation.
    *
-   * @details The inverse, `inv`, of a permutation `p` is defined such that `compose(p, inv) == compose(int, p) == identity`.
+   * @details The inverse, `inv`, of a permutation `p` is defined such that `compose(p, inv) == compose(inv, p) == identity`.
    *
    * @tparam Int Integral type.
    * @tparam N Degree of the permutations.

--- a/test/c++/nda_layout_for_each.cpp
+++ b/test/c++/nda_layout_for_each.cpp
@@ -34,11 +34,11 @@ TEST(NDA, ForEachIndexFromStrideOrder) {
 
 TEST(NDA, ForEachGetExtent) {
   constexpr auto shape_arr  = std::array{2, 3, 4};
-//   constexpr auto shape_code = nda::encode(shape_arr);
-//   constexpr auto zeros      = nda::stdutil::make_initialized_array<std::size(shape_arr)>(0l);
-//   static_assert(nda::details::get_extent<0, 3, shape_code>(zeros) == 2);
-//   static_assert(nda::details::get_extent<1, 3, shape_code>(zeros) == 3);
-//   static_assert(nda::details::get_extent<2, 3, shape_code>(zeros) == 4);
+  constexpr auto shape_code = nda::encode(shape_arr);
+  constexpr auto zeros      = nda::stdutil::make_initialized_array<std::size(shape_arr)>(0l);
+  static_assert(nda::details::get_extent<0, 3, shape_code>(zeros) == 2);
+  static_assert(nda::details::get_extent<1, 3, shape_code>(zeros) == 3);
+  static_assert(nda::details::get_extent<2, 3, shape_code>(zeros) == 4);
 
   auto shape_dyn = shape_arr;
   auto e1        = nda::details::get_extent<0, 3, 0>(shape_dyn);

--- a/test/c++/nda_layout_for_each.cpp
+++ b/test/c++/nda_layout_for_each.cpp
@@ -1,0 +1,97 @@
+// Copyright (c) 2020-2022 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn
+
+#include <gtest/gtest.h>
+
+#include <nda/layout/for_each.hpp>
+#include <nda/stdutil/array.hpp>
+
+#include <array>
+
+TEST(NDA, ForEachIndexFromStrideOrder) {
+  constexpr auto order_arr  = std::array{1, 2, 0};
+  constexpr auto order_code = nda::encode(order_arr);
+  static_assert(nda::details::index_from_stride_order<3>(order_code, 0) == 1);
+  static_assert(nda::details::index_from_stride_order<3>(order_code, 1) == 2);
+  static_assert(nda::details::index_from_stride_order<3>(order_code, 2) == 0);
+  EXPECT_EQ(nda::details::index_from_stride_order<3>(order_code, 0), 1);
+  EXPECT_EQ(nda::details::index_from_stride_order<3>(order_code, 1), 2);
+  EXPECT_EQ(nda::details::index_from_stride_order<3>(order_code, 2), 0);
+}
+
+TEST(NDA, ForEachGetExtent) {
+  constexpr auto shape_arr  = std::array{2, 3, 4};
+//   constexpr auto shape_code = nda::encode(shape_arr);
+//   constexpr auto zeros      = nda::stdutil::make_initialized_array<std::size(shape_arr)>(0l);
+//   static_assert(nda::details::get_extent<0, 3, shape_code>(zeros) == 2);
+//   static_assert(nda::details::get_extent<1, 3, shape_code>(zeros) == 3);
+//   static_assert(nda::details::get_extent<2, 3, shape_code>(zeros) == 4);
+
+  auto shape_dyn = shape_arr;
+  auto e1        = nda::details::get_extent<0, 3, 0>(shape_dyn);
+  auto e2        = nda::details::get_extent<1, 3, 0>(shape_dyn);
+  auto e3        = nda::details::get_extent<2, 3, 0>(shape_dyn);
+  EXPECT_EQ(e1, 2);
+  EXPECT_EQ(e2, 3);
+  EXPECT_EQ(e3, 4);
+}
+
+TEST(NDA, ForeachStaticAndDynamic) {
+  constexpr long n_i       = 2;
+  constexpr long n_j       = 3;
+  constexpr long n_k       = 4;
+  constexpr auto shape_arr = std::array{n_i, n_j, n_k};
+
+  // dynamic extents with C-order
+  int count   = 0;
+  auto flat_c = [](long i, long j, long k) { return i * n_j * n_k + j * n_k + k; };
+  nda::for_each(shape_arr, [&count, flat_c](long i, long j, long k) {
+    EXPECT_EQ(flat_c(i, j, k), count);
+    ++count;
+  });
+  EXPECT_EQ(count, n_i * n_j * n_k);
+
+  // static extents with C-order
+  count                     = 0;
+  constexpr auto shape_code = nda::encode(nda::stdutil::make_std_array<int>(shape_arr));
+  nda::for_each_static<shape_code, 0>(shape_arr, [&count, flat_c](long i, long j, long k) {
+    EXPECT_EQ(flat_c(i, j, k), count);
+    ++count;
+  });
+  EXPECT_EQ(count, n_i * n_j * n_k);
+
+  // static extents with Fortran-order
+  count                       = 0;
+  auto flat_f                 = [](long i, long j, long k) { return k * n_i * n_j + j * n_i + i; };
+  constexpr auto f_order_arr  = std::array{2, 1, 0};
+  constexpr auto f_order_code = nda::encode(f_order_arr);
+  nda::for_each_static<shape_code, f_order_code>(shape_arr, [&count, flat_f](long i, long j, long k) {
+    EXPECT_EQ(flat_f(i, j, k), count);
+    ++count;
+  });
+  EXPECT_EQ(count, n_i * n_j * n_k);
+
+  // dynamic extents with custom-order
+  count                            = 0;
+  auto flat_custom                 = [](long i, long j, long k) { return j * n_i * n_k + k * n_i + i; };
+  constexpr auto custom_order_arr  = std::array{1, 2, 0};
+  constexpr auto custom_order_code = nda::encode(custom_order_arr);
+  nda::for_each_static<0, custom_order_code>(shape_arr, [&count, flat_custom](long i, long j, long k) {
+    EXPECT_EQ(flat_custom(i, j, k), count);
+    ++count;
+  });
+  EXPECT_EQ(count, n_i * n_j * n_k);
+}

--- a/test/c++/nda_layout_permutation.cpp
+++ b/test/c++/nda_layout_permutation.cpp
@@ -23,7 +23,7 @@
 #include <numeric>
 #include <random>
 
-// Iake identity or random permutation of size N.
+// Make identity or random permutation of size N.
 template <int N>
 auto make_permutation(bool random = true) {
   std::array<int, N> arr{};
@@ -67,6 +67,8 @@ TEST(NDA, PermutationIsValid) {
   EXPECT_FALSE(nda::permutations::is_valid(nda::stdutil::append(perm, size - 1)));
   EXPECT_FALSE(nda::permutations::is_valid(nda::stdutil::append(perm, size + 1)));
   EXPECT_FALSE(nda::permutations::is_valid(nda::stdutil::append(perm, -1)));
+  perm[0] = size;
+  EXPECT_FALSE(nda::permutations::is_valid(perm));
 }
 
 TEST(NDA, PermutationComposeAndInverse) {
@@ -99,10 +101,10 @@ TEST(NDA, PermutationIdentityAndReverseIdentity) {
 }
 
 TEST(NDA, PermutationTransposition) {
-  auto arr = std::array{10, 100, 1000};
-  auto tp  = nda::permutations::transposition<std::size(arr)>(0, std::size(arr) - 1);
-  EXPECT_EQ((std::array{1000, 100, 10}), nda::permutations::apply(tp, arr));
-  EXPECT_EQ(arr, nda::permutations::apply(tp, nda::permutations::apply(tp, arr)));
+  auto arr    = std::array{10, 100, 1000};
+  auto transp = nda::permutations::transposition<std::size(arr)>(0, std::size(arr) - 1);
+  EXPECT_EQ((std::array{1000, 100, 10}), nda::permutations::apply(transp, arr));
+  EXPECT_EQ(arr, nda::permutations::apply(transp, nda::permutations::apply(transp, arr)));
 }
 
 TEST(NDA, PermutationCycle) {

--- a/test/c++/nda_layout_permutation.cpp
+++ b/test/c++/nda_layout_permutation.cpp
@@ -1,0 +1,135 @@
+// Copyright (c) 2020-2022 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn
+
+#include <gtest/gtest.h>
+
+#include <nda/layout/permutation.hpp>
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <random>
+
+// Iake identity or random permutation of size N.
+template <int N>
+auto make_permutation(bool random = true) {
+  std::array<int, N> arr{};
+  std::iota(arr.begin(), arr.end(), 0);
+  if (random) { std::shuffle(arr.begin(), arr.end(), std::mt19937{0xd62847d0}); }
+  return arr;
+}
+
+// Check encode/decode function.
+template <int N>
+void check_encode_decode() {
+  auto arr     = make_permutation<N>();
+  auto code    = nda::encode(arr);
+  auto decoded = nda::decode<N>(code);
+  EXPECT_EQ(arr, decoded);
+}
+
+TEST(NDA, LayoutEncodeDecode) {
+  check_encode_decode<0>();
+  check_encode_decode<1>();
+  check_encode_decode<2>();
+  check_encode_decode<3>();
+  check_encode_decode<4>();
+  check_encode_decode<5>();
+  check_encode_decode<6>();
+  check_encode_decode<7>();
+  check_encode_decode<8>();
+  check_encode_decode<9>();
+  check_encode_decode<10>();
+  check_encode_decode<11>();
+  check_encode_decode<12>();
+  check_encode_decode<13>();
+  check_encode_decode<14>();
+  check_encode_decode<15>();
+}
+
+TEST(NDA, PermutationIsValid) {
+  constexpr int size = 5;
+  auto perm          = make_permutation<size>();
+  EXPECT_TRUE(nda::permutations::is_valid(perm));
+  EXPECT_FALSE(nda::permutations::is_valid(nda::stdutil::append(perm, size - 1)));
+  EXPECT_FALSE(nda::permutations::is_valid(nda::stdutil::append(perm, size + 1)));
+  EXPECT_FALSE(nda::permutations::is_valid(nda::stdutil::append(perm, -1)));
+}
+
+TEST(NDA, PermutationComposeAndInverse) {
+  auto perm = std::array{1, 3, 0, 4, 2};
+  auto id   = make_permutation<std::size(perm)>(false);
+
+  EXPECT_EQ(id, nda::permutations::compose(id, id));
+  EXPECT_EQ(id, nda::permutations::inverse(id));
+
+  EXPECT_EQ(perm, nda::permutations::compose(id, perm));
+  EXPECT_EQ(perm, nda::permutations::compose(perm, id));
+  EXPECT_EQ(id, nda::permutations::compose(perm, nda::permutations::inverse(perm)));
+  EXPECT_EQ(id, nda::permutations::compose(nda::permutations::inverse(perm), perm));
+}
+
+TEST(NDA, PermutationApplyAndApplyInverse) {
+  auto perm = std::array{1, 3, 0, 4, 2};
+  auto arr  = std::array{'a', 'e', 'i', 'o', 'u'};
+  EXPECT_NE(arr, nda::permutations::apply(perm, arr));
+  EXPECT_NE(arr, nda::permutations::apply_inverse(perm, arr));
+  EXPECT_EQ(arr, nda::permutations::apply_inverse(perm, nda::permutations::apply(perm, arr)));
+}
+
+TEST(NDA, PermutationIdentityAndReverseIdentity) {
+  constexpr int size = 5;
+  auto id            = nda::permutations::identity<size>();
+  auto rev_id        = nda::permutations::reverse_identity<size>();
+  EXPECT_EQ(id, make_permutation<size>(false));
+  EXPECT_EQ(id, nda::permutations::compose(rev_id, rev_id));
+}
+
+TEST(NDA, PermutationTransposition) {
+  auto arr = std::array{10, 100, 1000};
+  auto tp  = nda::permutations::transposition<std::size(arr)>(0, std::size(arr) - 1);
+  EXPECT_EQ((std::array{1000, 100, 10}), nda::permutations::apply(tp, arr));
+  EXPECT_EQ(arr, nda::permutations::apply(tp, nda::permutations::apply(tp, arr)));
+}
+
+TEST(NDA, PermutationCycle) {
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(0));
+  EXPECT_EQ((std::array{3, 0, 1, 2}), nda::permutations::cycle<4>(1));
+  EXPECT_EQ((std::array{2, 3, 0, 1}), nda::permutations::cycle<4>(2));
+  EXPECT_EQ((std::array{1, 2, 3, 0}), nda::permutations::cycle<4>(3));
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(4));
+  EXPECT_EQ((std::array{1, 2, 3, 0}), nda::permutations::cycle<4>(-1));
+  EXPECT_EQ((std::array{2, 3, 0, 1}), nda::permutations::cycle<4>(-2));
+  EXPECT_EQ((std::array{3, 0, 1, 2}), nda::permutations::cycle<4>(-3));
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(-4));
+
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(0, 2));
+  EXPECT_EQ((std::array{1, 0, 2, 3}), nda::permutations::cycle<4>(1, 2));
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(2, 2));
+  EXPECT_EQ((std::array{1, 2, 0, 3}), nda::permutations::cycle<4>(-1, 3));
+  EXPECT_EQ((std::array{2, 0, 1, 3}), nda::permutations::cycle<4>(-2, 3));
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(-3, 3));
+
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(0, 5));
+  EXPECT_EQ((std::array{3, 0, 1, 2}), nda::permutations::cycle<4>(1, 5));
+  EXPECT_EQ((std::array{2, 3, 0, 1}), nda::permutations::cycle<4>(2, 5));
+  EXPECT_EQ((std::array{1, 2, 3, 0}), nda::permutations::cycle<4>(3, 5));
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(4, 5));
+  EXPECT_EQ((std::array{1, 2, 3, 0}), nda::permutations::cycle<4>(-1, 5));
+  EXPECT_EQ((std::array{2, 3, 0, 1}), nda::permutations::cycle<4>(-2, 5));
+  EXPECT_EQ((std::array{3, 0, 1, 2}), nda::permutations::cycle<4>(-3, 5));
+  EXPECT_EQ((std::array{0, 1, 2, 3}), nda::permutations::cycle<4>(-4, 5));
+}


### PR DESCRIPTION
- `encode`: only works correctly up to 8 dimensions but it should work up to 16 --> I simply added a missing `static_cast`
- `for_each_static`: only works correctly for C-layouts or for shapes which have the same extent in each dimension, always traverses the indices in C-order --> I rewrote the `for_each_static_impl` function such that it works for any layout and traverses it in the correct stride order