### PR TITLE
Fix Intel vs GNU ABI when building against MKL

### DIFF
--- a/c++/nda/blas/interface/cxx_interface.cpp
+++ b/c++/nda/blas/interface/cxx_interface.cpp
@@ -74,11 +74,21 @@ namespace nda::blas::f77 {
 
   double dot(int M, const double *x, int incx, const double *Y, int incy) { return F77_ddot(&M, x, &incx, Y, &incy); }
   dcomplex dot(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy) {
+#ifdef NDA_USE_MKL
+    MKL_Complex16 result;
+    cblas_zdotu_sub(M, mklcplx(x), incx, mklcplx(Y), incy, &result);
+#else
     auto result = F77_zdotu(&M, blacplx(x), &incx, blacplx(Y), &incy);
+#endif
     return dcomplex{result.real, result.imag};
   }
   dcomplex dotc(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy) {
+#ifdef NDA_USE_MKL
+    MKL_Complex16 result;
+    cblas_zdotc_sub(M, mklcplx(x), incx, mklcplx(Y), incy, &result);
+#else
     auto result = F77_zdotc(&M, blacplx(x), &incx, blacplx(Y), &incy);
+#endif
     return dcomplex{result.real, result.imag};
   }
 


### PR DESCRIPTION
For functions that return complex values, there are two strategies how values can be returned. Either via a value on the stack (aka return value) or via an implicit first argument (aka output argument). The former is called GNU ABI and the latter Intel ABI by the Intel MKL. There are two variants of the Intel MKL and when calling functions like zdotu that return a complex value it does make a difference which one the application is linked to.

Unfortunately, there is no way to detect this at runtime and other libraries that are linked into the application might have other preferences with regards to which MKL interface they want to use. With this commit we make the code ABI agnostic by simply using the CBLAS API which always uses an output argument.

https://www.intel.com/content/www/us/en/docs/onemkl/developer-guide-linux/2024-1/call-blas-funcs-return-complex-values-in-c-code.html

Fixes https://github.com/TRIQS/nda/issues/67