### PR TITLE
Fix bugs in assignment operators

### DIFF
--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -434,7 +434,7 @@ auto &operator/=(RHS const &rhs) noexcept {
  */
 template <std::ranges::contiguous_range R>
 auto &operator=(R const &rhs) noexcept
-  requires(Rank == 1 and not MemoryArray<R>)
+  requires(Rank == 1 and not MemoryArray<R> and not is_scalar_for_v<R, self_t>)
 {
   *this = array_const_view<std::ranges::range_value_t<R>, 1>{rhs};
   return *this;

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -436,7 +436,7 @@ template <std::ranges::contiguous_range R>
 auto &operator=(R const &rhs) noexcept
   requires(Rank == 1 and not MemoryArray<R>)
 {
-  *this = basic_array_view{rhs};
+  *this = array_const_view<std::ranges::range_value_t<R>, 1>{rhs};
   return *this;
 }
 

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -204,7 +204,7 @@ FORCEINLINE static decltype(auto) call(Self &&self, Ts const &...idxs) noexcept(
       long offset = self.lay(idxs...);
       if constexpr (is_view or not SelfIsRvalue) {
         // if the calling object is a view or an lvalue, we return a reference
-        return AccessorPolicy::template accessor<ValueType>::access(self.sto.data(), offset);
+        return AccessorPolicy::template accessor<r_v_t>::access(self.sto.data(), offset);
       } else {
         // otherwise, we return a copy of the value
         return ValueType{self.sto[offset]};
@@ -217,7 +217,7 @@ FORCEINLINE static decltype(auto) call(Self &&self, Ts const &...idxs) noexcept(
       static constexpr char newAlgebra = (ResultAlgebra == 'M' and (res_rank == 1) ? 'V' : ResultAlgebra);
       // resulting layout policy
       using r_layout_p = typename detail::layout_to_policy<std::decay_t<decltype(idxm)>>::type;
-      return basic_array_view<ValueType, res_rank, r_layout_p, newAlgebra, AccessorPolicy, OwningPolicy>{std::move(idxm), {self.sto, offset}};
+      return basic_array_view<r_v_t, res_rank, r_layout_p, newAlgebra, AccessorPolicy, OwningPolicy>{std::move(idxm), {self.sto, offset}};
     }
   }
 }

--- a/c++/nda/h5.hpp
+++ b/c++/nda/h5.hpp
@@ -128,7 +128,7 @@ namespace nda {
    */
   template <MemoryArray A>
   void h5_write(h5::group g, std::string const &name, A const &a, bool compress = true) {
-    if constexpr (std::is_same_v<typename A::value_type, std::string>) {
+    if constexpr (std::is_same_v<std::remove_cvref_t<typename A::value_type>, std::string>) {
       // 1-dimensional array/view of strings
       h5_write(g, name, detail::to_char_buf(a));
     } else if constexpr (is_scalar_v<typename A::value_type>) {

--- a/c++/nda/h5.hpp
+++ b/c++/nda/h5.hpp
@@ -128,7 +128,7 @@ namespace nda {
    */
   template <MemoryArray A>
   void h5_write(h5::group g, std::string const &name, A const &a, bool compress = true) {
-    if constexpr (std::is_same_v<std::remove_cvref_t<typename A::value_type>, std::string>) {
+    if constexpr (std::is_same_v<nda::get_value_t<A>, std::string>) {
       // 1-dimensional array/view of strings
       h5_write(g, name, detail::to_char_buf(a));
     } else if constexpr (is_scalar_v<typename A::value_type>) {

--- a/test/c++/nda_array_adapter.cpp
+++ b/test/c++/nda_array_adapter.cpp
@@ -32,7 +32,6 @@ struct foo {
 struct bar {
   int j = 0;
   bar(foo &&f) : j(f.i) { f.i = 0; }
-  bar(const foo &f) : j(f.i) {}
 };
 
 TEST(NDA, ArrayAdapterBasics) {
@@ -72,21 +71,6 @@ TEST(NDA, ArrayAdapterMoveElements) {
 }
 
 TEST(NDA, ArrayAdapterMoveElements2) {
-  // test moving elements from one array to another using an array adapter
-  nda::array<foo, 2> A_foo(2, 2);
-  for (int i = 0; i < 2; ++i)
-    for (int j = 0; j < 2; ++j) A_foo(i, j).i = 1 + i + 10 * j;
-
-  auto f2    = [A_foo2 = std::move(A_foo)](long i, long j) { return bar{A_foo2(i, j)}; };
-  auto A_bar = nda::array<bar, 2>{nda::array_adapter{std::array{2, 2}, f2}};
-
-  EXPECT_TRUE(A_foo.empty());
-  for (int i = 0; i < 2; ++i) {
-    for (int j = 0; j < 2; ++j) { EXPECT_EQ(A_bar(i, j).j, (1 + i + 10 * j)); }
-  }
-}
-
-TEST(NDA, ArrayAdapterMoveElements3) {
   // test moving elements from one array to another using nda::map instead of an array adapter
   nda::array<foo, 2> A_foo(2, 2);
   for (int i = 0; i < 2; ++i)

--- a/test/c++/nda_array_adapter.cpp
+++ b/test/c++/nda_array_adapter.cpp
@@ -32,6 +32,7 @@ struct foo {
 struct bar {
   int j = 0;
   bar(foo &&f) : j(f.i) { f.i = 0; }
+  bar(const foo &f) : j(f.i) {}
 };
 
 TEST(NDA, ArrayAdapterBasics) {
@@ -76,7 +77,7 @@ TEST(NDA, ArrayAdapterMoveElements2) {
   for (int i = 0; i < 2; ++i)
     for (int j = 0; j < 2; ++j) A_foo(i, j).i = 1 + i + 10 * j;
 
-  auto f2    = [A_foo2 = std::move(A_foo)](long i, long j) { return bar{std::move(A_foo2(i, j))}; };
+  auto f2    = [A_foo2 = std::move(A_foo)](long i, long j) { return bar{A_foo2(i, j)}; };
   auto A_bar = nda::array<bar, 2>{nda::array_adapter{std::array{2, 2}, f2}};
 
   EXPECT_TRUE(A_foo.empty());

--- a/test/c++/nda_basic_array_and_view.cpp
+++ b/test/c++/nda_basic_array_and_view.cpp
@@ -24,7 +24,7 @@
 #include <vector>
 #include <tuple>
 
-// Test fixture for testing various algorithms.
+// Test fixture for testing arrays and views.
 struct NDAArrayAndView : public ::testing::Test {
   protected:
   using lay_3d_t = nda::contiguous_layout_with_stride_order<nda::encode(std::array{1, 2, 0})>;
@@ -236,22 +236,29 @@ void check_assignments() {
   A10_v = arr_init;
   EXPECT_EQ(A, A10);
 
-  // rank specific assignments -> not working but should
-  // if constexpr (rank == 1) {
-  //   std::vector<value_t> vec(shape[0]);
-  //   std::iota(vec.begin(), vec.end(), 0);
+  // rank specific assignments
+  if constexpr (rank == 1) {
+    std::vector<value_t> vec(shape[0]);
+    std::iota(vec.begin(), vec.end(), 0);
 
-  //   // assign a contiguous range to an array
-  //   arr_t A11;
-  //   A11 = vec;
-  //   for (long i = 0; i < shape[0]; ++i) EXPECT_EQ(A11(i), vec[i]);
+    // assign a contiguous range to an array
+    arr_t A11;
+    A11 = vec;
+    for (long i = 0; i < shape[0]; ++i) EXPECT_EQ(A11(i), vec[i]);
 
-  //   // assign a contiguous range to a view -> not working but should
-  //   arr_t A12(shape);
-  //   view_t A12_v(A12);
-  //   A12_v = vec;
-  //   for (long i = 0; i < shape[0]; ++i) EXPECT_EQ(A12(i), vec[i]);
-  // }
+    // assign a contiguous range to a view
+    arr_t A12(shape);
+    view_t A12_v(A12);
+    A12_v = vec;
+    for (long i = 0; i < shape[0]; ++i) EXPECT_EQ(A12(i), vec[i]);
+
+    // assign a const vector to a view
+    const std::vector<value_t> cvec{1, 2, 3};
+    arr_t A13(3);
+    view_t A13_v(A13);
+    A13_v = cvec;
+    for (long i = 0; i < 3; ++i) EXPECT_EQ(A13(i), cvec[i]);
+  }
 }
 
 TEST_F(NDAArrayAndView, Constructors) {

--- a/test/c++/nda_bugs_and_issues.cpp
+++ b/test/c++/nda_bugs_and_issues.cpp
@@ -113,3 +113,14 @@ TEST(NDA, STLAlgorithmBug) {
   EXPECT_FALSE(std::lexicographical_compare(C.begin(), C.end(), D.begin(), D.end()));
   EXPECT_TRUE(std::lexicographical_compare(D.begin(), D.end(), C.begin(), C.end()));
 }
+
+TEST(NDA, AmbiguousAssignmentOperatorIssue) {
+  // issue concerning an ambiguous assignment operator overload when assigning a contiguous range
+  nda::array<std::string, 1> A(3);
+  A() = std::string("foo");
+  for (int i = 0; i < 3; ++i) { EXPECT_EQ(A(i), std::string("foo")); }
+
+  nda::array<std::array<int, 3>, 1> B(3);
+  B = std::array{1, 2, 3};
+  for (int i = 0; i < 3; ++i) { EXPECT_EQ(B(i), (std::array{1, 2, 3})); }
+}

--- a/test/c++/nda_views.cpp
+++ b/test/c++/nda_views.cpp
@@ -188,9 +188,9 @@ TEST(NDA, ConstView) {
 
   // assigning to a const array does not compile
   // const nda::array<long, 1> C = {1, 2, 3, 4};
-  // C(0) = 2; // this compiles but it shouldn't
+  // C(0) = 2;
   // C()(0) = 2;
-  // C(nda::range(0, 2))(0) = 10; // this compiles but it shouldn't
+  // C(nda::range(0, 2))(0) = 10;
 }
 
 TEST(NDA, ViewToStringstream) {


### PR DESCRIPTION
There were 2 bugs:

- Assigning a 1D contiguous range to a view did not work, since the assignment operator tried to construct a non-const view of a const range (it takes the range as `const &`).
- A bug in the function call operator in `_impl_basic_array_view_common.hpp` allowed to assign to const views/arrays, since it returned a view with non-const value type.