### PR TITLE
Fixes for negative strides

### DIFF
--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -516,7 +516,7 @@ void fill_with_scalar(Scalar const &scalar) noexcept {
     } else {
       const long stri  = indexmap().min_stride();
       const long Lstri = L * stri;
-      for (long i = 0; i < Lstri; i += stri) p[i] = scalar;
+      for (long i = 0; i != Lstri; i += stri) p[i] = scalar;
     }
   } else {
     // no compile-time memory layout guarantees

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -83,6 +83,12 @@
 [[nodiscard]] long is_contiguous() const noexcept { return lay.is_contiguous(); }
 
 /**
+ * @brief Are all the strides of the memory layout of the view/array positive?
+ * @return True if the nda::idx_map has positive strides, false otherwise.
+ */
+[[nodiscard]] long has_positive_strides() const noexcept { return lay.has_positive_strides(); }
+
+/**
  * @brief Is the view/array empty?
  * @return True if the view/array does not contain any elements.
  */

--- a/c++/nda/layout/idx_map.hpp
+++ b/c++/nda/layout/idx_map.hpp
@@ -224,7 +224,7 @@ namespace nda {
       auto s = size();
       if (s == 0) return true;
       int i = Rank - 1;
-      for (; len[stride_order[i]] == 1; --i);
+      while (len[stride_order[i]] == 1 and i > 0) --i;
       return (std::abs(str[stride_order[0]] * len[stride_order[0]]) == s * std::abs(str[stride_order[i]]));
     }
 

--- a/c++/nda/layout_transforms.hpp
+++ b/c++/nda/layout_transforms.hpp
@@ -109,7 +109,8 @@ namespace nda {
     // check size and contiguity of new shape
     EXPECTS_WITH_MESSAGE(a.size() == (std::accumulate(new_shape.cbegin(), new_shape.cend(), Int{1}, std::multiplies<>{})),
                          "Error in nda::reshape: New shape has an incorrect number of elements");
-    EXPECTS_WITH_MESSAGE(a.indexmap().is_contiguous(), "Error in nda::reshape: Only contiguous arrays/views are supported");
+    EXPECTS_WITH_MESSAGE(a.is_contiguous(), "Error in nda::reshape: Only contiguous arrays/views are supported");
+    EXPECTS_WITH_MESSAGE(a.has_positive_strides(), "Error in nda::reshape: Only arrays/views with positive strides are supported")
 
     // restrict supported layouts (why?)
     using A_t = std::remove_cvref_t<A>;

--- a/c++/nda/linalg/eigenelements.hpp
+++ b/c++/nda/linalg/eigenelements.hpp
@@ -45,7 +45,8 @@ namespace nda::linalg {
       // runtime checks
       EXPECTS((not m.empty()));
       EXPECTS(is_matrix_square(m, true));
-      EXPECTS(m.indexmap().is_contiguous());
+      EXPECTS(m.is_contiguous());
+      EXPECTS(m.has_positive_strides());
 
       // set up the workspace
       int dim   = m.extent(0);

--- a/c++/nda/mpi/gather.hpp
+++ b/c++/nda/mpi/gather.hpp
@@ -97,7 +97,9 @@ struct mpi::lazy<mpi::tag::gather, A> {
   template <nda::Array T>
   void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
     // check if the arrays can be used in the MPI call
-    if (not target.is_contiguous()) NDA_RUNTIME_ERROR << "Error in MPI gather for nda::Array: Target array needs to be contiguous";
+    if (not target.is_contiguous() or not target.has_positive_strides())
+      NDA_RUNTIME_ERROR << "Error in MPI gather for nda::Array: Target array needs to be contiguous with positive strides";
+
     static_assert(std::decay_t<A>::layout_t::stride_order_encoded == std::decay_t<T>::layout_t::stride_order_encoded,
                   "Error in MPI gather for nda::Array: Incompatible stride orders");
 
@@ -166,7 +168,8 @@ namespace nda {
   ArrayInitializer<std::remove_reference_t<A>> auto mpi_gather(A &&a, mpi::communicator comm = {}, int root = 0, bool all = false)
     requires(is_regular_or_view_v<A>)
   {
-    if (not a.is_contiguous()) NDA_RUNTIME_ERROR << "Error in MPI gather for nda::Array: Array needs to be contiguous";
+    if (not a.is_contiguous() or not a.has_positive_strides())
+      NDA_RUNTIME_ERROR << "Error in MPI gather for nda::Array: Array needs to be contiguous with positive strides";
     return mpi::lazy<mpi::tag::gather, A>{std::forward<A>(a), comm, root, all};
   }
 

--- a/c++/nda/mpi/reduce.hpp
+++ b/c++/nda/mpi/reduce.hpp
@@ -88,7 +88,9 @@ struct mpi::lazy<mpi::tag::reduce, A> {
   template <nda::Array T>
   void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
     // check if the arrays can be used in the MPI call
-    if (not target.is_contiguous()) NDA_RUNTIME_ERROR << "Error in MPI reduce for nda::Array: Target array needs to be contiguous";
+    if (not target.is_contiguous() or not target.has_positive_strides())
+      NDA_RUNTIME_ERROR << "Error in MPI reduce for nda::Array: Target array needs to be contiguous with positive strides";
+
     static_assert(std::decay_t<A>::layout_t::stride_order_encoded == std::decay_t<T>::layout_t::stride_order_encoded,
                   "Error in MPI reduce for nda::Array: Incompatible stride orders");
 
@@ -166,7 +168,8 @@ namespace nda {
                                                                MPI_Op op = MPI_SUM)
     requires(is_regular_or_view_v<A>)
   {
-    if (not a.is_contiguous()) NDA_RUNTIME_ERROR << "Error in MPI reduce for nda::Array: Array needs to be contiguous";
+    if (not a.is_contiguous() or not a.has_positive_strides())
+      NDA_RUNTIME_ERROR << "Error in MPI reduce for nda::Array: Array needs to be contiguous with positive strides";
     return mpi::lazy<mpi::tag::reduce, A>{std::forward<A>(a), comm, root, all, op};
   }
 

--- a/c++/nda/mpi/scatter.hpp
+++ b/c++/nda/mpi/scatter.hpp
@@ -91,7 +91,9 @@ struct mpi::lazy<mpi::tag::scatter, A> {
    */
   template <nda::Array T>
   void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
-    if (not target.is_contiguous()) NDA_RUNTIME_ERROR << "Error in MPI scatter for nda::Array: Target array needs to be contiguous";
+    if (not target.is_contiguous() or not target.has_positive_strides())
+      NDA_RUNTIME_ERROR << "Error in MPI scatter for nda::Array: Target array needs to be contiguous with positive strides";
+
     static_assert(std::decay_t<A>::layout_t::stride_order_encoded == std::decay_t<T>::layout_t::stride_order_encoded,
                   "Error in MPI scatter for nda::Array: Incompatible stride orders");
 
@@ -156,7 +158,8 @@ namespace nda {
   ArrayInitializer<std::remove_reference_t<A>> auto mpi_scatter(A &&a, mpi::communicator comm = {}, int root = 0, bool all = false)
     requires(is_regular_or_view_v<A>)
   {
-    if (not a.is_contiguous()) NDA_RUNTIME_ERROR << "Error in MPI scatter for nda::Array: Array needs to be contiguous";
+    if (not a.is_contiguous() or not a.has_positive_strides())
+      NDA_RUNTIME_ERROR << "Error in MPI scatter for nda::Array: Array needs to be contiguous with positive strides";
     return mpi::lazy<mpi::tag::scatter, A>{std::forward<A>(a), comm, root, all};
   }
 

--- a/test/c++/nda_basic_array_and_view.cpp
+++ b/test/c++/nda_basic_array_and_view.cpp
@@ -568,10 +568,11 @@ TEST_F(NDAArrayAndView, SliceAccessFull) {
       for (long k = 0; k < 4; ++k) EXPECT_EQ(A_3d(i, j, k), 42);
     }
   }
-  A_s3 = A_3d;
+  auto A_3d_copy = A_3d;
+  A_s3           = A_3d_copy;
   for (long i = 0; i < 2; ++i) {
     for (long j = 0; j < 3; ++j) {
-      for (long k = 0; k < 4; ++k) EXPECT_EQ(A_s3(i, j, k), A_3d(1 - i, 2 - j, 3 - k));
+      for (long k = 0; k < 4; ++k) EXPECT_EQ(A_3d(i, j, k), A_3d_copy(1 - i, 2 - j, 3 - k));
     }
   }
 }
@@ -965,8 +966,6 @@ TEST_F(NDAArrayAndView, StrideOrderOfArrays) {
 
 #if defined(__has_feature)
 #if !__has_feature(address_sanitizer)
-TEST_F(NDAArrayAndView, BadAlloc) {
-  EXPECT_THROW(nda::vector<int>(long(1e16)), std::bad_alloc);
-}
+TEST_F(NDAArrayAndView, BadAlloc) { EXPECT_THROW(nda::vector<int>(long(1e16)), std::bad_alloc); }
 #endif
 #endif

--- a/test/c++/nda_bugs_and_issues.cpp
+++ b/test/c++/nda_bugs_and_issues.cpp
@@ -124,3 +124,15 @@ TEST(NDA, AmbiguousAssignmentOperatorIssue) {
   B = std::array{1, 2, 3};
   for (int i = 0; i < 3; ++i) { EXPECT_EQ(B(i), (std::array{1, 2, 3})); }
 }
+
+TEST(NDA, AssignmentTo1DNegativeStridedViewsIssue) {
+  // issue concerning the assignment of scalar values to 1D strided views with negative strides
+  nda::array<int, 1> A(10);
+  for (int i = 0; auto &x : A) x = i++;
+
+  auto B = A(nda::range(9, -1, -1));
+  for (int i = 9; auto x : B) EXPECT_EQ(x, i--);
+
+  B = 1;
+  for (auto x : B) EXPECT_EQ(x, 1);
+}

--- a/test/c++/nda_bugs_and_issues.cpp
+++ b/test/c++/nda_bugs_and_issues.cpp
@@ -136,3 +136,36 @@ TEST(NDA, AssignmentTo1DNegativeStridedViewsIssue) {
   B = 1;
   for (auto x : B) EXPECT_EQ(x, 1);
 }
+
+TEST(NDA, IsStrided1DAndIsContiguousIssue) {
+  // issue concerning the nda::idx_map::is_strided_1d and the nda::idx_map::is_contiguous function
+  nda::array<int, 2> A(10, 10);
+  EXPECT_TRUE(A.indexmap().is_contiguous());
+  EXPECT_TRUE(A.indexmap().has_positive_strides());
+  EXPECT_TRUE(A.indexmap().is_strided_1d());
+
+  auto A_v1 = A(nda::range::all, nda::range(9, -1, -1));
+  EXPECT_TRUE(A_v1.indexmap().is_contiguous());
+  EXPECT_FALSE(A_v1.indexmap().has_positive_strides());
+  EXPECT_TRUE(A_v1.indexmap().is_strided_1d());
+
+  auto A_v2 = A(nda::range(9, -1, -1), nda::range::all);
+  EXPECT_TRUE(A_v2.indexmap().is_contiguous());
+  EXPECT_FALSE(A_v2.indexmap().has_positive_strides());
+  EXPECT_TRUE(A_v2.indexmap().is_strided_1d());
+
+  auto A_v3 = A(nda::range(9, -1, -1), nda::range(9, -1, -1));
+  EXPECT_TRUE(A_v3.indexmap().is_contiguous());
+  EXPECT_FALSE(A_v3.indexmap().has_positive_strides());
+  EXPECT_TRUE(A_v3.indexmap().is_strided_1d());
+
+  nda::array<int, 2> B(10, 1);
+  EXPECT_TRUE(B.indexmap().is_contiguous());
+  EXPECT_TRUE(B.indexmap().has_positive_strides());
+  EXPECT_TRUE(B.indexmap().is_strided_1d());
+
+  auto B_v1 = B(nda::range(0, 10, 2), nda::range::all);
+  EXPECT_FALSE(B_v1.indexmap().is_contiguous());
+  EXPECT_TRUE(B_v1.indexmap().has_positive_strides());
+  EXPECT_TRUE(B_v1.indexmap().is_strided_1d());
+}


### PR DESCRIPTION
- Fixes an issue with assigning a scalar to a 1D view with negative strides.
- Redefines the functions `is_contiguous` and `is_strided_1d` in `nda::idx_map` to also apply to views with negative strides.
- Introduces the function `has_positive_strides` in `nda::idx_map`.