### PR TITLE
[test] suspected memory leak? (do not merge)

### DIFF
--- a/test/python/CMakeLists.txt
+++ b/test/python/CMakeLists.txt
@@ -8,6 +8,11 @@ add_cpp2py_module(copy_move_stat)
 target_link_libraries(copy_move_stat nda_py)
 target_include_directories(copy_move_stat PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 
+# Build the cpp2py module
+add_cpp2py_module(memory_leak)
+target_link_libraries(memory_leak nda_py)
+target_include_directories(memory_leak PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
 ## Build the pybind11 module
 #pybind11_add_module(pybind_a pybind_a.cpp)
 #target_link_libraries(pybind_a PRIVATE pybind11 nda_py python_and_numpy)
@@ -17,7 +22,7 @@ target_include_directories(copy_move_stat PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 #target_link_libraries(pybind_test PRIVATE pybind11 nda_py python_and_numpy)
 
 # List of all tests
-set(all_tests wrap_basic_test copy_move_stat_test)
+set(all_tests wrap_basic_test copy_move_stat_test memory_leak_test)
 
 foreach(test ${all_tests})
   get_filename_component(test_name ${test} NAME_WE)

--- a/test/python/memory_leak.hpp
+++ b/test/python/memory_leak.hpp
@@ -1,0 +1,7 @@
+
+#include <nda/nda.hpp>
+
+void memory_leak(size_t size) {
+  nda::vector<dcomplex> tmp(size);
+  tmp += 1.0;
+}

--- a/test/python/memory_leak_desc.py
+++ b/test/python/memory_leak_desc.py
@@ -1,0 +1,18 @@
+from cpp2py.wrap_generator import *
+
+# The module
+module = module_(full_name = "memory_leak", doc = r"", app_name = "memory_leak")
+
+# Imports
+
+
+module.add_include("memory_leak.hpp")
+
+module.add_preamble("""
+#include <nda_py/cpp2py_converters.hpp>
+
+""")
+
+module.add_function ("void memory_leak(size_t size)", doc = r"""""")
+
+module.generate_code()

--- a/test/python/memory_leak_test.py
+++ b/test/python/memory_leak_test.py
@@ -1,0 +1,30 @@
+
+import os, psutil
+
+from memory_leak import memory_leak
+
+
+def get_mem_usage_mb():
+    return psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2
+
+
+def test_memory_leak():
+
+    P = 204
+    r = 34
+    N = 64
+
+    mem = []
+    
+    for i in range(5):
+            
+        memory_leak(P*(r+i)*N*N)
+        mem.append(get_mem_usage_mb())
+        print(f'--> Memory usage: {mem[-1]} MiB')
+
+    # The list "mem" takes a few bytes but less than 100 MiB
+    assert( mem[-1] < mem[0] + 100. )
+
+
+if __name__ == '__main__':
+    test_memory_leak()


### PR DESCRIPTION
Dear NDA developers,

I am using nda in a project where we call a c++ code from python repeatedly. The problem is that after a few iterations we run out of memory. Here is a small test example for nda that shows the symptoms.

I am not sure what the problem is but the behaviour is that any c++ function that allocates and assigns to an nda vector/array seems to "leak" memory when called from python. The behaviour is not consistent though.

It does not occur for 
- arrays with larger number of elements, or
- multiple allocations of arrays with the same size.

Could this be some "smart" memory handling gone rouge?

The test case runs the function
```c++
#include <nda/nda.hpp>

void memory_leak(size_t size) {
  nda::vector<dcomplex> tmp(size);
  tmp += 1.0;
}
```
repeatedly from python while checking the memory usage,
```python
import os, psutil
from memory_leak import memory_leak

def get_mem_usage_mb():
    return psutil.Process(os.getpid()).memory_info().rss / 1024 ** 2

def test_memory_leak():

    P = 204
    r = 34
    N = 64

    mem = []
    
    for i in range(5):
            
        memory_leak(P*(r+i)*N*N)
        mem.append(get_mem_usage_mb())
        print(f'--> Memory usage: {mem[-1]} MiB')

    # The list "mem" takes a few bytes but less than 100 MiB
    assert( mem[-1] < mem[0] + 100. )

if __name__ == '__main__':
    test_memory_leak()
```
and the output shows a scary increase in memory usage
```
100: --> Memory usage: 473.03125 MiB
100: --> Memory usage: 919.28125 MiB
100: --> Memory usage: 1378.28125 MiB
100: --> Memory usage: 1850.03125 MiB
100: --> Memory usage: 2334.53125 MiB
```
while the expected behaviour would be that the `nda::vector` memory would be deallocated after each call to the c++ function, please see below for the full test output.

Could you please help me understand this behaviour?

Best regards, Hugo



```
% ctest -V -R memory_leak                     
UpdateCTestConfiguration  from :/Users//dev/nda/cbuild/DartConfiguration.tcl
UpdateCTestConfiguration  from :/Users//dev/nda/cbuild/DartConfiguration.tcl
Test project /Users//dev/nda/cbuild
Constructing a list of tests
Done constructing a list of tests
Updating test list for fixtures
Added 0 tests to meet fixture requirements
Checking test dependency graph...
Checking test dependency graph end
test 100
    Start 100: Py_memory_leak_test

100: Test command: /opt/local/bin/python "/Users//dev/nda/test/python//memory_leak_test.py"
100: Working Directory: /Users//dev/nda/cbuild/test/python/
100: Environment variables: 
100:  PYTHONPATH=...
100: Test timeout computed to be: 10000000
100: --> Memory usage: 473.03125 MiB
100: --> Memory usage: 919.28125 MiB
100: --> Memory usage: 1378.28125 MiB
100: --> Memory usage: 1850.03125 MiB
100: --> Memory usage: 2334.53125 MiB
100: Traceback (most recent call last):
100:   File "/Users//dev/nda/test/python//memory_leak_test.py", line 30, in <module>
100:     test_memory_leak()
100:   File "/Users//dev/nda/test/python//memory_leak_test.py", line 26, in test_memory_leak
100:     assert( mem[-1] < mem[0] + 100. )
100: AssertionError
1/1 Test #100: Py_memory_leak_test ..............***Failed    6.37 sec

0% tests passed, 1 tests failed out of 1

Total Test time (real) =   6.38 sec

The following tests FAILED:
	100 - Py_memory_leak_test (Failed)
Errors while running CTest
Output from these tests are in: /Users//dev/nda/cbuild/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
```