### PR TITLE
Minor changes to the MPI routines

### DIFF
--- a/c++/nda/map.hpp
+++ b/c++/nda/map.hpp
@@ -195,8 +195,8 @@ namespace nda {
      * @return Result of the functor applied to the scalar arguments.
      */
     template <Scalar T0, Scalar... Ts>
-    auto operator()(T0 a0, Ts... as) const {
-      return f(a0, as...);
+    auto operator()(T0 t0, Ts... ts) const {
+      return f(t0, ts...);
     }
   };
 

--- a/c++/nda/mpi/broadcast.hpp
+++ b/c++/nda/mpi/broadcast.hpp
@@ -45,17 +45,7 @@ namespace nda {
    * - the array/view is not contiguous with positive strides or
    * - one of the MPI calls fails.
    *
-   * @code{.cpp}
-   * // create an array on all processes
-   * nda::array<int, 2> A(3, 4);
-   *
-   * // ...
-   * // fill array on root process
-   * // ...
-   *
-   * // broadcast the array to all processes
-   * mpi::broadcast(A);
-   * @endcode
+   * See @ref ex6_p1 for an example.
    *
    * @tparam A nda::basic_array or nda::basic_array_view type.
    * @param a Array/view to be broadcasted from/into.

--- a/c++/nda/mpi/reduce.hpp
+++ b/c++/nda/mpi/reduce.hpp
@@ -42,40 +42,6 @@
 
 namespace nda::detail {
 
-  // Helper function that (all)reduces arrays/views.
-  template <typename A1, typename A2>
-    requires(is_regular_or_view_v<A1> && is_regular_or_view_v<A2>)
-  void mpi_reduce_impl(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) { // NOLINT
-    // check the shape of the input arrays/views
-    EXPECTS_WITH_MESSAGE(have_mpi_equal_shapes(a_in, comm), "Error in nda::detail::mpi_reduce_impl: Shapes of arrays/views must be equal")
-
-    // simply copy if there is no active MPI environment or if the communicator size is < 2
-    if (not mpi::has_env || comm.size() < 2) {
-      a_out = a_in;
-      return;
-    }
-
-    // reduce the arrays/views
-    using value_type = typename std::decay_t<A1>::value_type;
-    if constexpr (not mpi::has_mpi_type<value_type>) {
-      // arrays/views of non-MPI types are reduced element-wise
-      a_out = nda::map([&](auto const &x) { return mpi::reduce(x, comm, root, all, op); })(a_in);
-    } else {
-      // for MPI-types we have to perform some checks on the input and ouput arrays/views
-      check_layout_mpi_compatible(a_in, "detail::mpi_reduce_impl");
-      if ((comm.rank() == root) || all) {
-        check_layout_mpi_compatible(a_out, "detail::mpi_reduce_impl");
-        nda::resize_or_check_if_view(a_out, a_in.shape());
-        if (std::abs(a_out.data() - a_in.data()) < a_in.size()) NDA_RUNTIME_ERROR << "Error in nda::detail::mpi_reduce_impl: Overlapping arrays";
-      }
-
-      // reduce the data
-      auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
-      auto a_in_span  = std::span{a_in.data(), static_cast<std::size_t>(a_in.size())};
-      mpi::reduce_range(a_in_span, a_out_span, comm, root, all, op);
-    }
-  }
-
   // Helper function that (all)reduces arrays/views in-place.
   template <typename A>
     requires(is_regular_or_view_v<A>)
@@ -103,92 +69,46 @@ namespace nda::detail {
 
 } // namespace nda::detail
 
-/**
- * @ingroup av_mpi
- * @brief Specialization of the `mpi::lazy` class for nda::Array types and the `mpi::tag::reduce` tag.
- *
- * @details An object of this class is returned when reducing nda::Array objects across multiple MPI processes.
- *
- * It models an nda::ArrayInitializer, that means it can be used to initialize and assign to nda::basic_array and
- * nda::basic_array_view objects. The result will be the reduction of the input arrays/views with respect to the given
- * MPI operation.
- *
- * See nda::lazy_mpi_reduce for an example.
- *
- * @tparam A nda::Array type to be reduced.
- */
-template <nda::Array A>
-struct mpi::lazy<mpi::tag::reduce, A> {
-  /// Value type of the array/view.
-  using value_type = typename std::decay_t<A>::value_type;
-
-  /// Type of the array/view stored in the lazy object.
-  using stored_type = A;
-
-  /// Array/View to be reduced.
-  stored_type rhs;
-
-  /// MPI communicator.
-  mpi::communicator comm;
-
-  /// MPI root process.
-  const int root{0}; // NOLINT (const is fine here)
-
-  /// Should all processes receive the result.
-  const bool all{false}; // NOLINT (const is fine here)
-
-  /// MPI reduction operation.
-  const MPI_Op op{MPI_SUM}; // NOLINT (const is fine here)
-
-  /**
-   * @brief Compute the shape of the nda::ArrayInitializer object.
-   *
-   * @details The shape of the initializer objects depends on the MPI rank and whether it receives the data or not:
-   *
-   * - On receiving ranks, the shape is the same as the shape of the input array/view.
-   * - On non-receiving ranks, the shape has the rank of the input array/view with only zeros, i.e. it is empty.
-   *
-   * @return Shape of the nda::ArrayInitializer object.
-   */
-  [[nodiscard]] auto shape() const {
-    if ((comm.rank() == root) || all) return rhs.shape();
-    return std::array<long, std::remove_cvref_t<stored_type>::rank>{};
-  }
-
-  /**
-   * @brief Execute the lazy MPI operation and write the result to a target array/view.
-   *
-   * @details The data will be reduced directly into the memory handle of the target array/view. If the target
-   * array/view is the same as the input array/view, i.e. if their data pointers are the same, the reduction is
-   * performed in-place.
-   *
-   * Types which cannot be reduced directly, i.e. which do not have an MPI type, are reduced element-wise.
-   *
-   * For MPI compatible types, the function throws an exception, if
-   * - the input array/view is not contiguous with positive strides.
-   * - the target array/view is not contiguous with positive strides on receiving ranks.
-   * - the operation is performed in-place but the target and input array have different sizes.
-   * - the operation is performed out-of-place and the memory of the target and input array/view overlap.
-   *
-   * @tparam T nda::Array type of the target array/view.
-   * @param target Target array/view.
-   */
-  template <nda::Array T>
-  void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
-    if (target.data() == rhs.data()) {
-      nda::detail::mpi_reduce_in_place_impl(target, comm, root, all, op);
-    } else {
-      nda::detail::mpi_reduce_impl(rhs, target, comm, root, all, op);
-    }
-  }
-};
-
 namespace nda {
 
   /**
    * @addtogroup av_mpi
    * @{
    */
+
+  // Helper function that (all)reduces arrays/views.
+  template <typename A1, typename A2>
+    requires(is_regular_or_view_v<A1> && is_regular_or_view_v<A2>)
+  void mpi_reduce_capi(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) { // NOLINT
+    // check the shape of the input arrays/views
+    EXPECTS_WITH_MESSAGE(detail::have_mpi_equal_shapes(a_in, comm), "Error in nda::mpi_reduce_capi: Shapes of arrays/views must be equal")
+
+    // simply copy if there is no active MPI environment or if the communicator size is < 2
+    if (not mpi::has_env || comm.size() < 2) {
+      a_out = a_in;
+      return;
+    }
+
+    // reduce the arrays/views
+    using value_type = typename std::decay_t<A1>::value_type;
+    if constexpr (not mpi::has_mpi_type<value_type>) {
+      // arrays/views of non-MPI types are reduced element-wise
+      a_out = nda::map([&](auto const &x) { return mpi::reduce(x, comm, root, all, op); })(a_in);
+    } else {
+      // for MPI-types we have to perform some checks on the input and ouput arrays/views
+      detail::check_layout_mpi_compatible(a_in, "mpi_reduce_capi");
+      if ((comm.rank() == root) || all) {
+        detail::check_layout_mpi_compatible(a_out, "mpi_reduce_capi");
+        resize_or_check_if_view(a_out, a_in.shape());
+        if (std::abs(a_out.data() - a_in.data()) < a_in.size()) NDA_RUNTIME_ERROR << "Error in nda::mpi_reduce_capi: Overlapping arrays";
+      }
+
+      // reduce the data
+      auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
+      auto a_in_span  = std::span{a_in.data(), static_cast<std::size_t>(a_in.size())};
+      mpi::reduce_range(a_in_span, a_out_span, comm, root, all, op);
+    }
+  }
 
   /**
    * @brief Implementation of a lazy MPI reduce for nda::basic_array or nda::basic_array_view types.
@@ -315,10 +235,90 @@ namespace nda {
   auto mpi_reduce(A const &a, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
     using return_t = get_regular_t<A>;
     return_t a_out;
-    detail::mpi_reduce_impl(a, a_out, comm, root, all, op);
+    mpi_reduce_capi(a, a_out, comm, root, all, op);
     return a_out;
   }
 
   /** @} */
 
 } // namespace nda
+
+/**
+ * @ingroup av_mpi
+ * @brief Specialization of the `mpi::lazy` class for nda::Array types and the `mpi::tag::reduce` tag.
+ *
+ * @details An object of this class is returned when reducing nda::Array objects across multiple MPI processes.
+ *
+ * It models an nda::ArrayInitializer, that means it can be used to initialize and assign to nda::basic_array and
+ * nda::basic_array_view objects. The result will be the reduction of the input arrays/views with respect to the given
+ * MPI operation.
+ *
+ * See nda::lazy_mpi_reduce for an example.
+ *
+ * @tparam A nda::Array type to be reduced.
+ */
+template <nda::Array A>
+struct mpi::lazy<mpi::tag::reduce, A> {
+  /// Value type of the array/view.
+  using value_type = typename std::decay_t<A>::value_type;
+
+  /// Type of the array/view stored in the lazy object.
+  using stored_type = A;
+
+  /// Array/View to be reduced.
+  stored_type rhs;
+
+  /// MPI communicator.
+  mpi::communicator comm;
+
+  /// MPI root process.
+  const int root{0}; // NOLINT (const is fine here)
+
+  /// Should all processes receive the result.
+  const bool all{false}; // NOLINT (const is fine here)
+
+  /// MPI reduction operation.
+  const MPI_Op op{MPI_SUM}; // NOLINT (const is fine here)
+
+  /**
+   * @brief Compute the shape of the nda::ArrayInitializer object.
+   *
+   * @details The shape of the initializer objects depends on the MPI rank and whether it receives the data or not:
+   *
+   * - On receiving ranks, the shape is the same as the shape of the input array/view.
+   * - On non-receiving ranks, the shape has the rank of the input array/view with only zeros, i.e. it is empty.
+   *
+   * @return Shape of the nda::ArrayInitializer object.
+   */
+  [[nodiscard]] auto shape() const {
+    if ((comm.rank() == root) || all) return rhs.shape();
+    return std::array<long, std::remove_cvref_t<stored_type>::rank>{};
+  }
+
+  /**
+   * @brief Execute the lazy MPI operation and write the result to a target array/view.
+   *
+   * @details The data will be reduced directly into the memory handle of the target array/view. If the target
+   * array/view is the same as the input array/view, i.e. if their data pointers are the same, the reduction is
+   * performed in-place.
+   *
+   * Types which cannot be reduced directly, i.e. which do not have an MPI type, are reduced element-wise.
+   *
+   * For MPI compatible types, the function throws an exception, if
+   * - the input array/view is not contiguous with positive strides.
+   * - the target array/view is not contiguous with positive strides on receiving ranks.
+   * - the operation is performed in-place but the target and input array have different sizes.
+   * - the operation is performed out-of-place and the memory of the target and input array/view overlap.
+   *
+   * @tparam T nda::Array type of the target array/view.
+   * @param target Target array/view.
+   */
+  template <nda::Array T>
+  void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
+    if (target.data() == rhs.data()) {
+      nda::detail::mpi_reduce_in_place_impl(target, comm, root, all, op);
+    } else {
+      nda::mpi_reduce_capi(rhs, target, comm, root, all, op);
+    }
+  }
+};

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -1255,46 +1255,6 @@ USE_HTAGS              = NO
 
 VERBATIM_HEADERS       = YES
 
-# If the CLANG_ASSISTED_PARSING tag is set to YES then doxygen will use the
-# clang parser (see:
-# http://clang.llvm.org/) for more accurate parsing at the cost of reduced
-# performance. This can be particularly helpful with template rich C++ code for
-# which doxygen's built-in parser lacks the necessary type information.
-# Note: The availability of this option depends on whether or not doxygen was
-# generated with the -Duse_libclang=ON option for CMake.
-# The default value is: NO.
-
-CLANG_ASSISTED_PARSING = YES
-
-# If the CLANG_ASSISTED_PARSING tag is set to YES and the CLANG_ADD_INC_PATHS
-# tag is set to YES then doxygen will add the directory of each input to the
-# include path.
-# The default value is: YES.
-# This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
-
-CLANG_ADD_INC_PATHS    = YES
-
-# If clang assisted parsing is enabled you can provide the compiler with command
-# line options that you would normally use when invoking the compiler. Note that
-# the include paths will already be set by doxygen for the files and directories
-# specified with INPUT and INCLUDE_PATH.
-# This tag requires that the tag CLANG_ASSISTED_PARSING is set to YES.
-
-CLANG_OPTIONS          =
-
-# If clang assisted parsing is enabled you can provide the clang parser with the
-# path to the directory containing a file called compile_commands.json. This
-# file is the compilation database (see:
-# http://clang.llvm.org/docs/HowToSetupToolingForLLVM.html) containing the
-# options used when the source files were built. This is equivalent to
-# specifying the -p option to a clang tool, such as clang-check. These options
-# will then be passed to the parser. Any options specified with CLANG_OPTIONS
-# will be added as well.
-# Note: The availability of this option depends on whether or not doxygen was
-# generated with the -Duse_libclang=ON option for CMake.
-
-CLANG_DATABASE_PATH    = @CMAKE_CURRENT_BINARY_DIR@/..
-
 #---------------------------------------------------------------------------
 # Configuration options related to the alphabetical class index
 #---------------------------------------------------------------------------


### PR DESCRIPTION
- Move C-style MPI functions out of the `detail` namespace
- Update the docs of the MPI functions
- Some general doc fixes