### PR TITLE
Generalize and fix LAPACK routines and add a solve function for linear systems

### DIFF
--- a/c++/nda/blas/tools.hpp
+++ b/c++/nda/blas/tools.hpp
@@ -99,27 +99,45 @@ namespace nda::blas {
   }();
 
   /**
-   * @brief Get the leading dimension in LAPACK jargon of an nda::MemoryMatrix.
+   * @brief Get the leading dimension of an nda::MemoryArray with rank 1 or 2 for LAPACK calls.
    *
-   * @tparam A nda::MemoryMatrix type.
-   * @param a nda::MemoryMatrix object.
-   * @return Leading dimension.
+   * @details The leading dimension is the stride between two consecutive columns (rows) of a matrix in Fortran (C)
+   * layout. For 1-dimensional arrays, we simply return the size of the array.
+   *
+   * @tparam A nda::MemoryArray type.
+   * @param a nda::MemoryArray object.
+   * @return Leading dimension for BLAS/LAPACK calls.
    */
-  template <MemoryMatrix A>
+  template <MemoryArray A>
+    requires(get_rank<A> == 1 or get_rank<A> == 2)
   int get_ld(A const &a) {
-    return a.indexmap().strides()[has_F_layout<A> ? 1 : 0];
+    if constexpr (get_rank<A> == 1) {
+      return a.size();
+    } else {
+      return a.indexmap().strides()[has_F_layout<A> ? 1 : 0];
+    }
   }
 
   /**
-   * @brief Get the number of columns in LAPACK jargon of an nda::MemoryMatrix.
+   * @brief Get the number of columns of an nda::MemoryArray for BLAS/LAPACK calls.
    *
-   * @tparam A nda::MemoryMatrix type.
-   * @param a nda::MemoryMatrix object.
-   * @return Number of columns.
+   * @details The number of columns corresponds to the extent of the second (first) dimension of a matrix in Fortran
+   * (C) layout. For 1-dimensional arrays, we return 1.
+   *
+   * @note This is not necessarily the same as the number of columns in the mathematical sense.
+   *
+   * @tparam A nda::MemoryArray type.
+   * @param a nda::MemoryArray object.
+   * @return Number of columns for BLAS/LAPACK calls.
    */
-  template <MemoryMatrix A>
+  template <MemoryArray A>
+    requires(get_rank<A> == 1 or get_rank<A> == 2)
   int get_ncols(A const &a) {
-    return a.shape()[has_F_layout<A> ? 1 : 0];
+    if constexpr (get_rank<A> == 1) {
+      return 1;
+    } else {
+      return a.shape()[has_F_layout<A> ? 1 : 0];
+    }
   }
 
   /** @} */

--- a/c++/nda/lapack/gesvd.hpp
+++ b/c++/nda/lapack/gesvd.hpp
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "./interface/cxx_interface.hpp"
+#include "../basic_functions.hpp"
 #include "../concepts.hpp"
 #include "../declarations.hpp"
 #include "../exceptions.hpp"
@@ -71,14 +72,19 @@ namespace nda::lapack {
    * @return Integer return code from the LAPACK call.
    */
   template <MemoryMatrix A, MemoryVector S, MemoryMatrix U, MemoryMatrix VT>
-    requires(have_same_value_type_v<A, U, VT> and mem::have_compatible_addr_space<A, S, U, VT> and is_blas_lapack_v<get_value_t<A>>)
+    requires(have_same_value_type_v<A, U, VT> and mem::have_compatible_addr_space<A, S, U, VT> and is_blas_lapack_v<get_value_t<A>>
+             and std::same_as<double, std::remove_cvref_t<get_value_t<S>>>)
   int gesvd(A &&a, S &&s, U &&u, VT &&vt) { // NOLINT (temporary views are allowed here)
-    static_assert(has_F_layout<A> and has_F_layout<U> and has_F_layout<VT>, "Error in nda::lapack::gesvd: C order not supported");
+    static_assert(has_C_layout<A> == has_C_layout<U> and has_C_layout<A> == has_C_layout<VT>,
+                  "Error in nda::lapack::gesvd: Matrix layouts have to be the same");
 
+    // check the dimensions of the input arrays/views and resize if necessary
     auto dm = std::min(a.extent(0), a.extent(1));
-    if (s.size() < dm) s.resize(dm);
+    if (s.size() < dm) resize_or_check_if_view(s, {dm});
+    if (u.extent(0) < a.extent(0) || u.extent(1) < a.extent(0)) resize_or_check_if_view(u, {a.extent(0), a.extent(0)});
+    if (vt.extent(0) < a.extent(1) || vt.extent(1) < a.extent(1)) resize_or_check_if_view(vt, {a.extent(1), a.extent(1)});
 
-    // must be lapack compatible
+    // input arrays/views must be lapack compatible
     EXPECTS(a.indexmap().min_stride() == 1);
     EXPECTS(s.indexmap().min_stride() == 1);
     EXPECTS(u.indexmap().min_stride() == 1);
@@ -102,16 +108,25 @@ namespace nda::lapack {
     value_type bufferSize_T{};
     auto rwork = array<double, 1, C_layout, heap<mem::get_addr_space<A>>>(5 * dm);
     int info   = 0;
-    gesvd_call('A', 'A', a.extent(0), a.extent(1), a.data(), get_ld(a), s.data(), u.data(), get_ld(u), vt.data(), get_ld(vt), &bufferSize_T, -1,
-               rwork.data(), info);
+    if constexpr (has_C_layout<A>) {
+      gesvd_call('A', 'A', a.extent(1), a.extent(0), a.data(), get_ld(a), s.data(), vt.data(), get_ld(vt), u.data(), get_ld(u), &bufferSize_T, -1,
+                 rwork.data(), info);
+    } else {
+      gesvd_call('A', 'A', a.extent(0), a.extent(1), a.data(), get_ld(a), s.data(), u.data(), get_ld(u), vt.data(), get_ld(vt), &bufferSize_T, -1,
+                 rwork.data(), info);
+    }
     int bufferSize = static_cast<int>(std::ceil(std::real(bufferSize_T)));
 
     // allocate work buffer and perform actual library call
     nda::array<value_type, 1, C_layout, heap<mem::get_addr_space<A>>> work(bufferSize);
-    gesvd_call('A', 'A', a.extent(0), a.extent(1), a.data(), get_ld(a), s.data(), u.data(), get_ld(u), vt.data(), get_ld(vt), work.data(), bufferSize,
-               rwork.data(), info);
+    if constexpr (has_C_layout<A>) {
+      gesvd_call('A', 'A', a.extent(1), a.extent(0), a.data(), get_ld(a), s.data(), vt.data(), get_ld(vt), u.data(), get_ld(u), work.data(),
+                 bufferSize, rwork.data(), info);
+    } else {
+      gesvd_call('A', 'A', a.extent(0), a.extent(1), a.data(), get_ld(a), s.data(), u.data(), get_ld(u), vt.data(), get_ld(vt), work.data(),
+                 bufferSize, rwork.data(), info);
+    }
 
-    if (info) NDA_RUNTIME_ERROR << "Error in nda::lapack::gesvd: info = " << info;
     return info;
   }
 

--- a/c++/nda/lapack/gesvd.hpp
+++ b/c++/nda/lapack/gesvd.hpp
@@ -39,6 +39,7 @@
 #include <algorithm>
 #include <cmath>
 #include <complex>
+#include <concepts>
 #include <utility>
 
 namespace nda::lapack {
@@ -84,7 +85,7 @@ namespace nda::lapack {
     resize_or_check_if_view(u, {a.extent(0), a.extent(0)});
     resize_or_check_if_view(vt, {a.extent(1), a.extent(1)});
 
-    // input arrays/views must be lapack compatible
+    // arrays/views must be LAPACK compatible
     EXPECTS(a.indexmap().min_stride() == 1);
     EXPECTS(s.indexmap().min_stride() == 1);
     EXPECTS(u.indexmap().min_stride() == 1);
@@ -118,7 +119,7 @@ namespace nda::lapack {
     int bufferSize = static_cast<int>(std::ceil(std::real(bufferSize_T)));
 
     // allocate work buffer and perform actual library call
-    nda::array<value_type, 1, C_layout, heap<mem::get_addr_space<A>>> work(bufferSize);
+    array<value_type, 1, C_layout, heap<mem::get_addr_space<A>>> work(bufferSize);
     if constexpr (has_C_layout<A>) {
       gesvd_call('A', 'A', a.extent(1), a.extent(0), a.data(), get_ld(a), s.data(), vt.data(), get_ld(vt), u.data(), get_ld(u), work.data(),
                  bufferSize, rwork.data(), info);

--- a/c++/nda/lapack/gesvd.hpp
+++ b/c++/nda/lapack/gesvd.hpp
@@ -73,16 +73,16 @@ namespace nda::lapack {
    */
   template <MemoryMatrix A, MemoryVector S, MemoryMatrix U, MemoryMatrix VT>
     requires(have_same_value_type_v<A, U, VT> and mem::have_compatible_addr_space<A, S, U, VT> and is_blas_lapack_v<get_value_t<A>>
-             and std::same_as<double, std::remove_cvref_t<get_value_t<S>>>)
+             and std::same_as<double, get_value_t<S>>)
   int gesvd(A &&a, S &&s, U &&u, VT &&vt) { // NOLINT (temporary views are allowed here)
     static_assert(has_C_layout<A> == has_C_layout<U> and has_C_layout<A> == has_C_layout<VT>,
                   "Error in nda::lapack::gesvd: Matrix layouts have to be the same");
 
-    // check the dimensions of the input arrays/views and resize if necessary
+    // check the dimensions of the output arrays/views and resize if necessary
     auto dm = std::min(a.extent(0), a.extent(1));
-    if (s.size() < dm) resize_or_check_if_view(s, {dm});
-    if (u.extent(0) < a.extent(0) || u.extent(1) < a.extent(0)) resize_or_check_if_view(u, {a.extent(0), a.extent(0)});
-    if (vt.extent(0) < a.extent(1) || vt.extent(1) < a.extent(1)) resize_or_check_if_view(vt, {a.extent(1), a.extent(1)});
+    resize_or_check_if_view(s, {dm});
+    resize_or_check_if_view(u, {a.extent(0), a.extent(0)});
+    resize_or_check_if_view(vt, {a.extent(1), a.extent(1)});
 
     // input arrays/views must be lapack compatible
     EXPECTS(a.indexmap().min_stride() == 1);

--- a/c++/nda/lapack/getrf.hpp
+++ b/c++/nda/lapack/getrf.hpp
@@ -27,6 +27,10 @@
 #include "../mem/address_space.hpp"
 #include "../traits.hpp"
 
+#ifndef NDA_HAVE_DEVICE
+#include "../device.hpp"
+#endif // NDA_HAVE_DEVICE
+
 #include <algorithm>
 #include <type_traits>
 
@@ -62,10 +66,14 @@ namespace nda::lapack {
   int getrf(A &&a, IPIV &&ipiv) { // NOLINT (temporary views are allowed here)
     static_assert(std::is_same_v<get_value_t<IPIV>, int>, "Error in nda::lapack::getri: Pivoting array must have elements of type int");
 
-    auto dm = std::min(a.extent(0), a.extent(1));
-    if (ipiv.size() < dm) ipiv.resize(dm); // ipiv needs to be a regular array?
+    // for C-layout arrays, call getrf with the transpose
+    if constexpr (has_C_layout<A>) return getrf(transpose(a), ipiv);
 
-    // must be lapack compatible
+    // check the dimensions of the input/output arrays/views and resize if necessary
+    auto dm = std::min(a.extent(0), a.extent(1));
+    if (ipiv.size() < dm) ipiv.resize(dm);
+
+    // arrays/views must be LAPACK compatible
     EXPECTS(a.indexmap().min_stride() == 1);
     EXPECTS(ipiv.indexmap().min_stride() == 1);
 
@@ -75,6 +83,7 @@ namespace nda::lapack {
 #endif
 #endif
 
+    // perform actual library call
     int info = 0;
     if constexpr (mem::have_device_compatible_addr_space<A, IPIV>) {
 #if defined(NDA_HAVE_DEVICE)

--- a/c++/nda/lapack/getri.hpp
+++ b/c++/nda/lapack/getri.hpp
@@ -29,6 +29,10 @@
 #include "../mem/address_space.hpp"
 #include "../traits.hpp"
 
+#ifndef NDA_HAVE_DEVICE
+#include "../device.hpp"
+#endif // NDA_HAVE_DEVICE
+
 #include <algorithm>
 #include <cmath>
 #include <complex>
@@ -58,15 +62,16 @@ namespace nda::lapack {
     requires(mem::have_compatible_addr_space<A, IPIV> and is_blas_lapack_v<get_value_t<A>>)
   int getri(A &&a, IPIV const &ipiv) { // NOLINT (temporary views are allowed here)
     static_assert(std::is_same_v<get_value_t<IPIV>, int>, "Error in nda::lapack::getri: Pivoting array must have elements of type int");
-    auto dm = std::min(a.extent(0), a.extent(1));
 
-    if (ipiv.size() < dm)
-      NDA_RUNTIME_ERROR << "Error in nda::lapack::getri: Pivot index array size " << ipiv.size() << " smaller than required size " << dm;
+    // check the dimensions of the input/output arrays/views and resize if necessary
+    EXPECTS(a.extent(0) == a.extent(1));
+    EXPECTS(ipiv.size() >= a.extent(0));
 
-    // must be lapack compatible
+    // arrays/views must be LAPACK compatible
     EXPECTS(a.indexmap().min_stride() == 1);
     EXPECTS(ipiv.indexmap().min_stride() == 1);
 
+    // perform the LAPACK calls
     int info = 0;
     if constexpr (mem::have_device_compatible_addr_space<A, IPIV>) {
 #if defined(NDA_HAVE_DEVICE)

--- a/c++/nda/lapack/getrs.hpp
+++ b/c++/nda/lapack/getrs.hpp
@@ -49,10 +49,6 @@ namespace nda::lapack {
    *
    * with a general n-by-n matrix \f$ \mathbf{A} \f$ using the LU factorization computed by `getrf`.
    *
-   * @note If the right hand side is a C-layout matrix \f$ \mathbf{B} \f$, it will create a temporary copy with Fortran
-   * layout before the LAPACK call, which is then copied back into the original matrix. This might be inefficient for
-   * large matrices and it is recommended to use Fortran layout.
-   *
    * @tparam A nda::MemoryMatrix type.
    * @tparam B nda::MemoryArray type.
    * @tparam IPIV nda::MemoryVector type.
@@ -69,18 +65,20 @@ namespace nda::lapack {
   int getrs(A const &a, B &&b, IPIV const &ipiv) { // NOLINT (temporary views are allowed here)
     static_assert(std::is_same_v<get_value_t<IPIV>, int>, "Error in nda::lapack::getrs: Pivoting array must have elements of type int");
     static_assert(get_rank<B> == 1 || get_rank<B> == 2, "Error in nda::lapack::getrs: Right hand side must have rank 1 or 2");
-    static_assert(not mem::have_device_compatible_addr_space<B> or blas::has_F_layout<B> or get_rank<B> == 1,
-                  "Error in nda::lapack::getrs: B must have Fortran layout when used on the device");
+    static_assert(has_F_layout<B> or get_rank<B> == 1, "Error in nda::lapack::getrs: B must have Fortran layout or rank 1");
+
+    // check the dimensions of the input/output arrays/views and resize if necessary
+    EXPECTS(a.extent(0) == a.extent(1));
+    EXPECTS(b.extent(0) == a.extent(0));
     EXPECTS(ipiv.size() >= std::min(a.extent(0), a.extent(1)));
 
-    // must be lapack compatible
+    // arrays/views must be LAPACK compatible
     EXPECTS(a.indexmap().min_stride() == 1);
     EXPECTS(b.indexmap().min_stride() == 1);
     EXPECTS(ipiv.indexmap().min_stride() == 1);
 
-    // check for lazy expressions
-    static constexpr bool conj_A = is_conj_array_expr<A>;
-    char op_a                    = get_op<conj_A, /* transpose = */ has_C_layout<A>>;
+    // check for lazy expressions and C-layout
+    char op_a = get_op<is_conj_array_expr<A>, has_C_layout<A>>;
 
     // perform actual library call
     int info = 0;
@@ -91,15 +89,7 @@ namespace nda::lapack {
       compile_error_no_gpu();
 #endif
     } else {
-      if constexpr (has_F_layout<B> or get_rank<B> == 1) {
-        // B is a matrix with Fortran layout
-        f77::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
-      } else {
-        // B is a matrix with C layout
-        matrix<get_value_t<B>, F_layout> b_f{b};
-        f77::getrs(op_a, get_ncols(a), get_ncols(b_f), a.data(), get_ld(a), ipiv.data(), b_f.data(), get_ld(b_f), info);
-        b = b_f;
-      }
+      f77::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
     }
     return info;
   }

--- a/c++/nda/lapack/getrs.hpp
+++ b/c++/nda/lapack/getrs.hpp
@@ -49,12 +49,12 @@ namespace nda::lapack {
    *
    * with a general n-by-n matrix \f$ \mathbf{A} \f$ using the LU factorization computed by `getrf`.
    *
-   * @note If the matrix \f$ \mathbf{B} \f$ is in C-layout, it will create a temporary copy of it with Fortran layout
-   * before calling the LAPACK routine. After the call, the result will be copied back to the original array. This might
-   * be inefficient for large matrices and it is recommended to use Fortran layout for input matrices.
+   * @note If the right hand side is a C-layout matrix \f$ \mathbf{B} \f$, it will create a temporary copy with Fortran
+   * layout before the LAPACK call, which is then copied back into the original matrix. This might be inefficient for
+   * large matrices and it is recommended to use Fortran layout.
    *
    * @tparam A nda::MemoryMatrix type.
-   * @tparam B nda::MemoryMatrix type.
+   * @tparam B nda::MemoryArray type.
    * @tparam IPIV nda::MemoryVector type.
    * @param a Input matrix. The factors \f$ \mathbf{L} \f$ and \f$ \mathbf{U} \f$ from the factorization \f$ \mathbf{A}
    * = \mathbf{P L U} \f$ as computed by `getrf`.
@@ -64,10 +64,13 @@ namespace nda::lapack {
    * interchanged with row `ipiv(i)`.
    * @return Integer return code from the LAPACK call.
    */
-  template <MemoryMatrix A, MemoryMatrix B, MemoryVector IPIV>
+  template <MemoryMatrix A, MemoryArray B, MemoryVector IPIV>
     requires(have_same_value_type_v<A, B> and mem::have_compatible_addr_space<A, B, IPIV> and is_blas_lapack_v<get_value_t<A>>)
   int getrs(A const &a, B &&b, IPIV const &ipiv) { // NOLINT (temporary views are allowed here)
     static_assert(std::is_same_v<get_value_t<IPIV>, int>, "Error in nda::lapack::getrs: Pivoting array must have elements of type int");
+    static_assert(get_rank<B> == 1 || get_rank<B> == 2, "Error in nda::lapack::getrs: Right hand side must have rank 1 or 2");
+    static_assert(not mem::have_device_compatible_addr_space<B> or blas::has_F_layout<B> or get_rank<B> == 1,
+                  "Error in nda::lapack::getrs: B must have Fortran layout when used on the device");
     EXPECTS(ipiv.size() >= std::min(a.extent(0), a.extent(1)));
 
     // must be lapack compatible
@@ -82,15 +85,13 @@ namespace nda::lapack {
     // perform actual library call
     int info = 0;
     if constexpr (mem::have_device_compatible_addr_space<A, B, IPIV>) {
-      // only allow Fortran layout to avoid additional copies on the device
-      static_assert(has_F_layout<B>, "Error in nda::lapack::getrs: B must have Fortran layout when used on the device");
 #if defined(NDA_HAVE_DEVICE)
       device::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
 #else
       compile_error_no_gpu();
 #endif
     } else {
-      if constexpr (has_F_layout<B>) {
+      if constexpr (has_F_layout<B> or get_rank<B> == 1) {
         // B is a matrix with Fortran layout
         f77::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
       } else {

--- a/c++/nda/lapack/getrs.hpp
+++ b/c++/nda/lapack/getrs.hpp
@@ -23,6 +23,7 @@
 
 #include "./interface/cxx_interface.hpp"
 #include "../concepts.hpp"
+#include "../declarations.hpp"
 #include "../macros.hpp"
 #include "../mem/address_space.hpp"
 #include "../traits.hpp"
@@ -47,6 +48,10 @@ namespace nda::lapack {
    * - \f$ \mathbf{A}^H \mathbf{X} = \mathbf{B} \f$
    *
    * with a general n-by-n matrix \f$ \mathbf{A} \f$ using the LU factorization computed by `getrf`.
+   *
+   * @note If the matrix \f$ \mathbf{B} \f$ is in C-layout, it will create a temporary copy of it with Fortran layout
+   * before calling the LAPACK routine. After the call, the result will be copied back to the original array. This might
+   * be inefficient for large matrices and it is recommended to use Fortran layout for input matrices.
    *
    * @tparam A nda::MemoryMatrix type.
    * @tparam B nda::MemoryMatrix type.
@@ -77,13 +82,23 @@ namespace nda::lapack {
     // perform actual library call
     int info = 0;
     if constexpr (mem::have_device_compatible_addr_space<A, B, IPIV>) {
+      // only allow Fortran layout to avoid additional copies on the device
+      static_assert(has_F_layout<B>, "Error in nda::lapack::getrs: B must have Fortran layout when used on the device");
 #if defined(NDA_HAVE_DEVICE)
       device::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
 #else
       compile_error_no_gpu();
 #endif
     } else {
-      f77::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
+      if constexpr (has_F_layout<B>) {
+        // B is a matrix with Fortran layout
+        f77::getrs(op_a, get_ncols(a), get_ncols(b), a.data(), get_ld(a), ipiv.data(), b.data(), get_ld(b), info);
+      } else {
+        // B is a matrix with C layout
+        matrix<get_value_t<B>, F_layout> b_f{b};
+        f77::getrs(op_a, get_ncols(a), get_ncols(b_f), a.data(), get_ld(a), ipiv.data(), b_f.data(), get_ld(b_f), info);
+        b = b_f;
+      }
     }
     return info;
   }

--- a/c++/nda/lapack/gtsv.hpp
+++ b/c++/nda/lapack/gtsv.hpp
@@ -23,6 +23,7 @@
 
 #include "./interface/cxx_interface.hpp"
 #include "../concepts.hpp"
+#include "../declarations.hpp"
 #include "../macros.hpp"
 #include "../mem/address_space.hpp"
 #include "../traits.hpp"
@@ -41,6 +42,10 @@ namespace nda::lapack {
    *
    * Note that the equation \f$ \mathbf{A}^T \mathbf{X} = \mathbf{B} \f$ may be solved by interchanging the order of the
    * arguments containing the subdiagonal elements.
+   *
+   * @note If the array \f$ \mathbf{B} \f$ is a matrix in C-layout, it will create a temporary copy of it with Fortran
+   * layout before calling the LAPACK routine. After the call, the result will be copied back to the original array.
+   * This might be inefficient for large arrays and it is recommended to use Fortran layout for input arrays.
    *
    * @tparam DL nda::MemoryVector type.
    * @tparam D nda::MemoryVector type.
@@ -62,16 +67,26 @@ namespace nda::lapack {
   int gtsv(DL &&dl, D &&d, DU &&du, B &&b) { // NOLINT (temporary views are allowed here)
     static_assert((get_rank<B> == 1 or get_rank<B> == 2), "Error in nda::lapack::gtsv: B must be an matrix/array/view of rank 1 or 2");
 
-    // get and check dimensions of input arrays
-    EXPECTS(dl.extent(0) == d.extent(0) - 1); // "gtsv : dimension mismatch between sub-diagonal and diagonal vectors "
-    EXPECTS(du.extent(0) == d.extent(0) - 1); // "gtsv : dimension mismatch between super-diagonal and diagonal vectors "
-    EXPECTS(b.extent(0) == d.extent(0));      // "gtsv : dimension mismatch between diagonal vector and RHS matrix, "
+    // check dimensions of input arrays
+    EXPECTS(dl.extent(0) == d.extent(0) - 1);
+    EXPECTS(du.extent(0) == d.extent(0) - 1);
+    EXPECTS(b.extent(0) == d.extent(0));
 
-    // perform actual library call
-    int N    = d.extent(0);
-    int NRHS = (get_rank<B> == 2 ? b.extent(1) : 1);
+    // perform actual library call depending on the array B
     int info = 0;
-    f77::gtsv(N, NRHS, dl.data(), d.data(), du.data(), b.data(), N, info);
+    if constexpr (get_rank<B> == 1) {
+      // B is a vector
+      f77::gtsv(d.extent(0), 1, dl.data(), d.data(), du.data(), b.data(), d.extent(0), info);
+    } else if constexpr (has_F_layout<B>) {
+      // B is a matrix with Fortran layout
+      f77::gtsv(d.extent(0), b.extent(1), dl.data(), d.data(), du.data(), b.data(), get_ld(b), info);
+    } else {
+      // B is a matrix with C layout
+      matrix<get_value_t<B>, F_layout> b_f{b};
+      f77::gtsv(d.extent(0), b.extent(1), dl.data(), d.data(), du.data(), b_f.data(), get_ld(b_f), info);
+      b = b_f;
+    }
+
     return info;
   }
 

--- a/c++/nda/lapack/gtsv.hpp
+++ b/c++/nda/lapack/gtsv.hpp
@@ -66,27 +66,16 @@ namespace nda::lapack {
     requires(have_same_value_type_v<DL, D, DU, B> and mem::on_host<DL, D, DU, B> and is_blas_lapack_v<get_value_t<DL>>)
   int gtsv(DL &&dl, D &&d, DU &&du, B &&b) { // NOLINT (temporary views are allowed here)
     static_assert((get_rank<B> == 1 or get_rank<B> == 2), "Error in nda::lapack::gtsv: B must be an matrix/array/view of rank 1 or 2");
+    static_assert(has_F_layout<B> or get_rank<B> == 1, "Error in nda::lapack::getrs: B must have Fortran layout or rank 1");
 
-    // check dimensions of input arrays
+    // check the dimensions of the input/output arrays/views
     EXPECTS(dl.extent(0) == d.extent(0) - 1);
     EXPECTS(du.extent(0) == d.extent(0) - 1);
     EXPECTS(b.extent(0) == d.extent(0));
 
-    // perform actual library call depending on the array B
+    // perform actual library call
     int info = 0;
-    if constexpr (get_rank<B> == 1) {
-      // B is a vector
-      f77::gtsv(d.extent(0), 1, dl.data(), d.data(), du.data(), b.data(), d.extent(0), info);
-    } else if constexpr (has_F_layout<B>) {
-      // B is a matrix with Fortran layout
-      f77::gtsv(d.extent(0), b.extent(1), dl.data(), d.data(), du.data(), b.data(), get_ld(b), info);
-    } else {
-      // B is a matrix with C layout
-      matrix<get_value_t<B>, F_layout> b_f{b};
-      f77::gtsv(d.extent(0), b.extent(1), dl.data(), d.data(), du.data(), b_f.data(), get_ld(b_f), info);
-      b = b_f;
-    }
-
+    f77::gtsv(d.extent(0), (get_rank<B> == 2 ? b.extent(1) : 1), dl.data(), d.data(), du.data(), b.data(), get_ld(b), info);
     return info;
   }
 

--- a/c++/nda/linalg.hpp
+++ b/c++/nda/linalg.hpp
@@ -31,3 +31,4 @@
 #include "./linalg/matmul.hpp"
 #include "./linalg/norm.hpp"
 #include "./linalg/solve.hpp"
+#include "./linalg/svd.hpp"

--- a/c++/nda/linalg.hpp
+++ b/c++/nda/linalg.hpp
@@ -30,3 +30,4 @@
 #include "./linalg/eigenelements.hpp"
 #include "./linalg/matmul.hpp"
 #include "./linalg/norm.hpp"
+#include "./linalg/solve.hpp"

--- a/c++/nda/linalg/matmul.hpp
+++ b/c++/nda/linalg/matmul.hpp
@@ -57,9 +57,9 @@ namespace nda {
     static constexpr bool is_valid_gemm_triple = []() {
       using blas::has_F_layout;
       if constexpr (has_F_layout<C>) {
-        return !(conj_A and has_F_layout<A>)and!(conj_B and has_F_layout<B>);
+        return !(conj_A and has_F_layout<A>) and !(conj_B and has_F_layout<B>);
       } else {
-        return !(conj_B and !has_F_layout<B>)and!(conj_A and !has_F_layout<A>);
+        return !(conj_B and !has_F_layout<B>) and !(conj_A and !has_F_layout<A>);
       }
     }();
 

--- a/c++/nda/linalg/solve.hpp
+++ b/c++/nda/linalg/solve.hpp
@@ -36,7 +36,7 @@
 
 #include <type_traits>
 
-namespace nda {
+namespace nda::linalg {
 
   /**
    * @addtogroup linalg_tools
@@ -107,4 +107,4 @@ namespace nda {
 
   /** @} */
 
-} // namespace nda
+} // namespace nda::linalg

--- a/c++/nda/linalg/solve.hpp
+++ b/c++/nda/linalg/solve.hpp
@@ -43,52 +43,31 @@ namespace nda {
    * @{
    */
 
-  /**
-   * @brief Solve a system of linear equations in place.
-   *
-   * @details The function solves a system of linear equations
-   *
-   * - \f$ \mathbf{A X} = \mathbf{B} \f$ or
-   * - \f$ \mathbf{A} \mathbf{x} = \mathbf{b} \f$,
-   *
-   * with a general n-by-n matrix \f$ \mathbf{A} \f$ and n-by-m  matrices \f$ \mathbf{X} \f$ and \f$ \mathbf{B} \f$ or
-   * vectors \f$ \mathbf{x} \f$ and \f$ \mathbf{b} \f$.
-   *
-   * It uses nda::lapack::getrf to compute the LU factorization of the matrix \f$ \mathbf{A} \f$ and then
-   * nda::lapack::getrs to solve the system of linear equations. An exception is thrown, if the LAPACK calls return a
-   * non-zero value.
-   *
-   * @note If the right hand side is a C-layout matrix \f$ \mathbf{B} \f$, it will create a temporary copy with Fortran
-   * layout inside the nda::lapack::getrs call, which is then copied back into the original matrix. This might be
-   * inefficient for large matrices and it is recommended to use Fortran layout.
-   *
-   * @tparam A nda::MemoryMatrix type.
-   * @tparam B nda::MemoryArray type of rank 1 or 2.
-   * @param a Input/output matrix. On entry, the left hand side matrix \f$ \mathbf{A} \f$. On exit, the result from the
-   * nda::lapack::getrf call.
-   * @param b Input/output matrix. On entry, the right hand side matrix \f$ \mathbf{B} \f$ (vector \f$ \mathbf{b} \f$).
-   * On exit, the solution matrix \f$ \mathbf{X} \f$ (vector \f$ \mathbf{x} \f$).
-   */
-  template <MemoryMatrix A, MemoryArray B>
-    requires(have_same_value_type_v<A, B> and mem::have_compatible_addr_space<A, B> and is_blas_lapack_v<get_value_t<A>>)
-  void solve_in_place(A &&a, B &&b) { // NOLINT (temporary views are allowed here)
-    constexpr auto addr_space = mem::common_addr_space<A, B>;
+  namespace detail {
 
-    // check dimensions
-    EXPECTS_WITH_MESSAGE(a.shape()[0] == a.shape()[1], "Error in nda::solve_in_place: Matrix A is not square");
-    EXPECTS_WITH_MESSAGE(a.shape()[0] == b.shape()[0], "Error in nda::solve_in_place: Dimension mismatch between matrix A and B");
+    // Function to solve a system of linear equations in place.
+    template <MemoryMatrix A, MemoryArray B>
+      requires(have_same_value_type_v<A, B> and mem::have_compatible_addr_space<A, B> and is_blas_lapack_v<get_value_t<A>>)
+    void solve_in_place(A &&a, B &&b) { // NOLINT (temporary views are allowed here)
+      constexpr auto addr_space = mem::common_addr_space<A, B>;
 
-    // pivot indices vector
-    auto ipiv = vector<int, heap<addr_space>>(a.shape()[0]);
+      // check dimensions
+      EXPECTS_WITH_MESSAGE(a.shape()[0] == a.shape()[1], "Error in nda::solve_in_place: Matrix A is not square");
+      EXPECTS_WITH_MESSAGE(a.shape()[0] == b.shape()[0], "Error in nda::solve_in_place: Dimension mismatch between matrix A and B");
 
-    // call lapack getrf
-    int info = lapack::getrf(a, ipiv);
-    if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::solve_in_place: getrf returned a non-zero value: info = " << info;
+      // pivot indices vector
+      auto ipiv = vector<int, heap<addr_space>>(a.shape()[0]);
 
-    // call lapack getrs
-    info = lapack::getrs(a, b, ipiv);
-    if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::solve_in_place: getrs returned a non-zero value: info = " << info;
-  }
+      // call lapack getrf
+      int info = lapack::getrf(a, ipiv);
+      if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::solve_in_place: getrf returned a non-zero value: info = " << info;
+
+      // call lapack getrs
+      info = lapack::getrs(a, b, ipiv);
+      if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::solve_in_place: getrs returned a non-zero value: info = " << info;
+    }
+
+  } // namespace detail
 
   /**
    * @brief Solve a system of linear equations.
@@ -101,8 +80,11 @@ namespace nda {
    * with a general n-by-n matrix \f$ \mathbf{A} \f$ and n-by-m  matrices \f$ \mathbf{X} \f$ and \f$ \mathbf{B} \f$ or
    * vectors \f$ \mathbf{x} \f$ and \f$ \mathbf{b} \f$.
    *
-   * It makes a copy of the input matrix \f$ \mathbf{A} \f$ and the input matrix/vector \f$ \mathbf{B} \f$/\f$
-   * \mathbf{b} \f$ and then calls nda::solve_in_place with the copies.
+   * It first makes a copy of the input matrix \f$ \mathbf{A} \f$ and the input matrix/vector \f$ \mathbf{B} \f$/\f$
+   * \mathbf{b} \f$ and then uses nda::lapack::getrf to compute the LU factorization of the matrix \f$ \mathbf{A} \f$
+   * which in turn is forwarded to nda::lapack::getrs to solve the system of linear equations.
+   *
+   * An exception is thrown, if the LAPACK calls return a non-zero value.
    *
    * @note If the right hand side is a matrix, the solution matrix \f$ \mathbf{X} \f$ is always returned in Fortran
    * layout.
@@ -119,7 +101,7 @@ namespace nda {
     using b_type = std::conditional_t<get_rank<B> == 1, vector<get_value_t<B>>, matrix<get_value_t<B>, F_layout>>;
     auto a_copy  = matrix<get_value_t<A>, F_layout>(a);
     auto b_copy  = b_type(b);
-    solve_in_place(a_copy, b_copy);
+    detail::solve_in_place(a_copy, b_copy);
     return b_copy;
   }
 

--- a/c++/nda/linalg/solve.hpp
+++ b/c++/nda/linalg/solve.hpp
@@ -1,0 +1,128 @@
+// Copyright (c) 2019-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Olivier Parcollet, Nils Wentzell
+
+/**
+ * @file
+ * @brief Provides solver functions for linear systems of equations.
+ */
+
+#pragma once
+
+#include "../basic_array.hpp"
+#include "../blas/tools.hpp"
+#include "../concepts.hpp"
+#include "../declarations.hpp"
+#include "../exceptions.hpp"
+#include "../lapack/getrf.hpp"
+#include "../lapack/getrs.hpp"
+#include "../layout/policies.hpp"
+#include "../macros.hpp"
+#include "../mem/address_space.hpp"
+#include "../mem/policies.hpp"
+#include "../traits.hpp"
+
+#include <type_traits>
+
+namespace nda {
+
+  /**
+   * @addtogroup linalg_tools
+   * @{
+   */
+
+  /**
+   * @brief Solve a system of linear equations in place.
+   *
+   * @details The function solves a system of linear equations
+   *
+   * - \f$ \mathbf{A X} = \mathbf{B} \f$ or
+   * - \f$ \mathbf{A} \mathbf{x} = \mathbf{b} \f$,
+   *
+   * with a general n-by-n matrix \f$ \mathbf{A} \f$ and n-by-m  matrices \f$ \mathbf{X} \f$ and \f$ \mathbf{B} \f$ or
+   * vectors \f$ \mathbf{x} \f$ and \f$ \mathbf{b} \f$.
+   *
+   * It uses nda::lapack::getrf to compute the LU factorization of the matrix \f$ \mathbf{A} \f$ and then
+   * nda::lapack::getrs to solve the system of linear equations. An exception is thrown, if the LAPACK calls return a
+   * non-zero value.
+   *
+   * @note If the right hand side is a C-layout matrix \f$ \mathbf{B} \f$, it will create a temporary copy with Fortran
+   * layout inside the nda::lapack::getrs call, which is then copied back into the original matrix. This might be
+   * inefficient for large matrices and it is recommended to use Fortran layout.
+   *
+   * @tparam A nda::MemoryMatrix type.
+   * @tparam B nda::MemoryArray type of rank 1 or 2.
+   * @param a Input/output matrix. On entry, the left hand side matrix \f$ \mathbf{A} \f$. On exit, the result from the
+   * nda::lapack::getrf call.
+   * @param b Input/output matrix. On entry, the right hand side matrix \f$ \mathbf{B} \f$ (vector \f$ \mathbf{b} \f$).
+   * On exit, the solution matrix \f$ \mathbf{X} \f$ (vector \f$ \mathbf{x} \f$).
+   */
+  template <MemoryMatrix A, MemoryArray B>
+    requires(have_same_value_type_v<A, B> and mem::have_compatible_addr_space<A, B> and is_blas_lapack_v<get_value_t<A>>)
+  void solve_in_place(A &&a, B &&b) { // NOLINT (temporary views are allowed here)
+    constexpr auto addr_space = mem::common_addr_space<A, B>;
+
+    // check dimensions
+    EXPECTS_WITH_MESSAGE(a.shape()[0] == a.shape()[1], "Error in nda::solve_in_place: Matrix A is not square");
+    EXPECTS_WITH_MESSAGE(a.shape()[1] == b.shape()[0], "Error in nda::solve_in_place: Dimension mismatch between matrix A and B");
+
+    // pivot indices vector
+    auto ipiv = vector<int, heap<addr_space>>(a.shape()[0]);
+
+    // call lapack getrf
+    int info = lapack::getrf(a, ipiv);
+    if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::solve_in_place: getrf returned a non-zero value: info = " << info;
+
+    // call lapack getrs
+    info = lapack::getrs(a, b, ipiv);
+    if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::solve_in_place: getrs returned a non-zero value: info = " << info;
+  }
+
+  /**
+   * @brief Solve a system of linear equations.
+   *
+   * @details The function solves a system of linear equations
+   *
+   * - \f$ \mathbf{A X} = \mathbf{B} \f$ or
+   * - \f$ \mathbf{A} \mathbf{x} = \mathbf{b} \f$,
+   *
+   * with a general n-by-n matrix \f$ \mathbf{A} \f$ and n-by-m  matrices \f$ \mathbf{X} \f$ and \f$ \mathbf{B} \f$ or
+   * vectors \f$ \mathbf{x} \f$ and \f$ \mathbf{b} \f$.
+   *
+   * It makes a copy of the input matrix \f$ \mathbf{A} \f$ and the input matrix/vector \f$ \mathbf{B} \f$/\f$
+   * \mathbf{b} \f$ and then calls nda::solve_in_place with the copies.
+   *
+   * @note If the right hand side is a matrix, the solution matrix \f$ \mathbf{X} \f$ is always returned in Fortran
+   * layout.
+   *
+   * @tparam A nda::Matrix type.
+   * @tparam B nda::Array type of rank 1 or 2.
+   * @param a Left hand side matrix \f$ \mathbf{A} \f$.
+   * @param b Right hand side matrix \f$ \mathbf{B} \f$ (vector \f$ \mathbf{b} \f$).
+   * @return Solution matrix \f$ \mathbf{X} \f$ (vector \f$ \mathbf{x} \f$).
+   */
+  template <Matrix A, Array B>
+    requires(have_same_value_type_v<A, B> and is_blas_lapack_v<get_value_t<A>>)
+  auto solve(A const &a, B const &b) { // NOLINT (temporary views are allowed here)
+    using b_type = std::conditional_t<get_rank<B> == 1, vector<get_value_t<B>>, matrix<get_value_t<B>, F_layout>>;
+    auto a_copy  = matrix<get_value_t<A>, F_layout>(a);
+    auto b_copy  = b_type(b);
+    solve_in_place(a_copy, b_copy);
+    return b_copy;
+  }
+
+  /** @} */
+
+} // namespace nda

--- a/c++/nda/linalg/solve.hpp
+++ b/c++/nda/linalg/solve.hpp
@@ -76,7 +76,7 @@ namespace nda {
 
     // check dimensions
     EXPECTS_WITH_MESSAGE(a.shape()[0] == a.shape()[1], "Error in nda::solve_in_place: Matrix A is not square");
-    EXPECTS_WITH_MESSAGE(a.shape()[1] == b.shape()[0], "Error in nda::solve_in_place: Dimension mismatch between matrix A and B");
+    EXPECTS_WITH_MESSAGE(a.shape()[0] == b.shape()[0], "Error in nda::solve_in_place: Dimension mismatch between matrix A and B");
 
     // pivot indices vector
     auto ipiv = vector<int, heap<addr_space>>(a.shape()[0]);

--- a/c++/nda/linalg/svd.hpp
+++ b/c++/nda/linalg/svd.hpp
@@ -36,7 +36,7 @@
 #include <tuple>
 #include <type_traits>
 
-namespace nda {
+namespace nda::linalg {
 
   /**
    * @addtogroup linalg_tools
@@ -49,7 +49,7 @@ namespace nda {
     template <MemoryMatrix A>
       requires(is_blas_lapack_v<get_value_t<A>>)
     auto svd_in_place(A &&a) { // NOLINT (temporary views are allowed here)
-      using layout_policy       = detail::layout_to_policy<typename std::remove_cvref_t<A>::layout_t>::type;
+      using layout_policy       = nda::detail::layout_to_policy<typename std::remove_cvref_t<A>::layout_t>::type;
       constexpr auto addr_space = mem::get_addr_space<A>;
 
       // vector s and matrices U and V^H
@@ -95,4 +95,4 @@ namespace nda {
 
   /** @} */
 
-} // namespace nda
+} // namespace nda::linalg

--- a/c++/nda/linalg/svd.hpp
+++ b/c++/nda/linalg/svd.hpp
@@ -43,44 +43,28 @@ namespace nda {
    * @{
    */
 
-  /**
-   * @brief Compute the singular value decomposition (SVD) of a matrix in place.
-   *
-   * @details The function computes the SVD of a given m-by-n matrix \f$ \mathbf{A} \f$:
-   * \f[
-   *   \mathbf{A} = \mathbf{U} \mathbf{S} \mathbf{V}^H \; ,
-   * \f]
-   * where \f$ \mathbf{U} \f$ is a unitary m-by-m matrix, \f$ \mathbf{V} \f$ is a unitary n-by-n matrix and \f$
-   * \mathbf{S} \f$ is an m-by-n matrix with non-negative real numbers on the diagonal.
-   *
-   * It first constructs the output vector \f$ \mathbf{s} \f$, which contains the singular values, and the output
-   * matrices \f$ \mathbf{U} \f$ and \f$ \mathbf{V}^H \f$. It then calls nda::lapack::gesvd to compute the SVD.
-   *
-   * @note If the input matrix \f$ \mathbf{A} \f$ is in Fortran layout, the output matrices \f$ \mathbf{U} \f$ and
-   * \f$ \mathbf{V}^H \f$ are also in Fortran layout. Otherwise, they are in C layout.
-   *
-   * @tparam A nda::MemoryMatrix type.
-   * @param a Input/output matrix. On entry, the m-by-n matrix \f$ \mathbf{A} \f$. On exit, the contents of \f$
-   * \mathbf{A} \f$ are destroyed.
-   * @return `std::tuple` containing \f$ \mathbf{U} \f$, \f$ \mathbf{s} \f$ and \f$ \mathbf{V}^H \f$.
-   */
-  template <MemoryMatrix A>
-    requires(is_blas_lapack_v<get_value_t<A>>)
-  auto svd_in_place(A &&a) { // NOLINT (temporary views are allowed here)
-    using layout_policy       = detail::layout_to_policy<typename std::remove_cvref_t<A>::layout_t>::type;
-    constexpr auto addr_space = mem::get_addr_space<A>;
+  namespace detail {
 
-    // vector s and matrices U and V^H
-    auto s  = vector<double, heap<addr_space>>(std::min(a.extent(0), a.extent(1)));
-    auto U  = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a.extent(0), a.extent(0));
-    auto VH = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a.extent(1), a.extent(1));
+    // Function to compute the singular value decomposition in place.
+    template <MemoryMatrix A>
+      requires(is_blas_lapack_v<get_value_t<A>>)
+    auto svd_in_place(A &&a) { // NOLINT (temporary views are allowed here)
+      using layout_policy       = detail::layout_to_policy<typename std::remove_cvref_t<A>::layout_t>::type;
+      constexpr auto addr_space = mem::get_addr_space<A>;
 
-    // call lapack gesvd
-    int info = lapack::gesvd(a, s, U, VH);
-    if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::svd_in_place: gesvd returned a non-zero value: info = " << info;
+      // vector s and matrices U and V^H
+      auto s  = vector<double, heap<addr_space>>(std::min(a.extent(0), a.extent(1)));
+      auto U  = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a.extent(0), a.extent(0));
+      auto VH = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a.extent(1), a.extent(1));
 
-    return std::make_tuple(U, s, VH);
-  }
+      // call lapack gesvd
+      int info = lapack::gesvd(a, s, U, VH);
+      if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::svd_in_place: gesvd returned a non-zero value: info = " << info;
+
+      return std::make_tuple(U, s, VH);
+    }
+
+  } // namespace detail
 
   /**
    * @brief Compute the singular value decomposition (SVD) of a matrix.
@@ -92,7 +76,12 @@ namespace nda {
    * where \f$ \mathbf{U} \f$ is a unitary m-by-m matrix, \f$ \mathbf{V} \f$ is a unitary n-by-n matrix and \f$
    * \mathbf{S} \f$ is an m-by-n matrix with non-negative real numbers on the diagonal.
    *
-   * It first makes a copy of the input matrix \f$ \mathbf{A} \f$ and then calls nda::svd_in_place with the copy.
+   * It first makes a copy of the input matrix \f$ \mathbf{A} \f$ and constructs the output vector \f$ \mathbf{s} \f$,
+   * which contains the singular values, and the output matrices \f$ \mathbf{U} \f$ and \f$ \mathbf{V}^H \f$. The SVD is
+   * performed by calling nda::lapack::gesvd.
+   *
+   * @note If the input matrix \f$ \mathbf{A} \f$ is in Fortran layout, the output matrices \f$ \mathbf{U} \f$ and
+   * \f$ \mathbf{V}^H \f$ are also in Fortran layout. Otherwise, they are in C layout.
    *
    * @tparam A nda::MemoryMatrix type.
    * @param a Input matrix \f$ \mathbf{A} \f$.
@@ -101,7 +90,7 @@ namespace nda {
   template <Matrix A>
     requires(is_blas_lapack_v<get_value_t<A>>)
   auto svd(A const &a) { // NOLINT (temporary views are allowed here)
-    return svd_in_place(basic_array{a});
+    return detail::svd_in_place(basic_array{a});
   }
 
   /** @} */

--- a/c++/nda/linalg/svd.hpp
+++ b/c++/nda/linalg/svd.hpp
@@ -1,0 +1,112 @@
+// Copyright (c) 2019-2024 Simons Foundation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0.txt
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Authors: Thomas Hahn, Olivier Parcollet, Nils Wentzell
+
+/**
+ * @file
+ * @brief Provides functions to compute the singular value decoomposition of a matrix.
+ */
+
+#pragma once
+
+#include "../basic_array.hpp"
+#include "../blas/tools.hpp"
+#include "../declarations.hpp"
+#include "../exceptions.hpp"
+#include "../lapack/gesvd.hpp"
+#include "../layout/policies.hpp"
+#include "../macros.hpp"
+#include "../mem/address_space.hpp"
+#include "../mem/policies.hpp"
+#include "../traits.hpp"
+
+#include <algorithm>
+#include <tuple>
+#include <type_traits>
+
+namespace nda {
+
+  /**
+   * @addtogroup linalg_tools
+   * @{
+   */
+
+  /**
+   * @brief Compute the singular value decomposition (SVD) of a matrix in place.
+   *
+   * @details The function computes the SVD of a given m-by-n matrix \f$ \mathbf{A} \f$:
+   * \f[
+   *   \mathbf{A} = \mathbf{U} \mathbf{S} \mathbf{V}^H \; ,
+   * \f]
+   * where \f$ \mathbf{U} \f$ is a unitary m-by-m matrix, \f$ \mathbf{V} \f$ is a unitary n-by-n matrix and \f$
+   * \mathbf{S} \f$ is an m-by-n matrix with non-negative real numbers on the diagonal.
+   *
+   * It first constructs the output vector \f$ \mathbf{s} \f$, which contains the singular values, and the output
+   * matrices \f$ \mathbf{U} \f$ and \f$ \mathbf{V}^H \f$. It then calls nda::lapack::gesvd to compute the SVD.
+   *
+   * @note If the input matrix \f$ \mathbf{A} \f$ is in Fortran layout, the output matrices \f$ \mathbf{U} \f$ and
+   * \f$ \mathbf{V}^H \f$ are also in Fortran layout. Otherwise, they are in C layout.
+   *
+   * @tparam A nda::MemoryMatrix type.
+   * @param a Input/output matrix. On entry, the m-by-n matrix \f$ \mathbf{A} \f$. On exit, the contents of \f$
+   * \mathbf{A} \f$ are destroyed.
+   * @return `std::tuple` containing \f$ \mathbf{U} \f$, \f$ \mathbf{s} \f$ and \f$ \mathbf{V}^H \f$.
+   */
+  template <MemoryMatrix A>
+    requires(is_blas_lapack_v<get_value_t<A>>)
+  auto svd_in_place(A &&a) { // NOLINT (temporary views are allowed here)
+    using layout_policy       = detail::layout_to_policy<typename std::remove_cvref_t<A>::layout_t>::type;
+    constexpr auto addr_space = mem::get_addr_space<A>;
+
+    // vector s and matrices U and V^H
+    auto s  = vector<double, heap<addr_space>>(std::min(a.extent(0), a.extent(1)));
+    auto U  = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a.extent(0), a.extent(0));
+    auto VH = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a.extent(1), a.extent(1));
+
+    // call lapack gesvd
+    int info = lapack::gesvd(a, s, U, VH);
+    if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::svd_in_place: gesvd returned a non-zero value: info = " << info;
+
+    return std::make_tuple(U, s, VH);
+  }
+
+  /**
+   * @brief Compute the singular value decomposition (SVD) of a matrix.
+   *
+   * @details The function computes the SVD of a given m-by-n matrix \f$ \mathbf{A} \f$:
+   * \f[
+   *   \mathbf{A} = \mathbf{U} \mathbf{S} \mathbf{V}^H \; ,
+   * \f]
+   * where \f$ \mathbf{U} \f$ is a unitary m-by-m matrix, \f$ \mathbf{V} \f$ is a unitary n-by-n matrix and \f$
+   * \mathbf{S} \f$ is an m-by-n matrix with non-negative real numbers on the diagonal.
+   *
+   * It first makes a copy of the input matrix \f$ \mathbf{A} \f$ and then calls nda::svd_in_place with the copy.
+   *
+   * @tparam A nda::MemoryMatrix type.
+   * @param a Input matrix \f$ \mathbf{A} \f$.
+   * @return `std::tuple` containing \f$ \mathbf{U} \f$, \f$ \mathbf{s} \f$ and \f$ \mathbf{V}^H \f$.
+   */
+  template <Matrix A>
+    requires(is_blas_lapack_v<get_value_t<A>>)
+  auto svd(A const &a) { // NOLINT (temporary views are allowed here)
+    using layout_policy       = detail::layout_to_policy<typename A::layout_t>::type;
+    constexpr auto addr_space = mem::get_addr_space<A>;
+    auto a_copy               = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a);
+    return svd_in_place(a_copy);
+  }
+
+  /** @} */
+
+} // namespace nda

--- a/c++/nda/linalg/svd.hpp
+++ b/c++/nda/linalg/svd.hpp
@@ -101,10 +101,7 @@ namespace nda {
   template <Matrix A>
     requires(is_blas_lapack_v<get_value_t<A>>)
   auto svd(A const &a) { // NOLINT (temporary views are allowed here)
-    using layout_policy       = detail::layout_to_policy<typename A::layout_t>::type;
-    constexpr auto addr_space = mem::get_addr_space<A>;
-    auto a_copy               = matrix<get_value_t<A>, layout_policy, heap<addr_space>>(a);
-    return svd_in_place(a_copy);
+    return svd_in_place(basic_array{a});
   }
 
   /** @} */

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -207,12 +207,12 @@ void test_getrs_getrf_getri() {
   auto A = matrix_t{{1, 2, 3}, {0, 1, 4}, {5, 6, 0}};
   auto B = matrix_t{{1, 5}, {4, 5}, {3, 6}};
 
-  // solve A * x = B using the exact matrix inverse
+  // solve A * X = B using the exact matrix inverse
   auto Ainv = matrix_t{{-24, 18, 5}, {20, -15, -4}, {-5, 4, 1}};
-  auto X1   = matrix_t{Ainv * B};
-  EXPECT_ARRAY_NEAR(matrix_t{A * X1}, B);
+  auto X    = matrix_t{Ainv * B};
+  EXPECT_ARRAY_NEAR(matrix_t{A * X}, B);
 
-  // solve A * x = B using getrf and getrs
+  // solve A * X = B using getrf and getrs
   auto Acopy = matrix_t{A};
   auto Bcopy = matrix_t{B};
   array<int, 1> ipiv(3);
@@ -220,7 +220,15 @@ void test_getrs_getrf_getri() {
   lapack::getrs(Acopy, Bcopy, ipiv);
   auto X2 = matrix_t{Bcopy};
   EXPECT_ARRAY_NEAR(matrix_t{A * X2}, B);
-  EXPECT_ARRAY_NEAR(X1, X2);
+  EXPECT_ARRAY_NEAR(X, X2);
+
+  // solve A * x = b using getrf and getrs
+  Acopy = A;
+  auto b = vector<value_t>{B(range::all, 0)};
+  lapack::getrf(Acopy, ipiv);
+  lapack::getrs(Acopy, b, ipiv);
+  EXPECT_ARRAY_NEAR(A * b, B(range::all, 0));
+  EXPECT_ARRAY_NEAR(X(range::all, 0), b);
 
   // compute the inverse of A using getrf and getri
   auto Ainv2 = Acopy;

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -95,9 +95,9 @@ TEST(NDA, LAPACKGtsvComplex) {
 }
 
 // Test LAPACK gesvd function.
-template <typename value_t>
+template <typename value_t, typename Layout>
 void test_gesvd() {
-  using matrix_t = matrix<value_t, F_layout>;
+  using matrix_t = matrix<value_t, Layout>;
 
   auto A      = matrix_t{{{1, 1, 1}, {2, 3, 4}, {3, 5, 2}, {4, 2, 5}, {5, 4, 3}}};
   auto [m, n] = A.shape();
@@ -115,8 +115,10 @@ void test_gesvd() {
 }
 
 TEST(NDA, LAPACKGesvd) {
-  test_gesvd<double>();
-  test_gesvd<std::complex<double>>();
+  test_gesvd<double, C_layout>();
+  test_gesvd<double, F_layout>();
+  test_gesvd<std::complex<double>, C_layout>();
+  test_gesvd<std::complex<double>, F_layout>();
 }
 
 // Test LAPACK geqp3, orgqr and ungqr functions.
@@ -223,7 +225,7 @@ void test_getrs_getrf_getri() {
   EXPECT_ARRAY_NEAR(X, X2);
 
   // solve A * x = b using getrf and getrs
-  Acopy = A;
+  Acopy  = A;
   auto b = vector<value_t>{B(range::all, 0)};
   lapack::getrf(Acopy, ipiv);
   lapack::getrs(Acopy, b, ipiv);

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -200,9 +200,9 @@ TEST(NDA, LAPACKGelss) {
 }
 
 // Test LAPACK getrs, getrf and getri functions.
-template <typename value_t>
+template <typename value_t, typename Layout>
 void test_getrs_getrf_getri() {
-  using matrix_t = matrix<value_t, F_layout>;
+  using matrix_t = matrix<value_t, Layout>;
 
   auto A = matrix_t{{1, 2, 3}, {0, 1, 4}, {5, 6, 0}};
   auto B = matrix_t{{1, 5}, {4, 5}, {3, 6}};
@@ -229,6 +229,8 @@ void test_getrs_getrf_getri() {
 }
 
 TEST(NDA, LAPAKCGetrsGetrfAndGetri) {
-  test_getrs_getrf_getri<double>();
-  test_getrs_getrf_getri<std::complex<double>>();
+  test_getrs_getrf_getri<double, C_layout>();
+  test_getrs_getrf_getri<double, F_layout>();
+  test_getrs_getrf_getri<std::complex<double>, C_layout>();
+  test_getrs_getrf_getri<std::complex<double>, F_layout>();
 }

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -26,99 +26,72 @@
 using namespace nda;
 
 // Test LAPACK gtsv function.
-template <typename value_t>
-void test_gtsv() {
-  // sub-diagonal, diagonal, and super-diagonal elements
-  vector<value_t> subdiag_vec   = {4, 3, 2, 1};
-  vector<value_t> diag_vec      = {1, 2, 3, 4, 5};
-  vector<value_t> superdiag_vec = {1, 2, 3, 4};
-
-  // right hand side
-  vector<value_t> B1 = {6, 2, 7, 4, 5};
-  vector<value_t> B2 = {1, 3, 8, 9, 10};
-  auto B             = matrix<value_t, F_layout>(5, 2);
-  B(range::all, 0)   = B1;
-  B(range::all, 1)   = B2;
-
-  // reference solutions
-  vector<double> ref_sol_1 = {43.0 / 33.0, 155.0 / 33.0, -208.0 / 33.0, 130.0 / 33.0, 7.0 / 33.0};
-  vector<double> ref_sol_2 = {-28.0 / 33.0, 61.0 / 33.0, 89.0 / 66.0, -35.0 / 66.0, 139.0 / 66.0};
-  matrix<double, F_layout> ref_sol(5, 2);
-  ref_sol(range::all, 0) = ref_sol_1;
-  ref_sol(range::all, 1) = ref_sol_2;
-
-  {
-    auto dl(subdiag_vec);
-    auto d(diag_vec);
-    auto du(superdiag_vec);
-    int info = lapack::gtsv(dl, d, du, B1);
-    EXPECT_EQ(info, 0);
-    EXPECT_ARRAY_NEAR(B1, ref_sol_1);
-  }
-  {
-    auto dl(subdiag_vec);
-    auto d(diag_vec);
-    auto du(superdiag_vec);
-    int info = lapack::gtsv(dl, d, du, B2);
-    EXPECT_EQ(info, 0);
-    EXPECT_ARRAY_NEAR(B2, ref_sol_2);
-  }
-  {
-    auto dl(subdiag_vec);
-    auto d(diag_vec);
-    auto du(superdiag_vec);
-    int info = lapack::gtsv(dl, d, du, B);
-    EXPECT_EQ(info, 0);
-    EXPECT_ARRAY_NEAR(B, ref_sol);
-  }
+void test_gtsv(auto dl, auto d, auto du, auto B, auto ref_sol) {
+  int info = lapack::gtsv(dl, d, du, B);
+  EXPECT_EQ(info, 0);
+  EXPECT_ARRAY_NEAR(B, ref_sol);
 }
-TEST(NDA, LAPACKGtsv) {
-  test_gtsv<double>();
-  test_gtsv<std::complex<double>>();
 
-  // test cgtsv
-  vector<std::complex<double>> subdiag_vec   = {-4i, -3i, -2i, -1i};
-  vector<std::complex<double>> diag_vec      = {1, 2, 3, 4, 5};
-  vector<std::complex<double>> superdiag_vec = {1i, 2i, 3i, 4i};
+TEST(NDA, LAPACKGtsvDouble) {
+  auto check = []<typename value_t, typename Layout>() {
+    // sub-diagonal, diagonal, and super-diagonal elements
+    vector<value_t> subdiag_vec   = {4, 3, 2, 1};
+    vector<value_t> diag_vec      = {1, 2, 3, 4, 5};
+    vector<value_t> superdiag_vec = {1, 2, 3, 4};
 
-  // right hand side
-  vector<std::complex<double>> B1 = {6 + 0i, 2i, 7 + 0i, 4i, 5 + 0i};
-  vector<std::complex<double>> B2 = {1i, 3 + 0i, 8i, 9 + 0i, 10i};
-  matrix<std::complex<double>, F_layout> B(5, 2);
-  B(range::all, 0) = B1;
-  B(range::all, 1) = B2;
+    // right hand side
+    vector<value_t> B1 = {6, 2, 7, 4, 5};
+    vector<value_t> B2 = {1, 3, 8, 9, 10};
+    auto B             = matrix<value_t, Layout>(5, 2);
+    B(range::all, 0)   = B1;
+    B(range::all, 1)   = B2;
 
-  // reference solutions
-  vector<std::complex<double>> ref_sol_1 = {137.0 / 33.0 + 0i, -61i / 33.0, 368.0 / 33.0 + 0i, 230i / 33.0, -13.0 / 33.0 + 0i};
-  vector<std::complex<double>> ref_sol_2 = {-35i / 33.0, 68.0 / 33.0 + 0i, -103i / 66.0, 415.0 / 66.0 + 0i, 215i / 66.0};
-  matrix<std::complex<double>, F_layout> ref_sol(5, 2);
-  ref_sol(range::all, 0) = ref_sol_1;
-  ref_sol(range::all, 1) = ref_sol_2;
+    // reference solutions
+    vector<double> ref_sol_1 = {43.0 / 33.0, 155.0 / 33.0, -208.0 / 33.0, 130.0 / 33.0, 7.0 / 33.0};
+    vector<double> ref_sol_2 = {-28.0 / 33.0, 61.0 / 33.0, 89.0 / 66.0, -35.0 / 66.0, 139.0 / 66.0};
+    matrix<double, Layout> ref_sol(5, 2);
+    ref_sol(range::all, 0) = ref_sol_1;
+    ref_sol(range::all, 1) = ref_sol_2;
 
-  {
-    auto dl(subdiag_vec);
-    auto d(diag_vec);
-    auto du(superdiag_vec);
-    int info = lapack::gtsv(dl, d, du, B1);
-    EXPECT_EQ(info, 0);
-    EXPECT_ARRAY_NEAR(B1, ref_sol_1);
-  }
-  {
-    auto dl(subdiag_vec);
-    auto d(diag_vec);
-    auto du(superdiag_vec);
-    int info = lapack::gtsv(dl, d, du, B2);
-    EXPECT_EQ(info, 0);
-    EXPECT_ARRAY_NEAR(B2, ref_sol_2);
-  }
-  {
-    auto dl(subdiag_vec);
-    auto d(diag_vec);
-    auto du(superdiag_vec);
-    int info = lapack::gtsv(dl, d, du, B);
-    EXPECT_EQ(info, 0);
-    EXPECT_ARRAY_NEAR(B, ref_sol);
-  }
+    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B1, ref_sol_1);
+    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B2, ref_sol_2);
+    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B, ref_sol);
+  };
+
+  check.operator()<double, C_layout>();
+  check.operator()<double, F_layout>();
+  check.operator()<std::complex<double>, C_layout>();
+  check.operator()<std::complex<double>, F_layout>();
+}
+
+TEST(NDA, LAPACKGtsvComplex) {
+  auto check = []<typename Layout>() {
+    // sub-diagonal, diagonal, and super-diagonal elements
+    vector<std::complex<double>> subdiag_vec   = {-4i, -3i, -2i, -1i};
+    vector<std::complex<double>> diag_vec      = {1, 2, 3, 4, 5};
+    vector<std::complex<double>> superdiag_vec = {1i, 2i, 3i, 4i};
+
+    // right hand side
+    vector<std::complex<double>> B1 = {6 + 0i, 2i, 7 + 0i, 4i, 5 + 0i};
+    vector<std::complex<double>> B2 = {1i, 3 + 0i, 8i, 9 + 0i, 10i};
+    matrix<std::complex<double>, Layout> B(5, 2);
+    B(range::all, 0) = B1;
+    B(range::all, 1) = B2;
+
+    // reference solutions
+    vector<std::complex<double>> ref_sol_1 = {137.0 / 33.0 + 0i, -61i / 33.0, 368.0 / 33.0 + 0i, 230i / 33.0, -13.0 / 33.0 + 0i};
+    vector<std::complex<double>> ref_sol_2 = {-35i / 33.0, 68.0 / 33.0 + 0i, -103i / 66.0, 415.0 / 66.0 + 0i, 215i / 66.0};
+    matrix<std::complex<double>, Layout> ref_sol(5, 2);
+    ref_sol(range::all, 0) = ref_sol_1;
+    ref_sol(range::all, 1) = ref_sol_2;
+
+    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B1, ref_sol_1);
+    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B2, ref_sol_2);
+    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B, ref_sol);
+  };
+
+  check.operator()<C_layout>();
+  check.operator()<F_layout>();
 }
 
 // Test LAPACK gesvd function.

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -33,7 +33,7 @@ void test_gtsv(auto dl, auto d, auto du, auto B, auto ref_sol) {
 }
 
 TEST(NDA, LAPACKGtsvDouble) {
-  auto check = []<typename value_t, typename Layout>() {
+  auto check = []<typename value_t>() {
     // sub-diagonal, diagonal, and super-diagonal elements
     vector<value_t> subdiag_vec   = {4, 3, 2, 1};
     vector<value_t> diag_vec      = {1, 2, 3, 4, 5};
@@ -42,14 +42,14 @@ TEST(NDA, LAPACKGtsvDouble) {
     // right hand side
     vector<value_t> B1 = {6, 2, 7, 4, 5};
     vector<value_t> B2 = {1, 3, 8, 9, 10};
-    auto B             = matrix<value_t, Layout>(5, 2);
+    auto B             = matrix<value_t, F_layout>(5, 2);
     B(range::all, 0)   = B1;
     B(range::all, 1)   = B2;
 
     // reference solutions
     vector<double> ref_sol_1 = {43.0 / 33.0, 155.0 / 33.0, -208.0 / 33.0, 130.0 / 33.0, 7.0 / 33.0};
     vector<double> ref_sol_2 = {-28.0 / 33.0, 61.0 / 33.0, 89.0 / 66.0, -35.0 / 66.0, 139.0 / 66.0};
-    matrix<double, Layout> ref_sol(5, 2);
+    matrix<double, F_layout> ref_sol(5, 2);
     ref_sol(range::all, 0) = ref_sol_1;
     ref_sol(range::all, 1) = ref_sol_2;
 
@@ -58,40 +58,33 @@ TEST(NDA, LAPACKGtsvDouble) {
     test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B, ref_sol);
   };
 
-  check.operator()<double, C_layout>();
-  check.operator()<double, F_layout>();
-  check.operator()<std::complex<double>, C_layout>();
-  check.operator()<std::complex<double>, F_layout>();
+  check.operator()<double>();
+  check.operator()<std::complex<double>>();
 }
 
 TEST(NDA, LAPACKGtsvComplex) {
-  auto check = []<typename Layout>() {
-    // sub-diagonal, diagonal, and super-diagonal elements
-    vector<std::complex<double>> subdiag_vec   = {-4i, -3i, -2i, -1i};
-    vector<std::complex<double>> diag_vec      = {1, 2, 3, 4, 5};
-    vector<std::complex<double>> superdiag_vec = {1i, 2i, 3i, 4i};
+  // sub-diagonal, diagonal, and super-diagonal elements
+  vector<std::complex<double>> subdiag_vec   = {-4i, -3i, -2i, -1i};
+  vector<std::complex<double>> diag_vec      = {1, 2, 3, 4, 5};
+  vector<std::complex<double>> superdiag_vec = {1i, 2i, 3i, 4i};
 
-    // right hand side
-    vector<std::complex<double>> B1 = {6 + 0i, 2i, 7 + 0i, 4i, 5 + 0i};
-    vector<std::complex<double>> B2 = {1i, 3 + 0i, 8i, 9 + 0i, 10i};
-    matrix<std::complex<double>, Layout> B(5, 2);
-    B(range::all, 0) = B1;
-    B(range::all, 1) = B2;
+  // right hand side
+  vector<std::complex<double>> B1 = {6 + 0i, 2i, 7 + 0i, 4i, 5 + 0i};
+  vector<std::complex<double>> B2 = {1i, 3 + 0i, 8i, 9 + 0i, 10i};
+  matrix<std::complex<double>, F_layout> B(5, 2);
+  B(range::all, 0) = B1;
+  B(range::all, 1) = B2;
 
-    // reference solutions
-    vector<std::complex<double>> ref_sol_1 = {137.0 / 33.0 + 0i, -61i / 33.0, 368.0 / 33.0 + 0i, 230i / 33.0, -13.0 / 33.0 + 0i};
-    vector<std::complex<double>> ref_sol_2 = {-35i / 33.0, 68.0 / 33.0 + 0i, -103i / 66.0, 415.0 / 66.0 + 0i, 215i / 66.0};
-    matrix<std::complex<double>, Layout> ref_sol(5, 2);
-    ref_sol(range::all, 0) = ref_sol_1;
-    ref_sol(range::all, 1) = ref_sol_2;
+  // reference solutions
+  vector<std::complex<double>> ref_sol_1 = {137.0 / 33.0 + 0i, -61i / 33.0, 368.0 / 33.0 + 0i, 230i / 33.0, -13.0 / 33.0 + 0i};
+  vector<std::complex<double>> ref_sol_2 = {-35i / 33.0, 68.0 / 33.0 + 0i, -103i / 66.0, 415.0 / 66.0 + 0i, 215i / 66.0};
+  matrix<std::complex<double>, F_layout> ref_sol(5, 2);
+  ref_sol(range::all, 0) = ref_sol_1;
+  ref_sol(range::all, 1) = ref_sol_2;
 
-    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B1, ref_sol_1);
-    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B2, ref_sol_2);
-    test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B, ref_sol);
-  };
-
-  check.operator()<C_layout>();
-  check.operator()<F_layout>();
+  test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B1, ref_sol_1);
+  test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B2, ref_sol_2);
+  test_gtsv(subdiag_vec, diag_vec, superdiag_vec, B, ref_sol);
 }
 
 // Test LAPACK gesvd function.
@@ -204,7 +197,8 @@ TEST(NDA, LAPACKGelss) {
 // Test LAPACK getrs, getrf and getri functions.
 template <typename value_t, typename Layout>
 void test_getrs_getrf_getri() {
-  using matrix_t = matrix<value_t, Layout>;
+  using matrix_t   = matrix<value_t, Layout>;
+  using f_matrix_t = matrix<value_t, F_layout>;
 
   auto A = matrix_t{{1, 2, 3}, {0, 1, 4}, {5, 6, 0}};
   auto B = matrix_t{{1, 5}, {4, 5}, {3, 6}};
@@ -216,7 +210,7 @@ void test_getrs_getrf_getri() {
 
   // solve A * X = B using getrf and getrs
   auto Acopy = matrix_t{A};
-  auto Bcopy = matrix_t{B};
+  auto Bcopy = f_matrix_t{B};
   array<int, 1> ipiv(3);
   lapack::getrf(Acopy, ipiv);
   lapack::getrs(Acopy, Bcopy, ipiv);
@@ -238,9 +232,60 @@ void test_getrs_getrf_getri() {
   EXPECT_ARRAY_NEAR(Ainv, Ainv2);
 }
 
-TEST(NDA, LAPAKCGetrsGetrfAndGetri) {
+TEST(NDA, LAPACKGetrsGetrfAndGetri) {
   test_getrs_getrf_getri<double, C_layout>();
   test_getrs_getrf_getri<double, F_layout>();
   test_getrs_getrf_getri<std::complex<double>, C_layout>();
   test_getrs_getrf_getri<std::complex<double>, F_layout>();
+}
+
+TEST(NDA, LAPACKGetrfWithRectangularMatrix) {
+  using f_matrix_t = matrix<double, F_layout>;
+  // using c_matrix_t = matrix<double, C_layout>;
+
+  auto A    = f_matrix_t{{1, 5}, {4, 5}, {3, 6}};
+  auto AT   = f_matrix_t(nda::transpose(A));
+  auto A_c  = matrix<double, C_layout>{A};
+  auto AT_c = matrix<double, C_layout>{AT};
+  auto ipiv = array<int, 1>(2);
+
+  // get the matrices P, L, U from getrf output
+  auto get_plu = [](auto const &M, auto const &ipiv, int m, int n) {
+    using layout_t = std::conditional_t<blas::has_C_layout<decltype(M)>, C_layout, F_layout>;
+    auto P         = matrix<double, layout_t>::zeros(m, m);
+    auto L         = matrix<double, layout_t>::zeros(m, m);
+    auto U         = matrix<double, layout_t>::zeros(m, n);
+    diagonal(P)    = 1;
+    diagonal(L)    = 1;
+    for (int i = 0; i < ipiv.size(); ++i) deep_swap(P(i, nda::range::all), P(ipiv(i) - 1, nda::range::all));
+    for (int i = 0; i < m; ++i) {
+      L(i, nda::range(i))    = (blas::has_C_layout<decltype(M)> ? M(nda::range(i), i) : M(i, nda::range(i)));
+      U(i, nda::range(i, n)) = (blas::has_C_layout<decltype(M)> ? M(nda::range(i, n), i) : M(i, nda::range(i, n)));
+    }
+    return std::make_tuple(P, L, U);
+  };
+
+  // LU decomposition for 3x2 Fortran layout matrix
+  auto LU_f_32 = A;
+  lapack::getrf(LU_f_32, ipiv);
+  auto [P_f_32, L_f_32, U_f_32] = get_plu(LU_f_32, ipiv, 3, 2);
+  EXPECT_ARRAY_NEAR(P_f_32 * A, L_f_32 * U_f_32);
+
+  // LU decomposition for 2x3 Fortran layout matrix
+  auto LU_f_23 = AT;
+  lapack::getrf(LU_f_23, ipiv);
+  auto [P_f_23, L_f_23, U_f_23] = get_plu(LU_f_23, ipiv, 2, 3);
+  EXPECT_ARRAY_NEAR(P_f_23 * AT, L_f_23 * U_f_23);
+
+  // LU decomposition for 3x2 C layout matrix
+  auto LU_c_32 = A_c;
+  lapack::getrf(LU_c_32, ipiv);
+  auto [P_c_32, L_c_32, U_c_32] = get_plu(LU_c_32, ipiv, 2, 3);
+  EXPECT_ARRAY_NEAR(P_c_32 * nda::transpose(A_c), L_c_32 * U_c_32);
+
+  // LU decomposition for 2x3 C layout matrix
+  auto LU_c_23 = AT_c;
+  lapack::getrf(LU_c_23, ipiv);
+  auto [P_c_23, L_c_23, U_c_23] = get_plu(LU_c_23, ipiv, 3, 2);
+  EXPECT_ARRAY_NEAR(P_c_23 * nda::transpose(AT_c), L_c_23 * U_c_23);
 }

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -392,3 +392,49 @@ TEST(NDA, LinearAlgebraNormExample) {
   EXPECT_EQ(nda::norm(v, std::numeric_limits<double>::infinity()), 2.5);
   EXPECT_EQ(nda::norm(v, -std::numeric_limits<double>::infinity()), 0.0);
 }
+
+// Check the solution of a linear system of equations.
+template <typename value_t, typename Layout>
+void test_solve() {
+  using matrix_t = nda::matrix<value_t, Layout>;
+  using vector_t = nda::vector<value_t>;
+
+  auto A = matrix_t{{1, 2, 3}, {0, 1, 4}, {5, 6, 0}};
+  auto B = matrix_t{{1, 5}, {4, 5}, {3, 6}};
+
+  // solve A * X = B using the exact matrix inverse
+  auto Ainv = matrix_t{{-24, 18, 5}, {20, -15, -4}, {-5, 4, 1}};
+  auto X   = matrix_t{Ainv * B};
+  EXPECT_ARRAY_NEAR(matrix_t{A * X}, B);
+
+  // solve A * X = B using solve_in_place
+  auto Acopy = matrix_t{A};
+  auto Bcopy = matrix_t{B};
+  nda::solve_in_place(Acopy, Bcopy);
+  EXPECT_ARRAY_NEAR(matrix_t{A * Bcopy}, B);
+  EXPECT_ARRAY_NEAR(X, Bcopy);
+
+  // solve A * x = b using solve_in_place
+  Acopy = A;
+  auto b = vector_t{B(nda::range::all, 0)};
+  nda::solve_in_place(Acopy, b);
+  EXPECT_ARRAY_NEAR(A * b, B(nda::range::all, 0));
+  EXPECT_ARRAY_NEAR(X(nda::range::all, 0), b);
+
+  // solve A * X = B using solve
+  auto X2 = nda::solve(A, B);
+  EXPECT_ARRAY_NEAR(matrix_t{A * X2}, B);
+  EXPECT_ARRAY_NEAR(X, X2);
+
+  // solve A * x = b using solve
+  auto x = nda::solve(A, B(nda::range::all, 0));
+  EXPECT_ARRAY_NEAR(A * x, B(nda::range::all, 0));
+  EXPECT_ARRAY_NEAR(X(nda::range::all, 0), x);
+}
+
+TEST(NDA, LinearAlgebraSolve) {
+  test_solve<double, nda::C_layout>();
+  test_solve<double, nda::F_layout>();
+  test_solve<std::complex<double>, nda::C_layout>();
+  test_solve<std::complex<double>, nda::F_layout>();
+}

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -397,7 +397,6 @@ TEST(NDA, LinearAlgebraNormExample) {
 template <typename value_t, typename Layout>
 void test_solve() {
   using matrix_t = nda::matrix<value_t, Layout>;
-  using vector_t = nda::vector<value_t>;
 
   auto A = matrix_t{{1, 2, 3}, {0, 1, 4}, {5, 6, 0}};
   auto B = matrix_t{{1, 5}, {4, 5}, {3, 6}};
@@ -406,20 +405,6 @@ void test_solve() {
   auto Ainv = matrix_t{{-24, 18, 5}, {20, -15, -4}, {-5, 4, 1}};
   auto X    = matrix_t{Ainv * B};
   EXPECT_ARRAY_NEAR(matrix_t{A * X}, B);
-
-  // solve A * X = B using solve_in_place
-  auto Acopy = matrix_t{A};
-  auto Bcopy = matrix_t{B};
-  nda::solve_in_place(Acopy, Bcopy);
-  EXPECT_ARRAY_NEAR(matrix_t{A * Bcopy}, B);
-  EXPECT_ARRAY_NEAR(X, Bcopy);
-
-  // solve A * x = b using solve_in_place
-  Acopy  = A;
-  auto b = vector_t{B(nda::range::all, 0)};
-  nda::solve_in_place(Acopy, b);
-  EXPECT_ARRAY_NEAR(A * b, B(nda::range::all, 0));
-  EXPECT_ARRAY_NEAR(X(nda::range::all, 0), b);
 
   // solve A * X = B using solve
   auto X2 = nda::solve(A, B);
@@ -453,14 +438,6 @@ void test_svd() {
   diagonal(S_1)         = s_1;
   EXPECT_ARRAY_NEAR(s_1, s, 1e-14);
   EXPECT_ARRAY_NEAR(A, U_1 * S_1 * VH_1, 1e-14);
-
-  // compute the SVD of A in place
-  auto A_copy           = A;
-  auto [U_2, s_2, VH_2] = nda::svd_in_place(A_copy);
-  auto S_2              = matrix_t::zeros(A.shape());
-  diagonal(S_2)         = s_2;
-  EXPECT_ARRAY_NEAR(s, s_2, 1e-14);
-  EXPECT_ARRAY_NEAR(A, U_2 * S_2 * VH_2, 1e-14);
 }
 
 TEST(NDA, LinearAlgebraSVD) {

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -450,7 +450,7 @@ void test_svd() {
   // compute the SVD of A
   auto [U_1, s_1, VH_1] = nda::svd(A);
   auto S_1              = matrix_t::zeros(A.shape());
-  for (auto i : nda::range(2)) S_1(i, i) = s_1(i);
+  diagonal(S_1)         = s_1;
   EXPECT_ARRAY_NEAR(s_1, s, 1e-14);
   EXPECT_ARRAY_NEAR(A, U_1 * S_1 * VH_1, 1e-14);
 
@@ -458,7 +458,7 @@ void test_svd() {
   auto A_copy           = A;
   auto [U_2, s_2, VH_2] = nda::svd_in_place(A_copy);
   auto S_2              = matrix_t::zeros(A.shape());
-  for (auto i : nda::range(2)) S_2(i, i) = s_2(i);
+  diagonal(S_2)         = s_2;
   EXPECT_ARRAY_NEAR(s, s_2, 1e-14);
   EXPECT_ARRAY_NEAR(A, U_2 * S_2 * VH_2, 1e-14);
 }

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -407,12 +407,12 @@ void test_solve() {
   EXPECT_ARRAY_NEAR(matrix_t{A * X}, B);
 
   // solve A * X = B using solve
-  auto X2 = nda::solve(A, B);
+  auto X2 = nda::linalg::solve(A, B);
   EXPECT_ARRAY_NEAR(matrix_t{A * X2}, B);
   EXPECT_ARRAY_NEAR(X, X2);
 
   // solve A * x = b using solve
-  auto x = nda::solve(A, B(nda::range::all, 0));
+  auto x = nda::linalg::solve(A, B(nda::range::all, 0));
   EXPECT_ARRAY_NEAR(A * x, B(nda::range::all, 0));
   EXPECT_ARRAY_NEAR(X(nda::range::all, 0), x);
 }
@@ -433,7 +433,7 @@ void test_svd() {
   auto s = nda::vector<double>{12, 3};
 
   // compute the SVD of A
-  auto [U_1, s_1, VH_1] = nda::svd(A);
+  auto [U_1, s_1, VH_1] = nda::linalg::svd(A);
   auto S_1              = matrix_t::zeros(A.shape());
   diagonal(S_1)         = s_1;
   EXPECT_ARRAY_NEAR(s_1, s, 1e-14);

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -404,7 +404,7 @@ void test_solve() {
 
   // solve A * X = B using the exact matrix inverse
   auto Ainv = matrix_t{{-24, 18, 5}, {20, -15, -4}, {-5, 4, 1}};
-  auto X   = matrix_t{Ainv * B};
+  auto X    = matrix_t{Ainv * B};
   EXPECT_ARRAY_NEAR(matrix_t{A * X}, B);
 
   // solve A * X = B using solve_in_place
@@ -415,7 +415,7 @@ void test_solve() {
   EXPECT_ARRAY_NEAR(X, Bcopy);
 
   // solve A * x = b using solve_in_place
-  Acopy = A;
+  Acopy  = A;
   auto b = vector_t{B(nda::range::all, 0)};
   nda::solve_in_place(Acopy, b);
   EXPECT_ARRAY_NEAR(A * b, B(nda::range::all, 0));
@@ -437,4 +437,35 @@ TEST(NDA, LinearAlgebraSolve) {
   test_solve<double, nda::F_layout>();
   test_solve<std::complex<double>, nda::C_layout>();
   test_solve<std::complex<double>, nda::F_layout>();
+}
+
+// Check the SVD of a matrix.
+template <typename value_t, typename Layout>
+void test_svd() {
+  using matrix_t = nda::matrix<value_t, Layout>;
+
+  auto A = matrix_t{{2, -2, 1}, {-4, -8, -8}};
+  auto s = nda::vector<double>{12, 3};
+
+  // compute the SVD of A
+  auto [U_1, s_1, VH_1] = nda::svd(A);
+  auto S_1              = matrix_t::zeros(A.shape());
+  for (auto i : nda::range(2)) S_1(i, i) = s_1(i);
+  EXPECT_ARRAY_NEAR(s_1, s, 1e-14);
+  EXPECT_ARRAY_NEAR(A, U_1 * S_1 * VH_1, 1e-14);
+
+  // compute the SVD of A in place
+  auto A_copy           = A;
+  auto [U_2, s_2, VH_2] = nda::svd_in_place(A_copy);
+  auto S_2              = matrix_t::zeros(A.shape());
+  for (auto i : nda::range(2)) S_2(i, i) = s_2(i);
+  EXPECT_ARRAY_NEAR(s, s_2, 1e-14);
+  EXPECT_ARRAY_NEAR(A, U_2 * S_2 * VH_2, 1e-14);
+}
+
+TEST(NDA, LinearAlgebraSVD) {
+  test_svd<double, nda::C_layout>();
+  test_svd<double, nda::F_layout>();
+  test_svd<std::complex<double>, nda::C_layout>();
+  test_svd<std::complex<double>, nda::F_layout>();
 }


### PR DESCRIPTION
* Fix `gtsv` to work for C-Layout matrices
* Fix `getrs` to work for C-Laytout matrices
* Generalize `getrs` to work with vectors
* Add convenient `solve` and `solve_in_place` functions for systems of linear equations