### PR TITLE
Update MPI routines to account for changes in mpi

### DIFF
--- a/c++/nda/macros.hpp
+++ b/c++/nda/macros.hpp
@@ -44,12 +44,12 @@
 
 #ifdef NDEBUG
 
-#define EXPECTS(X)
-#define ASSERT(X)
-#define ENSURES(X)
-#define EXPECTS_WITH_MESSAGE(X, ...)
-#define ASSERT_WITH_MESSAGE(X, ...)
-#define ENSURES_WITH_MESSAGE(X, ...)
+#define EXPECTS(X) {}
+#define ASSERT(X) {}
+#define ENSURES(X) {}
+#define EXPECTS_WITH_MESSAGE(X, ...) {}
+#define ASSERT_WITH_MESSAGE(X, ...) {}
+#define ENSURES_WITH_MESSAGE(X, ...) {}
 
 #else
 

--- a/c++/nda/mpi/broadcast.hpp
+++ b/c++/nda/mpi/broadcast.hpp
@@ -38,14 +38,15 @@ namespace nda {
    *
    * @details For the root process, the array/view is broadcasted to all other processes. For non-root processes, the
    * array/view is resized/checked to match the broadcasted dimensions and the data is written into the given
-   * array/view.
+   * array/view. The actual broadcasting is done by calling `mpi::broadcast_range`.
    *
-   * Throws an exception, if
-   * - a given view does not have the correct shape,
-   * - the array/view is not contiguous with positive strides or
-   * - one of the MPI calls fails.
+   * It throws an exception, if a given view does not have the correct shape.
    *
    * See @ref ex6_p1 for an example.
+   *
+   * @note If the array/view is contiguous with positive strides and if the value type is MPI compatible, the data is
+   * broadcasted using a single `MPI_Bcast` call. Otherwise, the data is broadcasted element-wise which can have
+   * considerable performance implications. Consider copying the data into a contiguous array/view before broadcasting.
    *
    * @tparam A nda::basic_array or nda::basic_array_view type.
    * @param a Array/view to be broadcasted from/into.
@@ -56,11 +57,20 @@ namespace nda {
   void mpi_broadcast(A &&a, mpi::communicator comm = {}, int root = 0) // NOLINT (temporary views are allowed here)
     requires(is_regular_or_view_v<A>)
   {
-    detail::check_layout_mpi_compatible(a, "mpi_broadcast");
+    // broadcast the shape of the input array/view on the root process
     auto dims = a.shape();
     mpi::broadcast(dims, comm, root);
-    if (comm.rank() != root) { resize_or_check_if_view(a, dims); }
-    mpi::broadcast_range(std::span{a.data(), static_cast<std::size_t>(a.size())}, comm, root);
+
+    // resize or check the output array/view on non-root processes
+    if (comm.rank() != root) resize_or_check_if_view(a, dims);
+
+    // call mpi::broadcast_range with a span if the array/view is contiguous with positive strides
+    if (a.is_contiguous() and a.has_positive_strides()) {
+      auto a_span = std::span{a.data(), static_cast<std::size_t>(a.size())};
+      mpi::broadcast_range(a_span, comm, root);
+    } else {
+      mpi::broadcast_range(a, comm, root);
+    }
   }
 
 } // namespace nda

--- a/c++/nda/mpi/gather.hpp
+++ b/c++/nda/mpi/gather.hpp
@@ -33,23 +33,19 @@
 #include <mpi/mpi.hpp>
 
 #include <cstddef>
-#include <functional>
-#include <numeric>
 #include <span>
 #include <type_traits>
-#include <utility>
 
 namespace nda::detail {
 
-  // Helper function to get the shape and total size of the gathered array/view.
+  // Helper function to get the shape of the gathered array/view.
   template <typename A>
     requires(is_regular_or_view_v<A> and std::decay_t<A>::is_stride_order_C())
   auto mpi_gather_shape_impl(A const &a, mpi::communicator comm, int root, bool all) {
-    auto dims          = a.shape();
-    dims[0]            = mpi::all_reduce(dims[0], comm);
-    auto gathered_size = std::accumulate(dims.begin(), dims.end(), 1l, std::multiplies<>());
+    auto dims = a.shape();
+    dims[0]   = mpi::all_reduce(dims[0], comm);
     if (!all && comm.rank() != root) dims = nda::stdutil::make_initialized_array<dims.size()>(0l);
-    return std::make_pair(dims, gathered_size);
+    return dims;
   }
 
 } // namespace nda::detail
@@ -62,28 +58,29 @@ namespace nda {
    */
 
   /**
-   * @brief Implementation of an MPI gather for nda::basic_array or nda::basic_array_view types using a C-style API.
+   * @brief Implementation of an MPI gather for nda::basic_array or nda::basic_array_view types that gathers directly
+   * into an existing array/view.
    *
    * @details The function gathers C-ordered input arrays/views from all processes in the given communicator and
    * makes the result available on the root process (`all == false`) or on all processes (`all == true`). The
    * arrays/views are joined along the first dimension.
    *
    * It is expected that all input arrays/views have the same shape on all processes except for the first dimension. The
-   * function throws an exception, if
-   * - the input array/view is not contiguous with positive strides,
-   * - the output array/view is not contiguous with positive strides on receiving ranks,
-   * - the output view does not have the correct shape on receiving ranks or
-   * - any of the MPI calls fails.
+   * function throws an exception if
+   * - an input array/view is not contiguous with positive strides,
+   * - an output array/view is not contiguous with positive strides on receiving ranks or
+   * - if an output view does not have the correct shape on receiving ranks.
    *
-   * The input arrays/views are simply concatenated along their first dimension. The content of the output array/view
-   * depends on the MPI rank and whether it receives the data or not:
+   * The actual gathering is done by calling `mpi::gather_range`. The input arrays/views are simply concatenated along
+   * their first dimension. The content of the output array/view depends on the MPI rank and whether it receives the
+   * data or not:
    * - On receiving ranks, it contains the gathered data and has a shape that is the same as the shape of the input
    * array/view except for the first dimension, which is the sum of the extents of all input arrays/views along the
    * first dimension.
    * - On non-receiving ranks, the output array/view is ignored and left unchanged.
    *
-   * If `mpi::has_env` is false or if the communicator size is < 2, it simply copies the input array/view to the output
-   * array/view.
+   * @note Gathering is only supported for contiguous arrays/views with positive strides and with MPI compatible value
+   * types.
    *
    * @tparam A1 nda::basic_array or nda::basic_array_view type with C-layout.
    * @tparam A2 nda::basic_array or nda::basic_array_view type with C-layout.
@@ -96,62 +93,26 @@ namespace nda {
   template <typename A1, typename A2>
     requires(is_regular_or_view_v<A1> and std::decay_t<A1>::is_stride_order_C()
              and is_regular_or_view_v<A2> and std::decay_t<A2>::is_stride_order_C())
-  void mpi_gather_capi(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false) { // NOLINT
+  void mpi_gather_into(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false) { // NOLINT
     // check the shape of the input arrays/views
     EXPECTS_WITH_MESSAGE(detail::have_mpi_equal_shapes(a_in(nda::range(1), nda::ellipsis{}), comm),
-                         "Error in nda::mpi_gather_capi: Shapes of arrays/views must be equal save the first one");
+                         "Error in nda::mpi_gather_into: Shapes of arrays/views must be equal save the first one");
 
-    // simply copy if there is no active MPI environment or if the communicator size is < 2
-    if (not mpi::has_env || comm.size() < 2) {
-      a_out = a_in;
-      return;
-    }
+    // get output shape
+    auto dims = detail::mpi_gather_shape_impl(a_in, comm, root, all);
 
-    // check if the input arrays/views can be used in the MPI call
-    detail::check_layout_mpi_compatible(a_in, "mpi_gather_capi");
-
-    // get output shape, resize or check the output array/view and prepare output span
-    auto [dims, gathered_size] = detail::mpi_gather_shape_impl(a_in, comm, root, all);
-    auto a_out_span            = std::span{a_out.data(), 0};
-    if (all || (comm.rank() == root)) {
-      // check if the output array/view can be used in the MPI call
-      detail::check_layout_mpi_compatible(a_out, "mpi_gather_capi");
-
-      // resize/check the size of the output array/view
+    // check if the input and output arrays/views can be used in the MPI call and resize or check the output array/view
+    detail::check_layout_mpi_compatible(a_in, "mpi_gather_into");
+    bool const receives = (all || (comm.rank() == root));
+    if (receives) {
+      detail::check_layout_mpi_compatible(a_out, "mpi_gather_into");
       resize_or_check_if_view(a_out, dims);
-
-      // prepare the output span
-      a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
     }
 
     // gather the data
-    auto a_in_span = std::span{a_in.data(), static_cast<std::size_t>(a_in.size())};
-    mpi::gather_range(a_in_span, a_out_span, gathered_size, comm, root, all);
-  }
-
-  /**
-   * @brief Implementation of a lazy MPI gather for nda::basic_array or nda::basic_array_view types.
-   *
-   * @details This function is lazy, i.e. it returns an mpi::lazy<mpi::tag::gather, A> object without performing the
-   * actual MPI operation. Since the returned object models an nda::ArrayInitializer, it can be used to
-   * initialize/assign to nda::basic_array and nda::basic_array_view objects.
-   *
-   * The behavior is otherwise similar to nda::mpi_gather.
-   *
-   * @warning MPI calls are done in the `invoke` and `shape` methods of the `mpi::lazy` object. If one rank calls one of
-   * these methods, all ranks in the communicator need to call the same method. Otherwise, the program will deadlock.
-   *
-   * @tparam A nda::basic_array or nda::basic_array_view type with C-layout.
-   * @param a Array/view to be gathered.
-   * @param comm `mpi::communicator` object.
-   * @param root Rank of the root process.
-   * @param all Should all processes receive the result of the gather.
-   * @return An mpi::lazy<mpi::tag::gather, A> object modelling an nda::ArrayInitializer.
-   */
-  template <typename A>
-    requires(is_regular_or_view_v<A> and std::decay_t<A>::is_stride_order_C())
-  auto lazy_mpi_gather(A &&a, mpi::communicator comm = {}, int root = 0, bool all = false) {
-    return mpi::lazy<mpi::tag::gather, A>{std::forward<A>(a), comm, root, all};
+    auto a_in_span  = std::span{a_in.data(), static_cast<std::size_t>(a_in.size())};
+    auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
+    mpi::gather_range(a_in_span, a_out_span, comm, root, all);
   }
 
   /**
@@ -161,7 +122,7 @@ namespace nda {
    * makes the result available on the root process (`all == false`) or on all processes (`all == true`). The
    * arrays/views are joined along the first dimension.
    *
-   * It simply constructs an empty array and then calls nda::mpi_gather_capi.
+   * It simply constructs an empty array and then calls nda::mpi_gather_into.
    *
    * See @ref ex6_p2 for examples.
    *
@@ -177,81 +138,10 @@ namespace nda {
   auto mpi_gather(A const &a, mpi::communicator comm = {}, int root = 0, bool all = false) {
     using return_t = get_regular_t<A>;
     return_t a_out;
-    mpi_gather_capi(a, a_out, comm, root, all);
+    mpi::gather_into(a, a_out, comm, root, all);
     return a_out;
   }
 
   /** @} */
 
 } // namespace nda
-
-/**
- * @ingroup av_mpi
- * @brief Specialization of the `mpi::lazy` class for nda::Array types and the `mpi::tag::gather` tag.
- *
- * @details An object of this class is returned when gathering nda::Array objects across multiple MPI processes.
- *
- * It models an nda::ArrayInitializer, that means it can be used to initialize and assign to nda::basic_array and
- * nda::basic_array_view objects. The result will be a concatenation of the input arrays/views along their first
- * dimension.
- *
- * See nda::lazy_mpi_gather for an example and more information.
- *
- * @tparam A nda::Array type to be gathered.
- */
-template <nda::Array A>
-struct mpi::lazy<mpi::tag::gather, A> {
-  /// Value type of the array/view.
-  using value_type = typename std::decay_t<A>::value_type;
-
-  /// Type of the array/view stored in the lazy object.
-  using stored_type = A;
-
-  /// Array/View to be gathered.
-  stored_type rhs;
-
-  /// MPI communicator.
-  mpi::communicator comm;
-
-  /// MPI root process.
-  const int root{0}; // NOLINT (const is fine here)
-
-  /// Should all processes receive the result.
-  const bool all{false}; // NOLINT (const is fine here)
-
-  /**
-   * @brief Compute the shape of the nda::ArrayInitializer object.
-   *
-   * @details The input arrays/views are simply concatenated along their first dimension. The shape of the initializer
-   * object depends on the MPI rank and whether it receives the data or not:
-   * - On receiving ranks, the shape is the same as the shape of the input array/view except for the first dimension,
-   * which is the sum of the extents of all input arrays/views along the first dimension.
-   * - On non-receiving ranks, the shape is empty, i.e. `(0,0,...,0)`.
-   *
-   * @warning This makes an MPI call.
-   *
-   * @return Shape of the nda::ArrayInitializer object.
-   */
-  [[nodiscard]] auto shape() const { return nda::detail::mpi_gather_shape_impl(rhs, comm, root, all).first; }
-
-  /**
-   * @brief Execute the lazy MPI operation and write the result to a target array/view.
-   *
-   * @details The data will be gathered directly into the memory handle of the target array/view.
-   *
-   * It is expected that all input arrays/views have the same shape on all processes except for the first dimension. The
-   * function throws an exception, if
-   * - the input array/view is not contiguous with positive strides,
-   * - the target array/view is not contiguous with positive strides on receiving ranks,
-   * - a target view does not have the correct shape on receiving ranks or
-   * - if any of the MPI calls fails.
-   *
-   * @tparam T nda::Array type with C-layout.
-   * @param target Target array/view.
-   */
-  template <nda::Array T>
-    requires(std::decay_t<T>::is_stride_order_C())
-  void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
-    nda::mpi_gather_capi(rhs, target, comm, root, all);
-  }
-};

--- a/c++/nda/mpi/reduce.hpp
+++ b/c++/nda/mpi/reduce.hpp
@@ -33,41 +33,10 @@
 #include <mpi.h>
 #include <mpi/mpi.hpp>
 
-#include <array>
-#include <cmath>
 #include <cstddef>
 #include <span>
 #include <type_traits>
 #include <utility>
-
-namespace nda::detail {
-
-  // Helper function that (all)reduces arrays/views in-place.
-  template <typename A>
-    requires(is_regular_or_view_v<A>)
-  void mpi_reduce_in_place_impl(A &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) { // NOLINT
-    // check the shape of the input arrays/views
-    EXPECTS_WITH_MESSAGE(have_mpi_equal_shapes(a_out, comm), "Error in nda::detail::mpi_reduce_in_place_impl: Shapes of arrays/views must be equal")
-
-    // do nothing if there is no active MPI environment or if the communicator size is < 2
-    if (not mpi::has_env || comm.size() < 2) { return; }
-
-    // reduce the arrays/views
-    using value_type = typename std::decay_t<A>::value_type;
-    if constexpr (not mpi::has_mpi_type<value_type>) {
-      // arrays/views of non-MPI types are reduced element-wise
-      nda::for_each(a_out.shape(), [&](auto... args) { mpi::reduce_in_place(a_out(args...), comm, root, all, op); });
-    } else {
-      // for MPI-types we have to perform some checks on the input/ouput arrays/views
-      check_layout_mpi_compatible(a_out, "detail::mpi_reduce_in_place_impl");
-
-      // reduce the data
-      auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
-      mpi::reduce_in_place_range(a_out_span, comm, root, all, op);
-    }
-  }
-
-} // namespace nda::detail
 
 namespace nda {
 
@@ -77,28 +46,25 @@ namespace nda {
    */
 
   /**
-   * @brief Implementation of an MPI reduce for nda::basic_array or nda::basic_array_view types using a C-style API.
+   * @brief Implementation of an MPI reduce for nda::basic_array or nda::basic_array_view types that reduces directly
+   * into an existing array/view.
    *
    * @details The function reduces input arrays/views from all processes in the given communicator and makes the result
    * available on the root process (`all == false`) or on all processes (`all == true`).
    *
    * It is expected that all input arrays/views have the same shape on all processes. The function throws an exception,
-   * if
-   * - the input array/view is not contiguous with positive strides (only for MPI compatible types),
-   * - the output array/view is not contiguous with positive strides on receiving ranks,
-   * - the output view does not have the correct shape on receiving ranks,
-   * - the data storage of the output array/view overlaps with the input array/view or
-   * - any of the MPI calls fails.
+   * if an output view does not have the correct shape on receiving ranks.
    *
-   * The content of the output array/view depends on the MPI rank and whether it receives the data or not:
+   * The actual reduction is done by calling `mpi::reduce_range`. The content of the output array/view depends on the
+   * MPI rank and whether it receives the data or not:
    * - On receiving ranks, it contains the reduced data and has a shape that is the same as the shape of the input
    * array/view.
    * - On non-receiving ranks, the output array/view is ignored and left unchanged.
    *
-   * Types which cannot be reduced directly, i.e. which do not have an MPI type, are reduced element-wise.
-   *
-   * If `mpi::has_env` is false or if the communicator size is < 2, it simply copies the input array/view to the output
-   * array/view.
+   * @note If the input/output arrays/views are contiguous with positive strides and if the value type is MPI
+   * compatible, the data is reduced using a single `MPI_Reduce` or `MPI_Allreduce` call. Otherwise, the data is reduced
+   * element-wise, which can have considerable performance implications. Consider copying the data into a contiguous
+   * array/view before reducing.
    *
    * @tparam A1 nda::basic_array or nda::basic_array_view type.
    * @tparam A2 nda::basic_array or nda::basic_array_view type.
@@ -111,91 +77,32 @@ namespace nda {
    */
   template <typename A1, typename A2>
     requires(is_regular_or_view_v<A1> && is_regular_or_view_v<A2>)
-  void mpi_reduce_capi(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) { // NOLINT
+  void mpi_reduce_into(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) { // NOLINT
     // check the shape of the input arrays/views
-    EXPECTS_WITH_MESSAGE(detail::have_mpi_equal_shapes(a_in, comm), "Error in nda::mpi_reduce_capi: Shapes of arrays/views must be equal")
+    EXPECTS_WITH_MESSAGE(detail::have_mpi_equal_shapes(a_in, comm), "Error in nda::mpi_reduce_into: Shapes of arrays/views must be equal");
 
-    // simply copy if there is no active MPI environment or if the communicator size is < 2
-    if (not mpi::has_env || comm.size() < 2) {
-      a_out = a_in;
-      return;
-    }
+    // resize or check the output array/view on receiving ranks
+    bool const receives = (all || (comm.rank() == root));
+    if (receives) resize_or_check_if_view(a_out, a_in.shape());
 
-    // reduce the arrays/views
-    using value_type = typename std::decay_t<A1>::value_type;
-    if constexpr (not mpi::has_mpi_type<value_type>) {
-      // arrays/views of non-MPI types are reduced element-wise
-      a_out = nda::map([&](auto const &x) { return mpi::reduce(x, comm, root, all, op); })(a_in);
-    } else {
-      // for MPI-types we have to perform some checks on the input and ouput arrays/views
-      detail::check_layout_mpi_compatible(a_in, "mpi_reduce_capi");
-      if ((comm.rank() == root) || all) {
-        detail::check_layout_mpi_compatible(a_out, "mpi_reduce_capi");
-        resize_or_check_if_view(a_out, a_in.shape());
-        if (std::abs(a_out.data() - a_in.data()) < a_in.size()) NDA_RUNTIME_ERROR << "Error in nda::mpi_reduce_capi: Overlapping arrays";
+    // call mpi::reduce_range with a span if the input and output arrays/views are contiguous with positive strides
+    // (on non-receiving ranks, the output should always be contiguous since it is not used)
+    if (a_in.is_contiguous() and a_in.has_positive_strides()) {
+      auto a_in_span = std::span{a_in.data(), static_cast<std::size_t>(a_in.size())};
+      if ((a_out.is_contiguous() and a_out.has_positive_strides()) || !receives) {
+        auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
+        mpi::reduce_range(a_in_span, a_out_span, comm, root, all, op);
+      } else {
+        mpi::reduce_range(a_in_span, a_out, comm, root, all, op);
       }
-
-      // reduce the data
-      auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
-      auto a_in_span  = std::span{a_in.data(), static_cast<std::size_t>(a_in.size())};
-      mpi::reduce_range(a_in_span, a_out_span, comm, root, all, op);
+    } else {
+      if ((a_out.is_contiguous() and a_out.has_positive_strides()) || !receives) {
+        auto a_out_span = std::span{a_out.data(), static_cast<std::size_t>(a_out.size())};
+        mpi::reduce_range(a_in, a_out_span, comm, root, all, op);
+      } else {
+        mpi::reduce_range(a_in, a_out, comm, root, all, op);
+      }
     }
-  }
-
-  /**
-   * @brief Implementation of a lazy MPI reduce for nda::basic_array or nda::basic_array_view types.
-   *
-   * @details This function is lazy, i.e. it returns an mpi::lazy<mpi::tag::reduce, A> object without performing the
-   * actual MPI operation. Since the returned object models an nda::ArrayInitializer, it can be used to
-   * initialize/assign to nda::basic_array and nda::basic_array_view objects:
-   *
-   * The behavior is otherwise similar to nda::mpi_reduce and nda::mpi_reduce_in_place.
-   *
-   * The reduction is performed in-place if the target and input array/view are the same, e.g.
-   *
-   * @code{.cpp}
-   * A = mpi::reduce(A);
-   * @endcode
-   *
-   * @warning MPI calls are done in the `invoke` method of the `mpi::lazy` object. If one rank calls this methods, all
-   * ranks in the communicator need to call the same method. Otherwise, the program will deadlock.
-   *
-   * @tparam A nda::basic_array or nda::basic_array_view type.
-   * @param a Array/view to be reduced.
-   * @param comm `mpi::communicator` object.
-   * @param root Rank of the root process.
-   * @param all Should all processes receive the result of the reduction.
-   * @param op MPI reduction operation.
-   * @return An mpi::lazy<mpi::tag::reduce, A> object modelling an nda::ArrayInitializer.
-   */
-  template <typename A>
-    requires(is_regular_or_view_v<A>)
-  auto lazy_mpi_reduce(A &&a, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
-    return mpi::lazy<mpi::tag::reduce, A>{std::forward<A>(a), comm, root, all, op};
-  }
-
-  /**
-   * @brief Implementation of an in-place MPI reduce for nda::basic_array or nda::basic_array_view types.
-   *
-   * @details The function in-place reduces arrays/views from all processes in the given communicator and makes the
-   * result available on the root process (`all == false`) or on all processes (`all == true`).
-   *
-   * The behavior and requirements are similar to nda::mpi_reduce, except that the function does not return a new array.
-   * Instead it writes the result directly into the given array/view on receiving ranks.
-   *
-   * See @ref ex6_p4 for an example.
-   *
-   * @tparam A nda::basic_array or nda::basic_array_view type.
-   * @param a Array/view to be reduced.
-   * @param comm `mpi::communicator` object.
-   * @param root Rank of the root process.
-   * @param all Should all processes receive the result of the reduction.
-   * @param op MPI reduction operation.
-   */
-  template <typename A>
-    requires(is_regular_or_view_v<A>)
-  void mpi_reduce_in_place(A &&a, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) { // NOLINT
-    detail::mpi_reduce_in_place_impl(a, comm, root, all, op);
   }
 
   /**
@@ -204,9 +111,21 @@ namespace nda {
    * @details The function reduces input arrays/views from all processes in the given communicator and makes the result
    * available on the root process (`all == false`) or on all processes (`all == true`).
    *
-   * It simply constructs an empty array and then calls nda::mpi_gather_capi.
+   * It first default constructs an nda::basic_array object on the heap with its value type equal to the return type of
+   * `reduce(std::declval<get_value_t<A>>())` and the same rank and algebra as the input array/view. On receiving ranks,
+   * the output array is then resized to the shape of the input array/view.
+   *
+   * The actual reduction is done by calling nda::mpi_reduce_into with the input array/view and the constructed output
+   * array. The content of the returned array depends on the MPI rank and whether it receives the data or not:
+   * - On receiving ranks, it contains the reduced data.
+   * - On non-receiving ranks, the array is empty.
    *
    * See @ref ex6_p4 for an example.
+   *
+   * @note If the input arrays/views are contiguous with positive strides and if the value type is MPI compatible, the
+   * data is reduced using a single `MPI_Reduce` or `MPI_Allreduce` call. Otherwise, the data is reduced element-wise,
+   * which can have considerable performance implications. Consider copying the data into a contiguous array/view before
+   * reducing.
    *
    * @tparam A nda::basic_array or nda::basic_array_view type.
    * @param a Array/view to be reduced.
@@ -219,92 +138,13 @@ namespace nda {
   template <typename A>
     requires(is_regular_or_view_v<A>)
   auto mpi_reduce(A const &a, mpi::communicator comm = {}, int root = 0, bool all = false, MPI_Op op = MPI_SUM) {
-    using return_t = get_regular_t<A>;
+    using value_t  = std::remove_cvref_t<decltype(mpi::reduce(std::declval<get_value_t<A>>()))>;
+    using return_t = basic_array<value_t, get_rank<A>, typename A::layout_policy_t::contiguous_t, get_algebra<A>, heap<>>;
     return_t a_out;
-    mpi_reduce_capi(a, a_out, comm, root, all, op);
+    mpi_reduce_into(a, a_out, comm, root, all, op);
     return a_out;
   }
 
   /** @} */
 
 } // namespace nda
-
-/**
- * @ingroup av_mpi
- * @brief Specialization of the `mpi::lazy` class for nda::Array types and the `mpi::tag::reduce` tag.
- *
- * @details An object of this class is returned when reducing nda::Array objects across multiple MPI processes.
- *
- * It models an nda::ArrayInitializer, that means it can be used to initialize and assign to nda::basic_array and
- * nda::basic_array_view objects. The result will be the reduction of the input arrays/views with respect to the given
- * MPI operation.
- *
- * See nda::lazy_mpi_reduce for an example.
- *
- * @tparam A nda::Array type to be reduced.
- */
-template <nda::Array A>
-struct mpi::lazy<mpi::tag::reduce, A> {
-  /// Value type of the array/view.
-  using value_type = typename std::decay_t<A>::value_type;
-
-  /// Type of the array/view stored in the lazy object.
-  using stored_type = A;
-
-  /// Array/View to be reduced.
-  stored_type rhs;
-
-  /// MPI communicator.
-  mpi::communicator comm;
-
-  /// MPI root process.
-  const int root{0}; // NOLINT (const is fine here)
-
-  /// Should all processes receive the result.
-  const bool all{false}; // NOLINT (const is fine here)
-
-  /// MPI reduction operation.
-  const MPI_Op op{MPI_SUM}; // NOLINT (const is fine here)
-
-  /**
-   * @brief Compute the shape of the nda::ArrayInitializer object.
-   *
-   * @details The shape of the initializer objects depends on the MPI rank and whether it receives the data or not:
-   *
-   * - On receiving ranks, the shape is the same as the shape of the input array/view.
-   * - On non-receiving ranks, the shape has the rank of the input array/view with only zeros, i.e. it is empty.
-   *
-   * @return Shape of the nda::ArrayInitializer object.
-   */
-  [[nodiscard]] auto shape() const {
-    if ((comm.rank() == root) || all) return rhs.shape();
-    return std::array<long, std::remove_cvref_t<stored_type>::rank>{};
-  }
-
-  /**
-   * @brief Execute the lazy MPI operation and write the result to a target array/view.
-   *
-   * @details The data will be reduced directly into the memory handle of the target array/view. If the target
-   * array/view is the same as the input array/view, i.e. if their data pointers are the same, the reduction is
-   * performed in-place.
-   *
-   * Types which cannot be reduced directly, i.e. which do not have an MPI type, are reduced element-wise.
-   *
-   * For MPI compatible types, the function throws an exception, if
-   * - the input array/view is not contiguous with positive strides.
-   * - the target array/view is not contiguous with positive strides on receiving ranks.
-   * - the operation is performed in-place but the target and input array have different sizes.
-   * - the operation is performed out-of-place and the memory of the target and input array/view overlap.
-   *
-   * @tparam T nda::Array type of the target array/view.
-   * @param target Target array/view.
-   */
-  template <nda::Array T>
-  void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
-    if (target.data() == rhs.data()) {
-      nda::detail::mpi_reduce_in_place_impl(target, comm, root, all, op);
-    } else {
-      nda::mpi_reduce_capi(rhs, target, comm, root, all, op);
-    }
-  }
-};

--- a/c++/nda/mpi/scatter.hpp
+++ b/c++/nda/mpi/scatter.hpp
@@ -40,7 +40,8 @@
 
 namespace nda::detail {
 
-  // Helper function to get the shape and total size of the scattered array/view.
+  // Helper function to get the shape and total size of the scattered array/view as well as the stride along the first
+  // dimension.
   template <typename A>
     requires(is_regular_or_view_v<A> and std::decay_t<A>::is_stride_order_C())
   auto mpi_scatter_shape_impl(A const &a, mpi::communicator comm, int root) {
@@ -62,7 +63,8 @@ namespace nda {
    */
 
   /**
-   * @brief Implementation of an MPI scatter for nda::basic_array or nda::basic_array_view types using a C-style API.
+   * @brief Implementation of an MPI scatter for nda::basic_array or nda::basic_array_view types that scatters directly
+   * into an existing array/view.
    *
    * @details The function scatters a C-ordered input array/view from a root process across all processes in the given
    * communicator. The array/view is chunked into equal parts along the first dimension using `mpi::chunk_length`.
@@ -70,16 +72,16 @@ namespace nda {
    * It is expected that all input arrays/views have the same rank on all processes. The function throws an exception,
    * if
    * - the input array/view is not contiguous with positive strides on the root process,
-   * - the output array/view is not contiguous with positive strides,
-   * - the output view does not have the correct shape or
-   * - any of the MPI calls fails.
+   * - an output array/view is not contiguous with positive strides or
+   * - an output view does not have the correct shape.
    *
-   * The input array/view on the root process is chunked along the first dimension into equal (as much as possible)
-   * parts using `mpi::chunk_length`. If the extent of the input array along the first dimension is not divisible by the
-   * number of processes, processes with lower ranks will receive more data than processes with higher ranks.
+   * The actual scattering is done by calling `mpi::scatter_range`. The input array/view on the root process is chunked
+   * along the first dimension into equal (as much as possible) parts using `mpi::chunk_length`. If the extent of the
+   * input array along the first dimension is not divisible by the number of processes, processes with lower ranks will
+   * receive more data than processes with higher ranks.
    *
-   * If `mpi::has_env` is false or if the communicator size is < 2, it simply copies the input array/view to the output
-   * array/view.
+   * @note Scattering is only supported for contiguous arrays/views with positive strides and with MPI compatible value
+   * types.
    *
    * @tparam A1 nda::basic_array or nda::basic_array_view type with C-layout.
    * @tparam A2 nda::basic_array or nda::basic_array_view type with C-layout.
@@ -91,19 +93,13 @@ namespace nda {
   template <typename A1, typename A2>
     requires(is_regular_or_view_v<A1> and std::decay_t<A1>::is_stride_order_C()
              and is_regular_or_view_v<A2> and std::decay_t<A2>::is_stride_order_C())
-  void mpi_scatter_capi(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0) { // NOLINT
+  void mpi_scatter_into(A1 const &a_in, A2 &&a_out, mpi::communicator comm = {}, int root = 0) { // NOLINT
     // check the ranks of the input arrays/views
-    EXPECTS_WITH_MESSAGE(detail::have_mpi_equal_ranks(a_in, comm), "Error in nda::mpi_scatter_capi: Ranks of arrays/views must be equal")
-
-    // simply copy if there is no active MPI environment or if the communicator size is < 2
-    if (not mpi::has_env || comm.size() < 2) {
-      a_out = a_in;
-      return;
-    }
+    EXPECTS_WITH_MESSAGE(detail::have_mpi_equal_ranks(a_in, comm), "Error in nda::mpi_scatter_into: Ranks of arrays/views must be equal")
 
     // check if the input and output arrays/views can be used in the MPI call
-    if (comm.rank() == root) detail::check_layout_mpi_compatible(a_in, "mpi_scatter_capi");
-    detail::check_layout_mpi_compatible(a_out, "mpi_scatter_capi");
+    if (comm.rank() == root) detail::check_layout_mpi_compatible(a_in, "mpi_scatter_into");
+    detail::check_layout_mpi_compatible(a_out, "mpi_scatter_into");
 
     // get output shape and resize or check the output array/view
     auto [dims, scattered_size, stride0] = detail::mpi_scatter_shape_impl(a_in, comm, root);
@@ -116,36 +112,12 @@ namespace nda {
   }
 
   /**
-   * @brief Implementation of a lazy MPI scatter for nda::basic_array or nda::basic_array_view types.
-   *
-   * @details This function is lazy, i.e. it returns an mpi::lazy<mpi::tag::scatter, A> object without performing the
-   * actual MPI operation. Since the returned object models an nda::ArrayInitializer, it can be used to
-   * initialize/assign to nda::basic_array and nda::basic_array_view objects.
-   *
-   * The behavior is otherwise similar to nda::mpi_scatter.
-   *
-   * @warning MPI calls are done in the `invoke` and `shape` methods of the `mpi::lazy` object. If one rank calls one of
-   * these methods, all ranks in the communicator need to call the same method. Otherwise, the program will deadlock.
-   *
-   * @tparam A nda::basic_array or nda::basic_array_view type.
-   * @param a Array/view to be scattered.
-   * @param comm `mpi::communicator` object.
-   * @param root Rank of the root process.
-   * @return An mpi::lazy<mpi::tag::scatter, A> object modelling an nda::ArrayInitializer.
-   */
-  template <typename A>
-    requires(is_regular_or_view_v<A> and std::decay_t<A>::is_stride_order_C())
-  auto lazy_mpi_scatter(A &&a, mpi::communicator comm = {}, int root = 0) {
-    return mpi::lazy<mpi::tag::scatter, A>{std::forward<A>(a), comm, root, true};
-  }
-
-  /**
    * @brief Implementation of an MPI scatter for nda::basic_array or nda::basic_array_view types.
    *
    * @details The function scatters a C-ordered input array/view from a root process across all processes in the given
    * communicator. The array/view is chunked into equal parts along the first dimension using `mpi::chunk_length`.
    *
-   * It simply constructs an empty array and then calls nda::mpi_scatter_capi.
+   * It simply constructs an empty array and then calls nda::mpi_scatter_into.
    *
    * See @ref ex6_p3 for an example.
    *
@@ -160,81 +132,10 @@ namespace nda {
   auto mpi_scatter(A const &a, mpi::communicator comm = {}, int root = 0) {
     using return_t = get_regular_t<A>;
     return_t a_out;
-    mpi_scatter_capi(a, a_out, comm, root);
+    mpi::scatter_into(a, a_out, comm, root);
     return a_out;
   }
 
   /** @} */
 
 } // namespace nda
-
-/**
- * @ingroup av_mpi
- * @brief Specialization of the `mpi::lazy` class for nda::Array types and the `mpi::tag::scatter` tag.
- *
- * @details An object of this class is returned when scattering nda::Array objects across multiple MPI processes.
- *
- * It models an nda::ArrayInitializer, that means it can be used to initialize and assign to nda::basic_array and
- * nda::basic_array_view objects. The input array/view on the root process will be chunked along the first dimension
- * into equal parts using `mpi::chunk_length` and scattered across all processes in the communicator.
- *
- * See nda::mpi_scatter for an example and more information.
- *
- * @tparam A nda::Array type to be scattered.
- */
-template <nda::Array A>
-struct mpi::lazy<mpi::tag::scatter, A> {
-  /// Value type of the array/view.
-  using value_type = typename std::decay_t<A>::value_type;
-
-  /// Type of the array/view stored in the lazy object.
-  using stored_type = A;
-
-  /// Array/View to be scattered.
-  stored_type rhs;
-
-  /// MPI communicator.
-  mpi::communicator comm;
-
-  /// MPI root process.
-  const int root{0}; // NOLINT (const is fine here)
-
-  /// Should all processes receive the result. (doesn't make sense for scatter)
-  const bool all{false}; // NOLINT (const is fine here)
-
-  /**
-   * @brief Compute the shape of the nda::ArrayInitializer object.
-   *
-   * @details The input array/view on the root process is chunked along the first dimension into equal (as much as
-   * possible) parts using `mpi::chunk_length`.
-   *
-   * If the extent of the input array along the first dimension is not divisible by the number of processes, processes
-   * with lower ranks will receive more data than processes with higher ranks.
-   *
-   * @warning This makes an MPI call.
-   *
-   * @return Shape of the nda::ArrayInitializer object.
-   */
-  [[nodiscard]] auto shape() const { return std::get<0>(nda::detail::mpi_scatter_shape_impl(rhs, comm, root)); }
-
-  /**
-   * @brief Execute the lazy MPI operation and write the result to a target array/view.
-   *
-   * @details The data will be scattered directly into the memory handle of the target array/view.
-   *
-   * It is expected that all input arrays/views have the same rank on all processes. The function throws an exception,
-   * if
-   * - the input array/view on the root process is not contiguous with positive strides,
-   * - the target array/view is not contiguous with positive,
-   * - a target view does not have the correct shape or
-   * - if any of the MPI calls fails.
-   *
-   * @tparam T nda::Array type with C-layout.
-   * @param target Target array/view.
-   */
-  template <nda::Array T>
-    requires(std::decay_t<T>::is_stride_order_C())
-  void invoke(T &&target) const { // NOLINT (temporary views are allowed here)
-    nda::mpi_scatter_capi(rhs, target, comm, root);
-  }
-};

--- a/doc/DoxygenLayout.xml
+++ b/doc/DoxygenLayout.xml
@@ -57,11 +57,7 @@
         </tab>
         <tab type="user" url="@ref av_factories" title="Factories and transformations"/>
         <tab type="user" url="@ref av_hdf5" title="HDF5 support"/>
-        <tab type="usergroup" url="@ref av_mpi" title="MPI support">
-          <tab type="user" url="@ref mpi::lazy< mpi::tag::gather, A >" title="mpi::lazy<mpi::tag::gather, A>"/>
-          <tab type="user" url="@ref mpi::lazy< mpi::tag::reduce, A >" title="mpi::lazy<mpi::tag::reduce, A>"/>
-          <tab type="user" url="@ref mpi::lazy< mpi::tag::scatter, A >" title="mpi::lazy<mpi::tag::scatter, A>"/>
-        </tab>
+        <tab type="user" url="@ref av_mpi" title="MPI support"/>
         <tab type="usergroup" url="@ref av_math" title="Mathematical functions">
           <tab type="user" url="@ref nda::expr_call" title="expr_call"/>
           <tab type="user" url="@ref nda::mapped" title="mapped"/>

--- a/doc/ex6.md
+++ b/doc/ex6.md
@@ -158,8 +158,10 @@ Rank 3:
  [0,0,0,1]]
 ```
 
-If `A` would not be in Fortran-order, this code snippet wouldn't compile since the elements of a single column are not
-contiguous in memory in C-order.
+If `A` would not be in Fortran-order, this code snippet would still compile and also give us the expected output.
+However, since the elements of a single column are not contiguous in memory in C-order, it would broadcast each element
+separately. This can have enormous implications on the performance. We recommend to always use MPI routines with
+contiguous arrays/views, so that **nda** can make the MPI calls as efficiently as possible.
 
 > **Note**: All MPI routines have certain requirements for the arrays/views involved in the operation. Please check out
 > the documentation of the individual function, e.g. in this case nda::mpi_broadcast, if you have doubts.
@@ -342,7 +344,7 @@ Rank 3:
  [3,3]]
 ```
 
-Similar to the nda::mpi_gather, nda::mpi_scatter requires the input and output arrays to be in C-order.
+Similar to nda::mpi_gather, nda::mpi_scatter requires the input and output arrays to be in C-order.
 
 If the extent along the first dimension is not divisible by the number of MPI ranks, processes with lower ranks will
 receive more data than others:
@@ -438,3 +440,40 @@ Rank 1:
 
 In contrast to the standard `mpi::all_reduce` function, the in-place operation does not create and return a new array.
 Instead the result is directly written into the input array.
+
+@subsection ex6_p5 Using existing arrays/views
+
+Note that the functions nda::mpi_reduce, nda::mpi_gather and nda::mpi_scatter all return a newly constructed array which
+contains the result of the respective MPI operation.
+In case of large amounts of data, constructing a new obejct can be expensive and use a lot of additional memory.
+
+If there already exists an array/view that can be used as a receive (output) buffer, we can avoid this additional
+overhead by calling nda::mpi_reduce_into, nda::mpi_gather_into or nda::mpi_scatter_into instead.
+The `mpi_xxx_into` functions work exactly as their `mpi_xxx` counterparts except that they take an additional array/view
+as an argument into which the results are written, e.g.
+
+```cpp
+// scatter a view into an existing array
+auto C_into = nda::array<int, 2>(2, 2);
+mpi::scatter_into(B_rg, C_into, comm, root);
+print(C_into, comm);
+comm.barrier();
+```
+
+Output:
+
+```
+Rank 0:
+[[0,0]
+ [0,0]]
+Rank 2:
+[[2,2]
+ [2,2]]
+Rank 3:
+[[3,3]
+ [3,3]]
+Rank 1:
+[[1,1]
+ [1,1]]
+```
+

--- a/doc/groups.dox
+++ b/doc/groups.dox
@@ -193,6 +193,8 @@
  * [[6,6]
  *  [6,6]]
  * ```
+ *
+ * Se @ref ex6 for a more in-depth example.
  */
 
 /**

--- a/test/c++/nda_mpi.cpp
+++ b/test/c++/nda_mpi.cpp
@@ -189,6 +189,29 @@ TEST_F(NDAMpi, BroadcastOtherLayouts) {
   }
 }
 
+TEST_F(NDAMpi, BroadcastNonContiguousLayouts) {
+  // broadcast a non-contiguous array view
+  auto A_bcast = A;
+  if (mpi_rank == root) {
+    mpi::broadcast(A_bcast(nda::range(0, 6, 2), nda::range(0, 4, 2), _), comm, root);
+    EXPECT_ARRAY_EQ(A, A_bcast);
+  } else {
+    mpi::broadcast(A_bcast(nda::range(1, 6, 2), nda::range(1, 4, 2), _), comm, root);
+    EXPECT_ARRAY_EQ(A(nda::range(0, 6, 2), nda::range(0, 4, 2), _), A_bcast(nda::range(0, 6, 2), nda::range(0, 4, 2), _));
+    EXPECT_ARRAY_EQ(A(nda::range(0, 6, 2), nda::range(0, 4, 2), _), A_bcast(nda::range(1, 6, 2), nda::range(1, 4, 2), _));
+  }
+}
+
+TEST_F(NDAMpi, BroadcastCustomType) {
+  // broadcast a vector of matrices
+  using matrix_t = nda::matrix<std::complex<double>>;
+  nda::vector<matrix_t> B(5), B_exp(5);
+  for (int i = 0; i < 5; ++i) B_exp(i) = M * (i + 1);
+  if (mpi_rank == root) B = B_exp;
+  mpi::broadcast(B, comm, root);
+  for (int i = 0; i < 5; ++i) EXPECT_ARRAY_EQ(B_exp(i), B(i));
+}
+
 TEST_F(NDAMpi, Gather1DArray) {
   // allgather 1-dimensional arrays of different sizes
   auto C        = nda::vector<int>(mpi_rank + 1, mpi_rank);
@@ -197,6 +220,17 @@ TEST_F(NDAMpi, Gather1DArray) {
   for (int ofs = 0, r = 0; r < mpi_size; ofs += ++r) {
     auto view = C_gather(nda::range(ofs, ofs + r + 1));
     auto exp  = nda::vector<int>(r + 1, r);
+    EXPECT_ARRAY_EQ(exp, view);
+  }
+
+  // allgather 1-dimensional array into a 2-dimensional array
+  C      = nda::vector<int>(3, mpi_rank);
+  auto D = nda::matrix<int>{};
+  mpi::all_gather_into(nda::array_view<int, 2>{std::array{1l, 3l}, C.data()}, D, comm);
+  EXPECT_EQ(D.shape(), (std::array{mpi_size, 3l}));
+  for (int r = 0; r < mpi_size; ++r) {
+    auto view = D(r, _);
+    auto exp  = nda::vector<int>(3, r);
     EXPECT_ARRAY_EQ(exp, view);
   }
 }
@@ -243,35 +277,21 @@ TEST_F(NDAMpi, GatherOtherLayouts) {
   }
 }
 
-TEST_F(NDAMpi, GatherCustomType) {
-  // allgather an array of matrices
-  using matrix_t = nda::matrix<int>;
-  nda::vector<matrix_t> B(2);
-  nda::vector<matrix_t> exp(2 * mpi_size);
-  for (int r = 0; r < mpi_size; ++r) {
-    exp(r * 2)     = matrix_t::ones(shape_2d) * r;
-    exp(r * 2 + 1) = matrix_t::ones(shape_2d) * (r + 1);
-    if (r == mpi_rank) {
-      B(0) = exp(r * 2);
-      B(1) = exp(r * 2 + 1);
-    }
+TEST_F(NDAMpi, Scatter1DArray) {
+  // scatter 1-dimensional array
+  auto C = nda::vector<int>{};
+  if (mpi_rank == root) {
+    C.resize(mpi_size * 4);
+    for (long r = 0; r < mpi_size; ++r) C(nda::range(4 * r, 4 * (r + 1))) = r;
   }
+  auto C_scatter = mpi::scatter(C, comm);
+  EXPECT_EQ(C_scatter.size(), 4);
+  EXPECT_ARRAY_EQ(C_scatter, nda::vector<int>(4, mpi_rank));
 
-  auto B_gathered = mpi::all_gather(B, comm);
-  EXPECT_EQ(B_gathered.shape(), std::array{2l * mpi_size});
-  for (int i = 0; i < B_gathered.size(); ++i) { EXPECT_ARRAY_EQ(exp(i), B_gathered(i)); }
-}
-
-TEST_F(NDAMpi, LazyGather) {
-  // lazy-allgather 1-dimensional arrays of different sizes
-  auto C               = nda::vector<int>(mpi_rank + 1, mpi_rank);
-  decltype(C) C_gather = nda::lazy_mpi_gather(C, comm, root, true);
-  EXPECT_EQ(C_gather.size(), mpi_size * (mpi_size + 1) / 2);
-  for (int ofs = 0, r = 0; r < mpi_size; ofs += ++r) {
-    auto view = C_gather(nda::range(ofs, ofs + r + 1));
-    auto exp  = nda::vector<int>(r + 1, r);
-    EXPECT_ARRAY_EQ(exp, view);
-  }
+  // scatter 1-dimensional array into a column of an F-layout matrix
+  auto D = nda::matrix<int, nda::F_layout>::zeros(4, 2);
+  mpi::scatter_into(C, D(_, 0), comm);
+  EXPECT_ARRAY_EQ(D(_, 0), nda::vector<int>(4, mpi_rank));
 }
 
 TEST_F(NDAMpi, ScatterCLayout) {
@@ -303,66 +323,95 @@ TEST_F(NDAMpi, ScatterOtherLayouts) {
   EXPECT_ARRAY_EQ(A2(nda::range::all, nda::range(rg.first, rg.second), nda::range::all), A2_scatter_v);
 }
 
-TEST_F(NDAMpi, LazyScatter) {
-  // lazy-scatter a C-layout array
-  decltype(A) A_scatter1 = nda::lazy_mpi_scatter(A, comm);
-  auto [beg1, end1]      = itertools::chunk_range(0, A.shape()[0], comm.size(), comm.rank());
-  auto exp_shape1        = std::array{end1 - beg1, shape_3d[1], shape_3d[2]};
-  EXPECT_EQ(exp_shape1, A_scatter1.shape());
-  EXPECT_ARRAY_EQ(A(nda::range(beg1, end1), nda::ellipsis{}), A_scatter1);
-
-  // scatter a C-layout array view
-  auto A_scatter2   = nda::array<long, 2>(nda::lazy_mpi_scatter(A(0, nda::ellipsis{}), comm));
-  auto [beg2, end2] = itertools::chunk_range(0, A.shape()[1], comm.size(), comm.rank());
-  auto exp_shape2   = std::array{end2 - beg2, shape_3d[2]};
-  EXPECT_EQ(exp_shape2, A_scatter2.shape());
-  EXPECT_ARRAY_EQ(A(0, nda::range(beg2, end2), nda::ellipsis{}), A_scatter2);
-}
-
 TEST_F(NDAMpi, ReduceCLayout) {
   // reduce an array
-  auto A_sum = mpi::reduce(A, comm);
-  if (mpi_rank == 0) { EXPECT_ARRAY_EQ(A * mpi_size, A_sum); }
+  auto A_sum = mpi::reduce(A, comm, root);
+  if (mpi_rank == root) { EXPECT_ARRAY_EQ(A * mpi_size, A_sum); }
 
   // allreduce an array
   auto A_sum_all = mpi::all_reduce(A, comm);
   EXPECT_ARRAY_EQ(A * mpi_size, A_sum_all);
 
-  // allreduce an array view
+  // (all)reduce an array view
   auto B     = nda::make_regular(A * (mpi_rank + 1));
   auto B_max = mpi::all_reduce(B(0, 0, _), comm, MPI_MAX);
   EXPECT_ARRAY_EQ(B_max, A(0, 0, _) * mpi_size);
-  auto B_min = mpi::reduce(B(0, 0, _), comm, mpi_size - 1, false, MPI_MIN);
-  if (mpi_rank == mpi_size - 1) EXPECT_ARRAY_EQ(B_min, A(0, 0, _));
+  auto B_min = mpi::reduce(B(0, 0, _), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B_min, A(0, 0, _)); }
+}
+
+TEST_F(NDAMpi, ReduceCLayoutIntoExistingArray) {
+  // reduce an array into an existing array
+  auto A_sum = nda::zeros<long>(A.shape());
+  mpi::reduce_into(A, A_sum, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(A * mpi_size, A_sum);
+  } else {
+    EXPECT_ARRAY_EQ(A_sum, nda::zeros<long>(A.shape()));
+  }
+
+  // allreduce an array into an existing array
+  mpi::all_reduce_into(A, A_sum, comm);
+  EXPECT_ARRAY_EQ(A * mpi_size, A_sum);
+
+  // (all)reduce an array view into an existing array view
+  auto B = nda::make_regular(A * (mpi_rank + 1));
+  mpi::all_reduce_into(B(0, 0, _), B(1, 1, _), comm, MPI_MAX);
+  EXPECT_ARRAY_EQ(B(1, 1, _), A(0, 0, _) * mpi_size);
+  mpi::reduce_into(B(0, 0, _), B(2, 2, _), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B(2, 2, _), A(0, 0, _)); }
 }
 
 TEST_F(NDAMpi, ReduceCLayoutInPlace) {
-  // in-place reduce an array
+  // in place reduce an array
   auto B = A;
-  mpi::reduce_in_place(B, comm);
-  if (mpi_rank == 0) {
+  mpi::reduce_in_place(B, comm, root);
+  if (mpi_rank == root) {
     EXPECT_ARRAY_EQ(A * mpi_size, B);
   } else {
     EXPECT_ARRAY_EQ(A, B)
   };
 
-  // in-place allreduce an array
+  // in place allreduce an array
   B = A;
   mpi::all_reduce_in_place(B, comm);
   EXPECT_ARRAY_EQ(A * mpi_size, B);
 
-  // in-place (all)reduce an array view
+  // in place (all)reduce an array view
   B = A * (mpi_rank + 1);
   mpi::all_reduce_in_place(B(0, 0, _), comm, MPI_MAX);
   EXPECT_ARRAY_EQ(B(0, 0, _), A(0, 0, _) * mpi_size);
-  mpi::reduce_in_place(B(0, 1, _), comm, mpi_size - 1, false, MPI_MIN);
-  if (mpi_rank == mpi_size - 1) EXPECT_ARRAY_EQ(B(0, 1, _), A(0, 1, _));
+  mpi::reduce_in_place(B(0, 1, _), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B(0, 1, _), A(0, 1, _)); }
+}
+
+TEST_F(NDAMpi, ReduceCLayoutInPlaceWithMPIReduceInto) {
+  // in place reduce an array using mpi_reduce_into
+  auto B = A;
+  mpi::reduce_into(B, B, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(A * mpi_size, B);
+  } else {
+    EXPECT_ARRAY_EQ(A, B)
+  };
+
+  // in place allreduce an array using mpi_reduce_into
+  B = A;
+  mpi::all_reduce_into(B, B, comm);
+  EXPECT_ARRAY_EQ(A * mpi_size, B);
+
+  // in place (all)reduce an array view using mpi_reduce_into
+  B = A * (mpi_rank + 1);
+  mpi::all_reduce_into(B(0, 0, _), B(0, 0, _), comm, MPI_MAX);
+  EXPECT_ARRAY_EQ(B(0, 0, _), A(0, 0, _) * mpi_size);
+  mpi::reduce_into(B(0, 1, _), B(0, 1, _), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B(0, 1, _), A(0, 1, _)); }
 }
 
 TEST_F(NDAMpi, ReduceOtherLayouts) {
   // reduce an array
-  auto A2_sum = mpi::reduce(A2, comm);
-  if (mpi_rank == 0) { EXPECT_ARRAY_EQ(A2 * mpi_size, A2_sum); }
+  auto A2_sum = mpi::reduce(A2, comm, root);
+  if (mpi_rank == root) { EXPECT_ARRAY_EQ(A2 * mpi_size, A2_sum); }
 
   // allreduce an array
   auto A2_sum_all = mpi::all_reduce(A2, comm);
@@ -372,37 +421,133 @@ TEST_F(NDAMpi, ReduceOtherLayouts) {
   decltype(A2) B2 = A2 * (mpi_rank + 1);
   auto B2_max     = mpi::all_reduce(B2(_, 0, 0), comm, MPI_MAX);
   EXPECT_ARRAY_EQ(B2_max, A2(_, 0, 0) * mpi_size);
-  auto B2_min = mpi::reduce(B2(_, 0, 0), comm, mpi_size - 1, false, MPI_MIN);
-  if (mpi_rank == mpi_size - 1) EXPECT_ARRAY_EQ(B2_min, A2(_, 0, 0));
+  auto B2_min = mpi::reduce(B2(_, 0, 0), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B2_min, A2(_, 0, 0)); }
+}
+
+TEST_F(NDAMpi, ReduceOtherLayoutsIntoExistingArray) {
+  // reduce an array into an existing array
+  auto A2_sum = decltype(A2)::zeros(A2.shape());
+  mpi::reduce_into(A2, A2_sum, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(A2 * mpi_size, A2_sum);
+  } else {
+    EXPECT_ARRAY_EQ(A2_sum, decltype(A2)::zeros(A2.shape()));
+  }
+
+  // allreduce an array into an existing array
+  mpi::all_reduce_into(A2, A2_sum, comm);
+  EXPECT_ARRAY_EQ(A2 * mpi_size, A2_sum);
+
+  // (all)reduce an array view into an existing array view
+  decltype(A2) B2 = A2 * (mpi_rank + 1);
+  mpi::all_reduce_into(B2(_, 0, 0), B2(_, 1, 0), comm, MPI_MAX);
+  EXPECT_ARRAY_EQ(B2(_, 1, 0), A(_, 0, 0) * mpi_size);
+  mpi::reduce_into(B2(_, 0, 0), B2(_, 2, 0), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B2(_, 2, 0), A(_, 0, 0)); }
 }
 
 TEST_F(NDAMpi, ReduceOtherLayoutsInPlace) {
-  // in-place reduce an array
+  // in place reduce an array
   auto B2 = A2;
-  mpi::reduce_in_place(B2, comm);
-  if (mpi_rank == 0) {
+  mpi::reduce_in_place(B2, comm, root);
+  if (mpi_rank == root) {
     EXPECT_ARRAY_EQ(A2 * mpi_size, B2);
   } else {
     EXPECT_ARRAY_EQ(A2, B2)
   };
 
-  // in-place allreduce an array
+  // in place allreduce an array
   B2 = A2;
   mpi::all_reduce_in_place(B2, comm);
   EXPECT_ARRAY_EQ(A2 * mpi_size, B2);
 
-  // in-place (all)reduce an array view
+  // in place (all)reduce an array view
   B2 = A2 * (mpi_rank + 1);
   mpi::all_reduce_in_place(B2(_, 0, 0), comm, MPI_MAX);
   EXPECT_ARRAY_EQ(B2(_, 0, 0), A2(_, 0, 0) * mpi_size);
-  mpi::reduce_in_place(B2(_, 0, 1), comm, mpi_size - 1, false, MPI_MIN);
-  if (mpi_rank == mpi_size - 1) EXPECT_ARRAY_EQ(B2(_, 0, 1), A2(_, 0, 1));
+  mpi::reduce_in_place(B2(_, 0, 1), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B2(_, 0, 1), A2(_, 0, 1)); }
+}
+
+TEST_F(NDAMpi, ReduceOtherLayoutsInPlaceWithMPIReduceInto) {
+  // in place reduce an array using mpi_reduce_into
+  auto B2 = decltype(A2)::zeros(A2.shape());
+  mpi::reduce_into(A2, B2, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(A2 * mpi_size, B2);
+  } else {
+    EXPECT_ARRAY_EQ(B2, decltype(A2)::zeros(A2.shape()));
+  }
+
+  // in place allreduce an array using mpi_reduce_into
+  mpi::all_reduce_into(A2, B2, comm);
+  EXPECT_ARRAY_EQ(A2 * mpi_size, B2);
+
+  // in place (all)reduce an array view using mpi_reduce_into
+  B2 = A2 * (mpi_rank + 1);
+  mpi::all_reduce_into(B2(_, 0, 0), B2(_, 0, 0), comm, MPI_MAX);
+  EXPECT_ARRAY_EQ(B2(_, 0, 0), A2(_, 0, 0) * mpi_size);
+  mpi::reduce_into(B2(_, 0, 1), B2(_, 0, 1), comm, static_cast<int>(mpi_size - 1), false, MPI_MIN);
+  if (mpi_rank == mpi_size - 1) { EXPECT_ARRAY_EQ(B2(_, 0, 1), A2(_, 0, 1)); }
+}
+
+TEST_F(NDAMpi, ReduceNonContiguousLayouts) {
+  // reduce a non-contiguous array view
+  auto rg = nda::range(0, 4, 2);
+  auto N  = mpi::reduce(M(rg, rg), comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(M(rg, rg) * mpi_size, N);
+  } else {
+    EXPECT_TRUE(N.empty());
+  }
+
+  // allreduce a non-contiguous array view
+  N = mpi::all_reduce(M(rg, rg), comm);
+  EXPECT_ARRAY_EQ(M(rg, rg) * mpi_size, N);
+}
+
+TEST_F(NDAMpi, ReduceNonContiguousLayoutsInPlace) {
+  // in place reduce a non-contiguous array view
+  auto rg = nda::range(0, 4, 2);
+  auto N  = M;
+  mpi::reduce_in_place(N(rg, rg), comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(M(rg, rg) * mpi_size, N(rg, rg));
+  } else {
+    EXPECT_ARRAY_EQ(N, M);
+  }
+
+  // in place allreduce a non-contiguous array view
+  N = M;
+  mpi::all_reduce_in_place(N(rg, rg), comm);
+  EXPECT_ARRAY_EQ(M(rg, rg) * mpi_size, N(rg, rg));
+}
+
+TEST_F(NDAMpi, ReduceNonContiguousLayoutsIntoExistingArrays) {
+  // reduce a non-contiguous array view into an existing array
+  auto rg = nda::range(0, 4, 2);
+  auto N  = M;
+  mpi::reduce_into(M(rg, rg), N, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(M(rg, rg) * mpi_size, N);
+  } else {
+    EXPECT_ARRAY_EQ(N, M);
+  }
+
+  // allreduce a non-contiguous array view into a non-contiguous array view
+  N = M;
+  mpi::all_reduce_into(M(rg, rg), N(rg, rg), comm);
+  EXPECT_ARRAY_EQ(M(rg, rg) * mpi_size, N(rg, rg));
+
+  // allreduce an array into a non-contiguous array view
+  N = M(rg, rg);
+  mpi::all_reduce_into(N, M(rg, rg), comm);
+  EXPECT_ARRAY_EQ(N * mpi_size, M(rg, rg));
 }
 
 TEST_F(NDAMpi, ReduceCustomType) {
   using namespace nda::clef::literals;
-
-  // reduce an array of matrices
   using matrix_t = nda::matrix<double>;
   nda::vector<matrix_t> B(7);
   nda::vector<matrix_t> exp_sum(7);
@@ -415,39 +560,62 @@ TEST_F(NDAMpi, ReduceCustomType) {
     exp_sum(i)(k_, l_) << i * (mpi_size + 1) * mpi_size / 2 * (k_ + l_);
   }
 
+  // allreduce an array of matrices
   auto B_sum = mpi::all_reduce(B, comm);
-
   EXPECT_ARRAY_EQ(B_sum, exp_sum);
+
+  // in place reduce an array of matrices
+  B_sum = B;
+  mpi::reduce_in_place(B_sum, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(exp_sum, B_sum);
+  } else {
+    EXPECT_ARRAY_EQ(B, B_sum);
+  }
 }
 
-TEST_F(NDAMpi, LazyReduce) {
-  // lazy-reduce an array
-  decltype(A) A_sum = nda::lazy_mpi_reduce(A, comm);
-  if (mpi_rank == 0) {
-    EXPECT_ARRAY_EQ(A * mpi_size, A_sum);
-  } else {
-    EXPECT_EQ(A_sum.size(), 0);
+TEST_F(NDAMpi, ReduceCustomTypeIntoExistingArray) {
+  using namespace nda::clef::literals;
+  using matrix_t = nda::matrix<double>;
+  nda::vector<matrix_t> B(7);
+  nda::vector<matrix_t> exp_sum(7);
+
+  for (int i = 0; i < B.extent(0); ++i) {
+    B(i) = matrix_t{4, 4};
+    B(i)(k_, l_) << i * (mpi_rank + 1) * (k_ + l_);
+
+    exp_sum(i) = matrix_t{4, 4};
+    exp_sum(i)(k_, l_) << i * (mpi_size + 1) * mpi_size / 2 * (k_ + l_);
   }
 
-  // lazy-allreduce an array in-place
-  auto B2 = A2;
-  B2      = nda::lazy_mpi_reduce(B2, comm, root, true);
-  EXPECT_ARRAY_EQ(A2 * mpi_size, B2);
+  // allreduce an array of matrices into an existing array
+  auto B_sum = nda::vector<matrix_t>(7);
+  mpi::all_reduce_into(B, B_sum, comm);
+  EXPECT_ARRAY_EQ(B_sum, exp_sum);
+
+  // in place reduce an array of matrices using mpi_reduce_into
+  B_sum = B;
+  mpi::reduce_into(B_sum, B_sum, comm, root);
+  if (mpi_rank == root) {
+    EXPECT_ARRAY_EQ(exp_sum, B_sum);
+  } else {
+    EXPECT_ARRAY_EQ(B, B_sum);
+  }
 }
 
 TEST_F(NDAMpi, BroadcastTransposedMatrix) {
   nda::matrix<std::complex<double>> M_t = transpose(M);
   nda::matrix<std::complex<double>> N;
-  if (mpi_rank == 0) N = M_t;
-  mpi::broadcast(N, comm, 0);
+  if (mpi_rank == root) N = M_t;
+  mpi::broadcast(N, comm, root);
   EXPECT_ARRAY_EQ(M_t, N);
 }
 
 TEST_F(NDAMpi, BroadcastTransposedArray) {
   nda::array<long, 3> A_t = transpose(A);
   nda::array<long, 3> B(2, 4, 6);
-  if (mpi_rank == 0) B = A_t;
-  mpi::broadcast(B, comm, 0);
+  if (mpi_rank == root) B = A_t;
+  mpi::broadcast(B, comm, root);
   EXPECT_ARRAY_EQ(A_t, B);
 }
 
@@ -468,8 +636,8 @@ TEST_F(NDAMpi, VariousCollectiveCommunications) {
 
   // gather an array
   B *= -1;
-  arr_t D = mpi::gather(B, comm);
-  if (mpi_rank == 0) { EXPECT_ARRAY_NEAR(D, -A); }
+  arr_t D = mpi::gather(B, comm, root);
+  if (mpi_rank == root) { EXPECT_ARRAY_NEAR(D, -A); }
 
   // broadcast an array
   mpi::broadcast(D, comm);
@@ -481,8 +649,8 @@ TEST_F(NDAMpi, VariousCollectiveCommunications) {
   EXPECT_ARRAY_NEAR(D, -A);
 
   // reduce an array
-  arr_t R1 = mpi::reduce(A, comm);
-  if (mpi_rank == 0) { EXPECT_ARRAY_NEAR(R1, mpi_size * A); }
+  arr_t R1 = mpi::reduce(A, comm, root);
+  if (mpi_rank == root) { EXPECT_ARRAY_NEAR(R1, mpi_size * A); }
 
   // all reduce an array
   arr_t R2 = mpi::all_reduce(A, comm);
@@ -490,12 +658,10 @@ TEST_F(NDAMpi, VariousCollectiveCommunications) {
 }
 
 TEST_F(NDAMpi, PassingTemporaryObjects) {
-  auto A         = nda::array<int, 1>{1, 2, 3};
-  auto lazy_arr  = mpi::gather(nda::array<int, 1>{1, 2, 3}, comm);
-  auto res_arr   = nda::array<int, 1>(lazy_arr);
-  auto lazy_view = mpi::gather(A(), comm);
-  auto res_view  = nda::array<int, 1>(lazy_view);
-  if (comm.rank() == 0) {
+  auto A        = nda::array<int, 1>{1, 2, 3};
+  auto res_arr  = mpi::gather(nda::array<int, 1>{1, 2, 3}, comm, root);
+  auto res_view = mpi::gather(A(), comm, root);
+  if (comm.rank() == root) {
     for (long i = 0; i < comm.size(); ++i) {
       EXPECT_ARRAY_EQ(res_arr(nda::range(i * 3, (i + 1) * 3)), A);
       EXPECT_ARRAY_EQ(res_view(nda::range(i * 3, (i + 1) * 3)), A);


### PR DESCRIPTION
- Account for the changes in https://github.com/TRIQS/mpi/pull/27
- Rename `xxx_capi` to `xxx_into`
- Make MPI routines more flexible, e.g. allow non-contiguous views
- Update tests

