### PR TITLE
Deep partial evaluation for CLEF expression

### DIFF
--- a/c++/nda/clef/expression.hpp
+++ b/c++/nda/clef/expression.hpp
@@ -114,10 +114,27 @@ namespace nda::clef {
      * @return An nda::clef::expr object with the nda::clef::tags::function tag containing the current expression node
      * as the first child node and the other arguments as the remaining child nodes.
      */
+#ifdef __cpp_explicit_this_parameter
+    template <typename Self, typename... Args>
+    auto operator()(this Self &&self, Args &&...args) {
+      return expr<tags::function, expr, expr_storage_t<Args>...>{tags::function(), std::forward<Self>(self), std::forward<Args>(args)...};
+    }
+#else
     template <typename... Args>
-    auto operator()(Args &&...args) const {
+    auto operator()(Args &&...args) const & {
       return expr<tags::function, expr, expr_storage_t<Args>...>{tags::function(), *this, std::forward<Args>(args)...};
     }
+
+    template <typename... Args>
+    auto operator()(Args &&...args) & {
+      return expr<tags::function, expr, expr_storage_t<Args>...>{tags::function(), *this, std::forward<Args>(args)...};
+    }
+
+    template <typename... Args>
+    auto operator()(Args &&...args) && {
+      return expr<tags::function, expr, expr_storage_t<Args>...>{tags::function(), std::move(*this), std::forward<Args>(args)...};
+    }
+#endif
   };
 
   namespace detail {

--- a/c++/nda/clef/expression.hpp
+++ b/c++/nda/clef/expression.hpp
@@ -101,10 +101,26 @@ namespace nda::clef {
      * @return An nda::clef::expr object with the nda::clef::tags::subscript tag containing the current expression node
      * as the first child node and the other arguments as the remaining child nodes.
      */
+#ifdef __cpp_explicit_this_parameter
+    template <typename Self, typename... Args>
+    auto operator[](this Self &&self, Args &&...args) {
+      return expr<tags::subscript, expr, expr_storage_t<Args>...>{tags::subscript(), std::forward<Self>(self), std::forward<Args>(args)...};
+    }
+#else
     template <typename... Args>
-    auto operator[](Args &&...args) const {
+    auto operator[](Args &&...args) const & {
       return expr<tags::subscript, expr, expr_storage_t<Args>...>{tags::subscript(), *this, std::forward<Args>(args)...};
     }
+    template <typename... Args>
+    auto operator[](Args &&...args) & {
+      return expr<tags::subscript, expr, expr_storage_t<Args>...>{tags::subscript(), *this, std::forward<Args>(args)...};
+    }
+
+    template <typename... Args>
+    auto operator[](Args &&...args) && {
+      return expr<tags::subscript, expr, expr_storage_t<Args>...>{tags::subscript(), std::move(*this), std::forward<Args>(args)...};
+    }
+#endif
 
     /**
      * @brief Function call operator.

--- a/c++/nda/clef/operation.hpp
+++ b/c++/nda/clef/operation.hpp
@@ -20,6 +20,22 @@
 
 namespace nda::clef {
 
+  /// During a partial evaluation of an expression, the
+  // function nodes can be evaluated in 2 ways :
+  // - default : the function is evaluated iif all the arguments are non lazy
+  //             otherwise the node is kept, with its children replaced by evaluation
+  //             i.e. the function is NOT called.
+  // - if true : the function is CALLED with all the arguments, lazy of not.
+  //             It is not the default, as the function/object must be properly
+  //             implemented, by MOVING the argument in a new function node
+  //             with make_expr_call
+  template <typename F>
+  constexpr bool supports_partial_eval_of_calls = false;
+
+  /// Same as supports_partial_eval_of_calls but for the subscript operator
+  template <typename F>
+  constexpr bool supports_partial_eval_of_subscript = false;
+
   /**
    * @addtogroup clef_expr
    * @{
@@ -81,7 +97,9 @@ namespace nda::clef {
      * @return Result of the function call.
      */
     template <typename F, typename... Args>
-    FORCEINLINE decltype(auto) operator()(F &&f, Args &&...args) const {
+    FORCEINLINE auto operator()(F &&f, Args &&...args)
+       -> decltype(detail::fget(std::forward<F>(f))(detail::fget(std::forward<Args>(args))...)) const {
+      // trailing decltype is necessary for requires later in operation<Tag>
       return detail::fget(std::forward<F>(f))(detail::fget(std::forward<Args>(args))...);
     }
   };
@@ -99,7 +117,8 @@ namespace nda::clef {
      * @return Result of the subscript operation.
      */
     template <typename F, typename... Args>
-    FORCEINLINE decltype(auto) operator()(F &&f, Args &&...args) const {
+    FORCEINLINE auto operator()(F &&f, Args &&...args)
+       -> decltype(detail::fget(std::forward<F>(f)).operator[](detail::fget(std::forward<Args>(args))...)) const {
       // directly calling [args...] breaks clang
       return detail::fget(std::forward<F>(f)).operator[](detail::fget(std::forward<Args>(args))...);
     }
@@ -224,9 +243,18 @@ namespace nda::clef {
    * @param args Operands.
    * @return An nda::clef::expr for the given operation and operands.
    */
+
   template <typename Tag, typename... Args>
   FORCEINLINE auto op_dispatch(std::true_type, Args &&...args) {
-    return expr<Tag, expr_storage_t<Args>...>{Tag(), std::forward<Args>(args)...};
+    using Arg0 = std::decay_t<std::tuple_element_t<0, std::tuple<Args...>>>;
+    if constexpr (not(std::is_same_v<Tag, tags::function> and not supports_partial_eval_of_calls<Arg0>) and  //
+                  not(std::is_same_v<Tag, tags::subscript> and not supports_partial_eval_of_subscript<Arg0>) //and //
+                  //requires { operation<Tag>()(std::forward<Args>(args)...); }
+    ) {
+      return operation<Tag>()(std::forward<Args>(args)...);
+    } else {
+      return expr<Tag, expr_storage_t<Args>...>{Tag(), std::forward<Args>(args)...};
+    }
   }
 
   /**

--- a/c++/nda/clef/operation.hpp
+++ b/c++/nda/clef/operation.hpp
@@ -97,9 +97,7 @@ namespace nda::clef {
      * @return Result of the function call.
      */
     template <typename F, typename... Args>
-    FORCEINLINE auto operator()(F &&f, Args &&...args)
-       -> decltype(detail::fget(std::forward<F>(f))(detail::fget(std::forward<Args>(args))...)) const {
-      // trailing decltype is necessary for requires later in operation<Tag>
+    FORCEINLINE decltype(auto) operator()(F &&f, Args &&...args) const {
       return detail::fget(std::forward<F>(f))(detail::fget(std::forward<Args>(args))...);
     }
   };
@@ -117,9 +115,7 @@ namespace nda::clef {
      * @return Result of the subscript operation.
      */
     template <typename F, typename... Args>
-    FORCEINLINE auto operator()(F &&f, Args &&...args)
-       -> decltype(detail::fget(std::forward<F>(f)).operator[](detail::fget(std::forward<Args>(args))...)) const {
-      // directly calling [args...] breaks clang
+    FORCEINLINE decltype(auto) operator()(F &&f, Args &&...args) const {
       return detail::fget(std::forward<F>(f)).operator[](detail::fget(std::forward<Args>(args))...);
     }
   };
@@ -247,14 +243,12 @@ namespace nda::clef {
   template <typename Tag, typename... Args>
   FORCEINLINE auto op_dispatch(std::true_type, Args &&...args) {
     using Arg0 = std::decay_t<std::tuple_element_t<0, std::tuple<Args...>>>;
-    if constexpr (not(std::is_same_v<Tag, tags::function> and not supports_partial_eval_of_calls<Arg0>) and  //
-                  not(std::is_same_v<Tag, tags::subscript> and not supports_partial_eval_of_subscript<Arg0>) //and //
-                  //requires { operation<Tag>()(std::forward<Args>(args)...); }
-    ) {
-      return operation<Tag>()(std::forward<Args>(args)...);
-    } else {
+    if constexpr ((std::is_same_v<Tag, tags::function> and not supports_partial_eval_of_calls<Arg0>) or  //
+                  (std::is_same_v<Tag, tags::subscript> and not supports_partial_eval_of_subscript<Arg0>) //
+    )
       return expr<Tag, expr_storage_t<Args>...>{Tag(), std::forward<Args>(args)...};
-    }
+     else
+      return operation<Tag>()(std::forward<Args>(args)...);
   }
 
   /**

--- a/c++/nda/clef/operation.hpp
+++ b/c++/nda/clef/operation.hpp
@@ -20,26 +20,37 @@
 
 namespace nda::clef {
 
-  /// During a partial evaluation of an expression, the
-  // function nodes can be evaluated in 2 ways :
-  // - default : the function is evaluated iif all the arguments are non lazy
-  //             otherwise the node is kept, with its children replaced by evaluation
-  //             i.e. the function is NOT called.
-  // - if true : the function is CALLED with all the arguments, lazy of not.
-  //             It is not the default, as the function/object must be properly
-  //             implemented, by MOVING the argument in a new function node
-  //             with make_expr_call
-  template <typename F>
-  constexpr bool supports_partial_eval_of_calls = false;
-
-  /// Same as supports_partial_eval_of_calls but for the subscript operator
-  template <typename F>
-  constexpr bool supports_partial_eval_of_subscript = false;
-
   /**
    * @addtogroup clef_expr
    * @{
    */
+
+  /**
+   * @brief Controls evaluation behavior of function nodes during partial expression evaluation.
+   *
+   * When partially evaluating an expression tree, function nodes have two evaluation modes:
+   * - false (default): Function is evaluated only if all arguments are non-lazy values.
+   *   If any argument is lazy, the node is preserved with evaluated children but the
+   *   function itself is NOT called.
+   * - true: Function is ALWAYS called with all arguments (lazy or non-lazy).
+   *   This requires the function to properly handle non-lazy arguments by moving them
+   *   into new expression nodes using make_expr_call.
+   *
+   * @tparam F Function type to specialize for
+   */
+  template <typename F>
+  constexpr bool supports_partial_eval_of_calls = false;
+
+  /**
+   * @brief Controls evaluation behavior of subscript operations during partial expression evaluation.
+   *
+   * Similar to supports_partial_eval_of_calls but specifically for the subscript operator[].
+   * When true, the subscript operation will be called even with lazy arguments.
+   *
+   * @tparam T Type to specialize subscript evaluation for
+   */
+  template <typename T>
+  constexpr bool supports_partial_eval_of_subscript = false;
 
   namespace detail {
 

--- a/test/c++/nda_clef.cpp
+++ b/test/c++/nda_clef.cpp
@@ -12,6 +12,7 @@
 #include <array>
 #include <functional>
 #include <iostream>
+#include <sstream>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -473,4 +474,53 @@ TEST_F(CLEF, SumExpressionOverDomain) {
   EXPECT_EQ(clef::sum(ex3, x0_ = dom1, x1_ = dom2), 5 + 2 * 6 + 3 * 7 + 2 * 8 + 9);
   EXPECT_EQ(dom1.size(), 3);
   EXPECT_EQ(clef::sum(ex3, x0_ = std::vector{1, 2, 3}, x1_ = std::vector{4, 5, 6}), 5 + 2 * 6 + 3 * 7 + 2 * 8 + 9);
+}
+
+// ========= Deep Evaluation of Function Calls ==========
+int f1(int x) {
+  //std::cerr << "Eval f1 " << x << std::endl;
+  return 100 * x;
+}
+CLEF_MAKE_FNT_LAZY(f1);
+
+struct _f3 {
+  auto operator()(auto x, auto y) const {
+    if constexpr (nda::clef::is_lazy<decltype(x)>) {
+      if constexpr (nda::clef::is_lazy<decltype(y)>) {
+        return make_expr_call(*this, x, y);
+      } else {
+        // std::cerr << "Eval f3 ONE LAZY " << x << " " << y << std::endl;
+        return f1(x) + auto{y};
+      }
+    } else {
+      // std::cerr << "Eval f3 " << x << " " << y << std::endl;
+      return 10 * x + y;
+    }
+  }
+};
+template <>
+constexpr bool nda::clef::supports_partial_eval_of_calls<_f3> = true;
+
+static constexpr _f3 f3{};
+std::ostream &operator<<(std::ostream &out, _f3) { return out << "f3"; }
+
+TEST_F(CLEF, DeepEval1) {
+  nda::clef::placeholder<0> x_;
+  nda::clef::placeholder<1> y_;
+  nda::clef::placeholder<2> z_;
+  auto ex = x_ + (10 * y_ + 100 * z_);
+  auto ev = eval(ex, y_ = 20, z_ = 30);
+  std::stringstream s1, s2;
+  s1 << ev;
+  s2 << x_ + 3200;
+  EXPECT_EQ(s1.str(), s2.str());
+  EXPECT_EQ(eval(ev, x_ = 1), 1 + 10 * 20 + 100 * 30);
+}
+
+TEST_F(CLEF, DeepEvalFntCall) {
+  nda::clef::placeholder<0> x_;
+  nda::clef::placeholder<1> y_;
+  auto ex = x_ + f3(x_, y_);
+  auto ev = eval(ex, y_ = 20);
+  EXPECT_EQ(eval(ev, x_ = 1), 1 + f1(1) + 20);
 }

--- a/test/c++/nda_clef.cpp
+++ b/test/c++/nda_clef.cpp
@@ -490,7 +490,10 @@ struct _f3 {
         return make_expr_call(*this, x, y);
       } else {
         // std::cerr << "Eval f3 ONE LAZY " << x << " " << y << std::endl;
-        return f1(x) + auto{y};
+	auto yy = y;
+        return f1(x) + std::move(yy);
+        //c++23 only
+	//return f1(x) + auto{y};
       }
     } else {
       // std::cerr << "Eval f3 " << x << " " << y << std::endl;


### PR DESCRIPTION
- Add deep partial evaluation to CLEF expression.

 During a partial evaluation, the operation is explicitly called at each node, instead of simply evaluating the children and waiting for all the arguments to be known (non lazy) to do the operation (previous behavior).

- This is disabled by default for the tags::function and tags::subscript node, i.e. () and [] call operators.

- However, if the traits supports_partial_eval_of_calls/supports_partial_eval_of_subscript are set to true for an object the ()/[] is called during the partial evaluation.

- It is not set by default since writing a partial evaluation for an object requires a bit of care, i.e. to properly move the arguments into the make_expr_call object. At this stage, it is only intended for advanced users, and for some specific cases where a partial evaluation of the function can compress it significantly for performance.

- To illustrate the previous point, a simple lambda add(auto x, auto y) { return x + y;} used in a node  {function, add, x_, y_} would compile with the new behavior, but after a partial eval on y= y0, its value y0 would be dangling. As it is unlikely that default user will write add with a move, the new behavior is not by default for ()/[]

- NB : put the partial eval for call by default compiles but breaks 2 tests in TRIQS lib.