### PR TITLE
Add support for array of user defined h5 compound

### DIFF
--- a/c++/nda/h5.hpp
+++ b/c++/nda/h5.hpp
@@ -31,6 +31,11 @@
 
 namespace nda {
 
+  // template <typename T>
+  // concept IsH5NativeOrCompound = ::h5::is_h5_compound<T> and requires {
+  //   { h5::detail::hid_t_of<T>() } -> std::convertible_to<h5::hid_t>;
+  // };
+
   /**
    * @addtogroup av_hdf5
    * @{
@@ -121,7 +126,7 @@ namespace nda {
     if constexpr (std::is_same_v<nda::get_value_t<A>, std::string>) {
       // 1-dimensional array/view of strings
       h5_write(g, name, detail::to_char_buf(a));
-    } else if constexpr (is_scalar_v<typename A::value_type>) {
+    } else if constexpr (is_scalar_v<typename A::value_type> or ::h5::is_h5_compound<typename A::value_type>) {
       // n-dimensional array/view of scalars
       // make a copy if the array/view is not in C-order and write the copy
       if (not a.indexmap().is_stride_order_C()) {
@@ -304,7 +309,7 @@ namespace nda {
       h5::char_buf cb;
       h5_read(g, name, cb);
       detail::from_char_buf(cb, a);
-    } else if constexpr (is_scalar_v<typename A::value_type>) {
+    } else if constexpr (is_scalar_v<typename A::value_type> or ::h5::is_h5_compound<typename A::value_type>) {
       // n-dimensional array/view of scalars
       // read into a temporary array if the array/view is not in C-order and copy the elements
       if (not a.indexmap().is_stride_order_C()) {

--- a/test/c++/nda_compound.cpp
+++ b/test/c++/nda_compound.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2024--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
+#include "./test_common.hpp"
+
+#include <nda/gtest_tools.hpp>
+#include <nda/nda.hpp>
+
+#include <array>
+#include <type_traits>
+#include <vector>
+#include <tuple>
+
+#include <nda/h5.hpp>
+//#include <hdf5_hl.h>
+
+#include <H5Tpublic.h> // HDF5 type creation API
+
+struct S {
+  int a;
+  double x;
+  int u                                                         = 1;
+  friend constexpr bool operator<=>(const S &lhs, const S &rhs) = default;
+};
+
+template <>
+h5::hid_t h5::detail::hid_t_of<S>() {
+  hid_t type = H5Tcreate(H5T_COMPOUND, sizeof(S));
+  H5Tinsert(type, "s", HOFFSET(S, a), H5T_NATIVE_INT);
+  H5Tinsert(type, "x", HOFFSET(S, x), H5T_NATIVE_DOUBLE);
+  H5Tinsert(type, "u", HOFFSET(S, u), H5T_NATIVE_INT);
+  return type;
+}
+
+template <>
+constexpr bool h5::is_h5_compound<S> = true;
+
+TEST(NDA, H5Compound) {
+  nda::array<S, 1> A{{1, 2.0}, {3, 4.0}, {5, 6.0}, {7, 8.0}, {9, 10.0}}; // NOLINT
+
+  static_assert(requires { h5::detail::hid_t_of<decltype(A)::value_type>(); });
+  {
+    h5::file out("compound.h5", 'w');
+    h5::write(out, "A", A);
+  }
+
+  {
+    h5::file in("compound.h5", 'r');
+    auto B = h5::read<nda::array<S, 1>>(in, "A");
+    EXPECT_EQ(A, B);
+  }
+};

--- a/test/c++/nda_compound.cpp
+++ b/test/c++/nda_compound.cpp
@@ -14,33 +14,7 @@
 #include <tuple>
 
 #include <nda/h5.hpp>
-//#include <hdf5_hl.h>
-
 #include <H5Tpublic.h> // HDF5 type creation API
-#include "hdf5.h"
-
-namespace h5 {
-  template <typename T>
-    requires(h5::is_h5_compound<T>)
-  void h5_write(h5::group g, std::string const &name, T const &x) {
-    h5::object s_type = h5::detail::hid_t_of<T>();
-    hsize_t dims[1]   = {1};                             //NOLINT
-    h5::object space  = H5Screate_simple(1, dims, NULL); //NOLINT
-    h5::object dset   = H5Dcreate2(g, name.c_str(), s_type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    H5Dwrite(dset, s_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, &x);
-  }
-
-  template <typename T>
-    requires(h5::is_h5_compound<T>)
-  void h5_read(h5::group g, std::string const &name, T &x) {
-    h5::object s_type = h5::detail::hid_t_of<T>();
-    hsize_t dims[1]   = {1};                             //NOLINT
-    h5::object space  = H5Screate_simple(1, dims, NULL); //NOLINT
-    h5::object dset   = H5Dopen2(g, name.c_str(), H5P_DEFAULT);
-    H5Dread(dset, s_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, &x);
-  }
-} // namespace h5
-
 struct S {
   int a;
   double x;

--- a/test/c++/nda_compound.cpp
+++ b/test/c++/nda_compound.cpp
@@ -17,6 +17,29 @@
 //#include <hdf5_hl.h>
 
 #include <H5Tpublic.h> // HDF5 type creation API
+#include "hdf5.h"
+
+namespace h5 {
+  template <typename T>
+    requires(h5::is_h5_compound<T>)
+  void h5_write(h5::group g, std::string const &name, T const &x) {
+    h5::object s_type = h5::detail::hid_t_of<T>();
+    hsize_t dims[1]   = {1};                             //NOLINT
+    h5::object space  = H5Screate_simple(1, dims, NULL); //NOLINT
+    h5::object dset   = H5Dcreate2(g, name.c_str(), s_type, space, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    H5Dwrite(dset, s_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, &x);
+  }
+
+  template <typename T>
+    requires(h5::is_h5_compound<T>)
+  void h5_read(h5::group g, std::string const &name, T &x) {
+    h5::object s_type = h5::detail::hid_t_of<T>();
+    hsize_t dims[1]   = {1};                             //NOLINT
+    h5::object space  = H5Screate_simple(1, dims, NULL); //NOLINT
+    h5::object dset   = H5Dopen2(g, name.c_str(), H5P_DEFAULT);
+    H5Dread(dset, s_type, H5S_ALL, H5S_ALL, H5P_DEFAULT, &x);
+  }
+} // namespace h5
 
 struct S {
   int a;

--- a/test/c++/nda_compound.cpp
+++ b/test/c++/nda_compound.cpp
@@ -39,16 +39,19 @@ constexpr bool h5::is_h5_compound<S> = true;
 
 TEST(NDA, H5Compound) {
   nda::array<S, 1> A{{1, 2.0}, {3, 4.0}, {5, 6.0}, {7, 8.0}, {9, 10.0}}; // NOLINT
-
+  S s{1, 1.3, -1};                                                       // NOLINT
   static_assert(requires { h5::detail::hid_t_of<decltype(A)::value_type>(); });
   {
     h5::file out("compound.h5", 'w');
     h5::write(out, "A", A);
+    h5::write(out, "s", s);
   }
 
   {
     h5::file in("compound.h5", 'r');
-    auto B = h5::read<nda::array<S, 1>>(in, "A");
+    auto B  = h5::read<nda::array<S, 1>>(in, "A");
+    auto sb = h5::read<S>(in, "s");
     EXPECT_EQ(A, B);
+    EXPECT_EQ(s, sb);
   }
 };


### PR DESCRIPTION
- To treat a small struct as a compound
- You need to :
   - specialize a trait in h5
   - write the function to make the h5 type (should in future be done with reflection).
- Added test.