### PR TITLE
Xsimd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc/html
 .*.swo
 .*.swn
 .claude
+.idea

--- a/c++/nda/CMakeLists.txt
+++ b/c++/nda/CMakeLists.txt
@@ -59,10 +59,7 @@ if(OpenMPSupport)
 endif ()
 
 #XSIMD
-target_include_directories(${PROJECT_NAME}_c
-        PUBLIC
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/deps/xsimd_src/include>
-)
+target_link_libraries(${PROJECT_NAME}_c PUBLIC xsimd)
 
 # ========= Blas / Lapack ==========
 

--- a/c++/nda/CMakeLists.txt
+++ b/c++/nda/CMakeLists.txt
@@ -58,6 +58,12 @@ if(OpenMPSupport)
   target_compile_definitions(${PROJECT_NAME}_c PUBLIC NDA_HAVE_OPENMP)
 endif ()
 
+#XSIMD
+target_include_directories(${PROJECT_NAME}_c
+        PUBLIC
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/deps/xsimd_src/include>
+)
+
 # ========= Blas / Lapack ==========
 
 message(STATUS "-------- Lapack detection -------------")

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -278,15 +278,9 @@ void assert_simd_access_bounds(const long offset) const noexcept(has_no_boundche
 public:
 
 template <typename... Args>
-FORCEINLINE native_simd<ValueType> load(simd::vectorize_t, Args... idx) const noexcept(has_no_boundcheck) {
-  static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
-  const long offset = lay(idx...);
-  assert_simd_access_bounds(offset);
-  return native_simd<ValueType>::load_unaligned(data() + offset);
-}
-
-template <typename... Args>
-FORCEINLINE native_simd<ValueType> load(simd::emulate_t, Args... idx) const noexcept(has_no_boundcheck) {
+FORCEINLINE native_simd<ValueType> load(auto simd_tag, Args... idx) const noexcept(has_no_boundcheck) {
+  static_assert(std::is_same_v<decltype(simd_tag), simd::vectorize_t> or std::is_same_v<decltype(simd_tag), simd::emulate_t>,
+                "Load tag can only be vectorize or emulate");
   static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
   const long offset = lay(idx...);
   assert_simd_access_bounds(offset);

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -264,7 +264,7 @@ FORCEINLINE decltype(auto) operator()(Ts const &...idxs) && noexcept(has_no_boun
 
 template <typename... Args>
 FORCEINLINE native_simd<ValueType> load(simd::vectorize_t, Args... idx) const {
-  static_assert(Vectorizable<ValueType>, "Store function is called with a type that is not a vectorizable type");
+  static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
   const long offset = lay(idx...);
   return native_simd<ValueType>::load_unaligned(data() + offset);
 }

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -262,6 +262,21 @@ FORCEINLINE decltype(auto) operator()(Ts const &...idxs) && noexcept(has_no_boun
   return call<Algebra, true>(*this, idxs...);
 }
 
+template <typename... Args>
+FORCEINLINE native_simd<ValueType> load(Args... idx) const {
+  static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
+  const long offset = lay(idx...);
+  return native_simd<ValueType>::load_unaligned(data()+offset);
+}
+
+template <typename... Args>
+FORCEINLINE void store(const native_simd<ValueType> &value, Args... idx) {
+  static_assert(Vectorizable<ValueType>, "Store function is called with a type that is not a vectorizable type");
+  const long offset = lay(idx...);
+  value.store_unaligned(data()+offset);
+}
+
+
 /**
  * @brief Subscript operator to access the 1-dimensional view/array.
  *

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -263,7 +263,14 @@ FORCEINLINE decltype(auto) operator()(Ts const &...idxs) && noexcept(has_no_boun
 }
 
 template <typename... Args>
-FORCEINLINE native_simd<ValueType> load(Args... idx) const {
+FORCEINLINE native_simd<ValueType> load(simd::vectorize_t, Args... idx) const {
+  static_assert(Vectorizable<ValueType>, "Store function is called with a type that is not a vectorizable type");
+  const long offset = lay(idx...);
+  return native_simd<ValueType>::load_unaligned(data() + offset);
+}
+
+template <typename... Args>
+FORCEINLINE native_simd<ValueType> load(simd::emulate_t, Args... idx) const {
   static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
   const long offset = lay(idx...);
   return native_simd<ValueType>::load_unaligned(data()+offset);
@@ -511,8 +518,12 @@ void assign_from_ndarray(RHS const &rhs) { // FIXME noexcept {
   if constexpr (mem::on_device<self_t> || mem::on_device<RHS>) {
     NDA_RUNTIME_ERROR << "Error in assign_from_ndarray: Fallback to elementwise assignment not implemented for arrays/views on the GPU";
   }
-  if constexpr (same_stride_order and is_simd_enabled_v<RHS, ValueType> and is_simd_enabled_v<self_t>) {
-    nda::for_each_static<0, get_layout_info<self_t>.stride_order, native_simd<ValueType>::size>(shape(),[this, &rhs](auto const &...args) {(*this).store(rhs.load(args...), args...); }, [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
+  using dispatch_t = simd::dispatch_policy_t<RHS, ValueType>;
+  if constexpr (same_stride_order
+                and is_simd_enabled_v<self_t> and (std::is_same_v<dispatch_t, simd::vectorize_t> or std::is_same_v<dispatch_t, simd::emulate_t>)) {
+    nda::for_each_static<0, get_layout_info<self_t>.stride_order, native_simd<ValueType>::size>(
+       shape(), [this, &rhs](auto const &...args) { (*this).store(rhs.load(dispatch_t{}, args...), args...); },
+       [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
   }
   else {
     nda::for_each(shape(), [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -268,7 +268,11 @@ void assert_simd_access_bounds(const long offset) const noexcept(has_no_boundche
   static_assert(
      has_contiguous_layout<self_t>,
      "This functions should only be called when we have a contiguous layout. This can fail only when the rules of vectorization is relaxed therefore this function needs to be updated");
-  if constexpr (!has_no_boundcheck) { assert(offset + native_simd<ValueType>::size <= this->size() && "NDA: SIMD access out of bounds"); }
+  if constexpr (!has_no_boundcheck) {
+    if (offset + native_simd<ValueType>::size > this->size()) {
+      throw std::runtime_error("Index out of bounds for SIMD access.\n");
+    }
+  }
 }
 
 public:

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -262,27 +262,40 @@ FORCEINLINE decltype(auto) operator()(Ts const &...idxs) && noexcept(has_no_boun
   return call<Algebra, true>(*this, idxs...);
 }
 
+private:
+// Right now we are only doing SIMD access in contiguous layouts. If this rule is relaxed we need to change this function as well.
+void assert_simd_access_bounds(const long offset) const noexcept(has_no_boundcheck) {
+  static_assert(
+     has_contiguous_layout<self_t>,
+     "This functions should only be called when we have a contiguous layout. This can fail only when the rules of vectorization is relaxed therefore this function needs to be updated");
+  if constexpr (!has_no_boundcheck) { assert(offset + native_simd<ValueType>::size <= this->size() && "NDA: SIMD access out of bounds"); }
+}
+
+public:
+
 template <typename... Args>
-FORCEINLINE native_simd<ValueType> load(simd::vectorize_t, Args... idx) const {
+FORCEINLINE native_simd<ValueType> load(simd::vectorize_t, Args... idx) const noexcept(has_no_boundcheck) {
   static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
   const long offset = lay(idx...);
+  assert_simd_access_bounds(offset);
   return native_simd<ValueType>::load_unaligned(data() + offset);
 }
 
 template <typename... Args>
-FORCEINLINE native_simd<ValueType> load(simd::emulate_t, Args... idx) const {
+FORCEINLINE native_simd<ValueType> load(simd::emulate_t, Args... idx) const noexcept(has_no_boundcheck) {
   static_assert(Vectorizable<ValueType>, "Load function is called with a type that is not a vectorizable type");
   const long offset = lay(idx...);
-  return native_simd<ValueType>::load_unaligned(data()+offset);
+  assert_simd_access_bounds(offset);
+  return native_simd<ValueType>::load_unaligned(data() + offset);
 }
 
 template <typename... Args>
-FORCEINLINE void store(const native_simd<ValueType> &value, Args... idx) {
+FORCEINLINE void store(const native_simd<ValueType> &value, Args... idx) noexcept(has_no_boundcheck) {
   static_assert(Vectorizable<ValueType>, "Store function is called with a type that is not a vectorizable type");
   const long offset = lay(idx...);
-  value.store_unaligned(data()+offset);
+  assert_simd_access_bounds(offset);
+  value.store_unaligned(data() + offset);
 }
-
 
 /**
  * @brief Subscript operator to access the 1-dimensional view/array.
@@ -524,8 +537,7 @@ void assign_from_ndarray(RHS const &rhs) { // FIXME noexcept {
     nda::for_each_static<0, get_layout_info<self_t>.stride_order, native_simd<ValueType>::size>(
        shape(), [this, &rhs](auto const &...args) { (*this).store(rhs.load(dispatch_t{}, args...), args...); },
        [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
-  }
-  else {
+  } else {
     nda::for_each(shape(), [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
   }
 }

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -511,7 +511,12 @@ void assign_from_ndarray(RHS const &rhs) { // FIXME noexcept {
   if constexpr (mem::on_device<self_t> || mem::on_device<RHS>) {
     NDA_RUNTIME_ERROR << "Error in assign_from_ndarray: Fallback to elementwise assignment not implemented for arrays/views on the GPU";
   }
-  nda::for_each(shape(), [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
+  if constexpr (same_stride_order and is_simd_enabled_v<RHS, ValueType> and is_simd_enabled_v<self_t>) {
+    nda::for_each_static<0, get_layout_info<self_t>.stride_order, native_simd<ValueType>::size>(shape(),[this, &rhs](auto const &...args) {(*this).store(rhs.load(args...), args...); }, [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
+  }
+  else {
+    nda::for_each(shape(), [this, &rhs](auto const &...args) { (*this)(args...) = rhs(args...); });
+  }
 }
 
 // Implementation to fill a view/array with a constant scalar value.

--- a/c++/nda/algorithms.hpp
+++ b/c++/nda/algorithms.hpp
@@ -69,6 +69,18 @@ namespace nda {
     return fold(std::move(f), a, get_value_t<A>{});
   }
 
+  template <Array A, typename F_SIMD, typename F_SCALAR, Vectorizable R>
+    requires(is_simd_enabled_v<A> and std::is_same_v<R, get_value_t<A>>)
+  auto fold(F_SIMD f_simd, F_SCALAR f_scalar, A const &a, native_simd<R> r_simd, R r_scalar) {
+    nda::for_each_static<0, get_layout_info<A>.stride_order, native_simd<R>::size>(
+       a.shape(), [&a, &r_simd, &f_simd](auto &&...args) { r_simd = f_simd(r_simd, native_simd<R>(a.load(args...))); },
+       [&a, &r_scalar, &f_scalar](auto &&...args) { r_scalar = f_scalar(r_scalar, a(args...)); });
+    alignas(r_simd.alignment()) std::array<R, r_simd.size()> res;
+    r_simd.store(res.data());
+    for (int i = 0; i < r_simd.size(); i++) { r_scalar = f_scalar(r_scalar, res[i]); }
+    return r_scalar;
+  }
+
   /**
    * @brief Does any of the elements of the array evaluate to true?
    *
@@ -122,12 +134,23 @@ namespace nda {
    */
   template <Array A>
   auto max_element(A const &a) {
-    return fold(
-       [](auto const &x, auto const &y) {
-         using std::max;
-         return max(x, y);
-       },
-       a, get_first_element(a));
+    if constexpr (is_simd_enabled_v<A>) {
+      using value_t = get_value_t<A>;
+      using simd_t  = native_simd<value_t>;
+      simd_t max_simd(get_first_element(a));
+      auto f_simd        = [&a, &max_simd](auto &&...args) { max_simd = xsimd::max(max_simd, a.load(args...)); };
+      value_t max_scalar = get_first_element(a);
+      auto f_scalar      = [&a, &max_scalar](auto &&...args) { max_scalar = std::max(max_scalar, a(args...)); };
+      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+      return std::max(max_scalar, xsimd::reduce_max(max_simd));
+    } else {
+      return fold(
+         [](auto const &x, auto const &y) {
+           using std::max;
+           return max(x, y);
+         },
+         a, get_first_element(a));
+    }
   }
 
   /**
@@ -141,12 +164,23 @@ namespace nda {
    */
   template <Array A>
   auto min_element(A const &a) {
-    return fold(
-       [](auto const &x, auto const &y) {
-         using std::min;
-         return min(x, y);
-       },
-       a, get_first_element(a));
+    if constexpr (is_simd_enabled_v<A>) {
+      using value_t = get_value_t<A>;
+      using simd_t  = native_simd<value_t>;
+      simd_t min_simd(get_first_element(a));
+      auto f_simd        = [&a, &min_simd](auto &&...args) { min_simd = xsimd::min(min_simd, a.load(args...)); };
+      value_t min_scalar = get_first_element(a);
+      auto f_scalar      = [&a, &min_scalar](auto &&...args) { min_scalar = std::min(min_scalar, a(args...)); };
+      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+      return std::min(min_scalar, xsimd::reduce_min(min_simd));
+    } else {
+      return fold(
+         [](auto const &x, auto const &y) {
+           using std::min;
+           return min(x, y);
+         },
+         a, get_first_element(a));
+    }
   }
 
   /**
@@ -159,12 +193,34 @@ namespace nda {
    */
   template <ArrayOfRank<2> A>
   double frobenius_norm(A const &a) {
-    return std::sqrt(fold(
-       [](double r, auto const &x) -> double {
-         auto ab = std::abs(x);
-         return r + ab * ab;
-       },
-       a, double(0)));
+    if constexpr (is_simd_enabled_v<A> and not is_complex_v<get_value_t<A>>) {
+      using value_t = get_value_t<A>;
+      using simd_t  = native_simd<value_t>;
+      simd_t r_simd(value_t(0));
+      auto f_simd = [&a, &r_simd](auto &&...args) {
+        simd_t x   = a.load(args...);
+        simd_t abs = xsimd::abs(x);
+        if constexpr (std::is_integral_v<value_t>) {
+          r_simd = abs * abs + r_simd;
+        } else {
+          r_simd = xsimd::fma(abs, abs, r_simd);
+        }
+      };
+      double r      = 0;
+      auto f_scalar = [&a, &r](auto &&...args) {
+        auto abs = std::abs(a(args...));
+        r        = abs * abs + r;
+      };
+      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+      return std::sqrt((static_cast<double>(xsimd::reduce_add(r_simd)) + r));
+    } else {
+      return std::sqrt(fold(
+         [](double r, auto const &x) -> double {
+           auto ab = std::abs(x);
+           return r + ab * ab;
+         },
+         a, double(0)));
+    }
   }
 
   /**
@@ -179,8 +235,20 @@ namespace nda {
     requires(nda::Scalar<Value> or nda::Array<Value>)
   {
     if constexpr (nda::Scalar<Value>) {
-      return fold(std::plus<>{}, a);
-    } else { // Array<Value>
+      if constexpr (is_simd_enabled_v<A>) {
+        using value_t = get_value_t<A>;
+        using simd_t  = native_simd<value_t>;
+        simd_t sum_simd(value_t{0});
+        auto f_simd = [&a, &sum_simd](auto &&...args) { sum_simd += a.load(args...); };
+        value_t sum_scalar{0};
+        auto f_scalar = [&a, &sum_scalar](auto &&...args) { sum_scalar += a(args...); };
+        nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+        return sum_scalar + xsimd::reduce_add(sum_simd);
+      } else {
+        return fold(std::plus<>{}, a);
+      }
+    } else {
+      // Array<Value>
       return fold(std::plus<>{}, a, Value::zeros(get_first_element(a).shape()));
     }
   }
@@ -197,7 +265,18 @@ namespace nda {
     requires(nda::Scalar<Value> or nda::Array<Value>)
   {
     if constexpr (nda::Scalar<Value>) {
-      return fold(std::multiplies<>{}, a, get_value_t<A>{1});
+      if constexpr (is_simd_enabled_v<A>) {
+        using value_t = get_value_t<A>;
+        using simd_t  = native_simd<value_t>;
+        simd_t product_simd(value_t{1});
+        auto f_simd = [&a, &product_simd](auto &&...args) { product_simd *= a.load(args...); };
+        value_t product_scalar{1};
+        auto f_scalar = [&a, &product_scalar](auto &&...args) { product_scalar *= a(args...); };
+        nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+        return product_scalar * xsimd::reduce_mul(product_simd);
+      } else {
+        return fold(std::multiplies<>{}, a, get_value_t<A>{1});
+      }
     } else { // Array<Value>
       return fold(std::multiplies<>{}, a, Value::ones(get_first_element(a).shape()));
     }
@@ -215,7 +294,17 @@ namespace nda {
   template <Array A, Array B>
     requires(nda::get_rank<A> == nda::get_rank<B>)
   [[nodiscard]] constexpr auto hadamard(A &&a, B &&b) {
-    return nda::map([](auto const &x, auto const &y) { return x * y; })(std::forward<A>(a), std::forward<B>(b));
+    if constexpr (is_simd_enabled_v<A> and is_simd_enabled_v<B> and std::is_same_v<get_value_t<A>, get_value_t<B>>) {
+      using value_t = get_value_t<A>;
+      using simd_t  = native_simd<value_t>;
+      struct mul {
+        value_t operator()(const value_t &x, const value_t &y) const { return x * y; }
+        simd_t load(const simd_t &x, const simd_t &y) const { return x * y; };
+      };
+      return nda::map(mul{})(std::forward<A>(a), std::forward<B>(b));
+    } else {
+      return nda::map([](auto const &x, auto const &y) { return x * y; })(std::forward<A>(a), std::forward<B>(b));
+    }
   }
 
   /**

--- a/c++/nda/algorithms.hpp
+++ b/c++/nda/algorithms.hpp
@@ -70,12 +70,13 @@ namespace nda {
   }
 
   template <Array A, typename F_SIMD, typename F_SCALAR, Vectorizable R>
-    requires(is_simd_enabled_v<A> and std::is_same_v<R, get_value_t<A>>)
+    requires(std::is_same_v<simd::dispatch_policy_t<A, R>, simd::vectorize_t> or std::is_same_v<simd::dispatch_policy_t<A, R>, simd::emulate_t>)
   auto fold(F_SIMD f_simd, F_SCALAR f_scalar, A const &a, native_simd<R> r_simd, R r_scalar) {
     nda::for_each_static<0, get_layout_info<A>.stride_order, native_simd<R>::size>(
-       a.shape(), [&a, &r_simd, &f_simd](auto &&...args) { r_simd = f_simd(r_simd, native_simd<R>(a.load(args...))); },
+       a.shape(),
+       [&a, &r_simd, &f_simd](auto &&...args) { r_simd = f_simd(r_simd, native_simd<R>(a.load(simd::dispatch_policy_t<A, R>{}, args...))); },
        [&a, &r_scalar, &f_scalar](auto &&...args) { r_scalar = f_scalar(r_scalar, a(args...)); });
-    alignas(r_simd.alignment()) std::array<R, r_simd.size()> res;
+    alignas(native_simd<R>::arch_type::alignment()) std::array<R, r_simd.size()> res;
     r_simd.store(res.data());
     for (int i = 0; i < r_simd.size(); i++) { r_scalar = f_scalar(r_scalar, res[i]); }
     return r_scalar;
@@ -134,22 +135,23 @@ namespace nda {
    */
   template <Array A>
   auto max_element(A const &a) {
-    if constexpr (is_simd_enabled_v<A>) {
-      using value_t = get_value_t<A>;
-      using simd_t  = native_simd<value_t>;
-      simd_t max_simd(get_first_element(a));
-      auto f_simd        = [&a, &max_simd](auto &&...args) { max_simd = xsimd::max(max_simd, a.load(args...)); };
-      value_t max_scalar = get_first_element(a);
-      auto f_scalar      = [&a, &max_scalar](auto &&...args) { max_scalar = std::max(max_scalar, a(args...)); };
-      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
-      return std::max(max_scalar, xsimd::reduce_max(max_simd));
-    } else {
+    using dispatch_t = simd::dispatch_policy_t<A>;
+    if constexpr (std::is_same_v<dispatch_t, simd::scalar_t>) {
       return fold(
          [](auto const &x, auto const &y) {
            using std::max;
            return max(x, y);
          },
          a, get_first_element(a));
+    } else {
+      using value_t = get_value_t<A>;
+      using simd_t  = native_simd<value_t>;
+      simd_t max_simd(get_first_element(a));
+      auto f_simd        = [&a, &max_simd](auto &&...args) { max_simd = xsimd::max(max_simd, a.load(dispatch_t{}, args...)); };
+      value_t max_scalar = get_first_element(a);
+      auto f_scalar      = [&a, &max_scalar](auto &&...args) { max_scalar = std::max(max_scalar, a(args...)); };
+      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+      return std::max(max_scalar, xsimd::reduce_max(max_simd));
     }
   }
 
@@ -164,22 +166,23 @@ namespace nda {
    */
   template <Array A>
   auto min_element(A const &a) {
-    if constexpr (is_simd_enabled_v<A>) {
-      using value_t = get_value_t<A>;
-      using simd_t  = native_simd<value_t>;
-      simd_t min_simd(get_first_element(a));
-      auto f_simd        = [&a, &min_simd](auto &&...args) { min_simd = xsimd::min(min_simd, a.load(args...)); };
-      value_t min_scalar = get_first_element(a);
-      auto f_scalar      = [&a, &min_scalar](auto &&...args) { min_scalar = std::min(min_scalar, a(args...)); };
-      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
-      return std::min(min_scalar, xsimd::reduce_min(min_simd));
-    } else {
+    using dispatch_t = simd::dispatch_policy_t<A>;
+    if constexpr (std::is_same_v<dispatch_t, simd::scalar_t>) {
       return fold(
          [](auto const &x, auto const &y) {
            using std::min;
            return min(x, y);
          },
          a, get_first_element(a));
+    } else {
+      using value_t = get_value_t<A>;
+      using simd_t  = native_simd<value_t>;
+      simd_t min_simd(get_first_element(a));
+      auto f_simd        = [&a, &min_simd](auto &&...args) { min_simd = xsimd::min(min_simd, a.load(dispatch_t{}, args...)); };
+      value_t min_scalar = get_first_element(a);
+      auto f_scalar      = [&a, &min_scalar](auto &&...args) { min_scalar = std::min(min_scalar, a(args...)); };
+      nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
+      return std::min(min_scalar, xsimd::reduce_min(min_simd));
     }
   }
 
@@ -193,12 +196,20 @@ namespace nda {
    */
   template <ArrayOfRank<2> A>
   double frobenius_norm(A const &a) {
-    if constexpr (is_simd_enabled_v<A> and not is_complex_v<get_value_t<A>>) {
+    using dispatch_t = simd::dispatch_policy_t<A>;
+    if constexpr (std::is_same_v<dispatch_t, simd::scalar_t> or is_complex_v<get_value_t<A>>) {
+      return std::sqrt(fold(
+         [](double r, auto const &x) -> double {
+           auto ab = std::abs(x);
+           return r + ab * ab;
+         },
+         a, double(0)));
+    } else {
       using value_t = get_value_t<A>;
       using simd_t  = native_simd<value_t>;
       simd_t r_simd(value_t(0));
       auto f_simd = [&a, &r_simd](auto &&...args) {
-        simd_t x   = a.load(args...);
+        simd_t x   = a.load(dispatch_t{}, args...);
         simd_t abs = xsimd::abs(x);
         if constexpr (std::is_integral_v<value_t>) {
           r_simd = abs * abs + r_simd;
@@ -213,13 +224,6 @@ namespace nda {
       };
       nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
       return std::sqrt((static_cast<double>(xsimd::reduce_add(r_simd)) + r));
-    } else {
-      return std::sqrt(fold(
-         [](double r, auto const &x) -> double {
-           auto ab = std::abs(x);
-           return r + ab * ab;
-         },
-         a, double(0)));
     }
   }
 
@@ -235,17 +239,18 @@ namespace nda {
     requires(nda::Scalar<Value> or nda::Array<Value>)
   {
     if constexpr (nda::Scalar<Value>) {
-      if constexpr (is_simd_enabled_v<A>) {
+      using dispatch_t = simd::dispatch_policy_t<A>;
+      if constexpr (std::is_same_v<dispatch_t, simd::scalar_t>) {
+        return fold(std::plus<>{}, a);
+      } else {
         using value_t = get_value_t<A>;
         using simd_t  = native_simd<value_t>;
         simd_t sum_simd(value_t{0});
-        auto f_simd = [&a, &sum_simd](auto &&...args) { sum_simd += a.load(args...); };
+        auto f_simd = [&a, &sum_simd](auto &&...args) { sum_simd += a.load(dispatch_t{}, args...); };
         value_t sum_scalar{0};
         auto f_scalar = [&a, &sum_scalar](auto &&...args) { sum_scalar += a(args...); };
         nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
         return sum_scalar + xsimd::reduce_add(sum_simd);
-      } else {
-        return fold(std::plus<>{}, a);
       }
     } else {
       // Array<Value>
@@ -265,19 +270,21 @@ namespace nda {
     requires(nda::Scalar<Value> or nda::Array<Value>)
   {
     if constexpr (nda::Scalar<Value>) {
-      if constexpr (is_simd_enabled_v<A>) {
+      using dispatch_t = simd::dispatch_policy_t<A>;
+      if constexpr (std::is_same_v<dispatch_t, simd::scalar_t>) {
+        return fold(std::multiplies<>{}, a);
+      } else {
         using value_t = get_value_t<A>;
         using simd_t  = native_simd<value_t>;
         simd_t product_simd(value_t{1});
-        auto f_simd = [&a, &product_simd](auto &&...args) { product_simd *= a.load(args...); };
+        auto f_simd = [&a, &product_simd](auto &&...args) { product_simd *= a.load(dispatch_t{}, args...); };
         value_t product_scalar{1};
         auto f_scalar = [&a, &product_scalar](auto &&...args) { product_scalar *= a(args...); };
         nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
         return product_scalar * xsimd::reduce_mul(product_simd);
-      } else {
-        return fold(std::multiplies<>{}, a, get_value_t<A>{1});
       }
-    } else { // Array<Value>
+    } else {
+      // Array<Value>
       return fold(std::multiplies<>{}, a, Value::ones(get_first_element(a).shape()));
     }
   }

--- a/c++/nda/algorithms.hpp
+++ b/c++/nda/algorithms.hpp
@@ -69,18 +69,19 @@ namespace nda {
     return fold(std::move(f), a, get_value_t<A>{});
   }
 
-  template <Array A, typename F_SIMD, typename F_SCALAR, Vectorizable R>
-    requires(std::is_same_v<simd::dispatch_policy_t<A, R>, simd::vectorize_t> or std::is_same_v<simd::dispatch_policy_t<A, R>, simd::emulate_t>)
-  auto fold(F_SIMD f_simd, F_SCALAR f_scalar, A const &a, native_simd<R> r_simd, R r_scalar) {
-    nda::for_each_static<0, get_layout_info<A>.stride_order, native_simd<R>::size>(
-       a.shape(),
-       [&a, &r_simd, &f_simd](auto &&...args) { r_simd = f_simd(r_simd, native_simd<R>(a.load(simd::dispatch_policy_t<A, R>{}, args...))); },
-       [&a, &r_scalar, &f_scalar](auto &&...args) { r_scalar = f_scalar(r_scalar, a(args...)); });
-    alignas(native_simd<R>::arch_type::alignment()) std::array<R, r_simd.size()> res;
-    r_simd.store(res.data());
-    for (int i = 0; i < r_simd.size(); i++) { r_scalar = f_scalar(r_scalar, res[i]); }
-    return r_scalar;
-  }
+  //TODO: Maybe add another fold function that can interact with SIMD types.
+//  template <Array A, typename F_SIMD, typename F_SCALAR, Vectorizable R>
+//    requires(std::is_same_v<simd::dispatch_policy_t<A, R>, simd::vectorize_t> or std::is_same_v<simd::dispatch_policy_t<A, R>, simd::emulate_t>)
+//  auto fold(F_SIMD f_simd, F_SCALAR f_scalar, A const &a, native_simd<R> r_simd, R r_scalar) {
+//    nda::for_each_static<0, get_layout_info<A>.stride_order, native_simd<R>::size>(
+//       a.shape(),
+//       [&a, &r_simd, &f_simd](auto &&...args) { r_simd = f_simd(r_simd, native_simd<R>(a.load(simd::dispatch_policy_t<A, R>{}, args...))); },
+//       [&a, &r_scalar, &f_scalar](auto &&...args) { r_scalar = f_scalar(r_scalar, a(args...)); });
+//    alignas(native_simd<R>::arch_type::alignment()) std::array<R, r_simd.size()> res;
+//    r_simd.store(res.data());
+//    for (int i = 0; i < r_simd.size(); i++) { r_scalar = f_scalar(r_scalar, res[i]); }
+//    return r_scalar;
+//  }
 
   /**
    * @brief Does any of the elements of the array evaluate to true?

--- a/c++/nda/algorithms.hpp
+++ b/c++/nda/algorithms.hpp
@@ -200,8 +200,8 @@ namespace nda {
     if constexpr (std::is_same_v<dispatch_t, simd::scalar_t> or is_complex_v<get_value_t<A>>) {
       return std::sqrt(fold(
          [](double r, auto const &x) -> double {
-           auto ab = std::abs(x);
-           return r + ab * ab;
+           auto abs = std::abs(x);
+           return xsimd::fma(abs, abs, r);
          },
          a, double(0)));
     } else {
@@ -211,16 +211,12 @@ namespace nda {
       auto f_simd = [&a, &r_simd](auto &&...args) {
         simd_t x   = a.load(dispatch_t{}, args...);
         simd_t abs = xsimd::abs(x);
-        if constexpr (std::is_integral_v<value_t>) {
-          r_simd = abs * abs + r_simd;
-        } else {
-          r_simd = xsimd::fma(abs, abs, r_simd);
-        }
+        r_simd     = xsimd::fma(abs, abs, r_simd);
       };
       double r      = 0;
       auto f_scalar = [&a, &r](auto &&...args) {
         auto abs = std::abs(a(args...));
-        r        = abs * abs + r;
+        r        = xsimd::fma(abs, abs, r);
       };
       nda::for_each_static<0, get_layout_info<A>.stride_order, simd_t::size>(a.shape(), std::move(f_simd), std::move(f_scalar));
       return std::sqrt((static_cast<double>(xsimd::reduce_add(r_simd)) + r));

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -69,13 +69,10 @@ namespace nda {
     }
 
     template <typename... Args>
-    auto load(simd::vectorize_t, Args &&...args) const {
-      return -(a.load(simd::vectorize, std::forward<Args>(args)...));
-    }
-
-    template <typename... Args>
-    auto load(simd::emulate_t, Args &&...args) const {
-      return -(a.load(simd::emulate, std::forward<Args>(args)...));
+    auto load(auto simd_tag, Args &&...args) const {
+      static_assert(std::is_same_v<decltype(simd_tag), simd::vectorize_t> or std::is_same_v<decltype(simd_tag), simd::emulate_t>,
+                    "Load tag can only be vectorize or emulate");
+      return -(a.load(simd_tag, std::forward<Args>(args)...));
     }
 
     /**

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -389,14 +389,12 @@ namespace nda {
 
     public:
     template <typename... Args>
-    auto load(simd::vectorize_t, Args const &...args) const {
-      return _call_load<simd::vectorize_t>(args...);
+    auto load(auto simd_tag, Args const &...args) const {
+      static_assert(std::is_same_v<decltype(simd_tag), simd::vectorize_t> or std::is_same_v<decltype(simd_tag), simd::emulate_t>,
+                    "Load tag can only be vectorize or emulate");
+      return _call_load<decltype(simd_tag)>(args...);
     }
 
-    template <typename... Args>
-    auto load(simd::emulate_t, Args const &...args) const {
-      return _call_load<simd::emulate_t>(args...);
-    }
   };
 
   /**

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -277,19 +277,54 @@ namespace nda {
     private:
     template <typename Tag, typename... Args>
     auto _call_load(Args const &...args) const {
-      using dispatch_t   = Tag;
+      using dispatch_t = Tag;
+      /**
+     * This lambda implements a critical optimization for matrix/scalar
+     * binary operations (e.g., `M + s` or `s - M`) where `OP` is '+' or '-'.
+     *
+     * In an expression like `matrix + scalar`, the scalar value is only
+     * added to the diagonal elements of the matrix.
+     *
+     * This lambda is called by the expression's `load` function, which loads
+     * data one SIMD block at a time. The parameters `(i, j)` are the
+     * row/column indices of the *start* of the SIMD block being loaded.
+     *
+     * This function's job is to:
+     * 1. Detect if the current SIMD block contains a diagonal element.
+     * 2. If it does, create a temporary SIMD vector that has the scalar
+     * value *only* at that diagonal element's position (e.g., `[0, 0, s, 0]`).
+     * 3. Add or subtract this temporary vector from the matrix data.
+     * 4. If the block contains no diagonal element, just return the matrix data.
+     */
       auto diagonal_simd = [this](long i, long j) {
-        // This lambda function can only be used when we have a matrix. This constexpr is needed because otherwise we might get compile errors.
+        // This lambda is only valid for Matrix + Scalar operations. This if constexpr is needed so that we dont have compile errors for other cases.
         if constexpr (sizeof...(Args) == 2 and (Vectorizable<L_t> or Vectorizable<R_t>)) {
+
+          // Calculate the 'diagonal index'.
+          // For a C-layout (row-major) load starting at `(i, j)`, the vector
+          // loads elements `(i, j), (i, j+1), (i, j+2), ...`.
+          // A diagonal element `(i, i)` would be at index `k = i - j`
+          // (i.e., we are at element `(i, j+k)` and we need `j+k == i`).
           long diff = i - j;
+
+          // Handle F-layout (column-major).
+          // For an F-layout load starting at `(i, j)`, the vector loads
+          // `(i, j), (i+1, j), (i+2, j), ...`.
+          // A diagonal element `(j, j)` would be at index `k = j - i`
+          // (i.e., we are at element `(i+k, j)` and we need `i+k == j`).
+          // This flips the sign of our 'diff', so we correct for it here.
           if constexpr ((l_is_scalar and get_layout_info<R>.stride_order == Fortran_stride_order<2>)
                         or (r_is_scalar and get_layout_info<L>.stride_order == Fortran_stride_order<2>)) {
             diff = -diff;
           }
           if constexpr (l_is_scalar) {
             using simd_t = native_simd<L_t>;
+            // Check if the diagonal element's index `diff` is outside the bounds of our SIMD chunk
             if (diff < 0 or diff > simd_t::size - 1) return r.load(dispatch_t{}, i, j);
+            // A diagonal element is in this block at index `diff`.
+            // Create a temporary, zero-initialized array on the stack.
             alignas(simd_t::arch_type::alignment()) std::array<L_t, simd_t::size> tmp{};
+            // Place the scalar value `l` only at the diagonal position.
             tmp[diff] = l;
             if constexpr (OP == '+') {
               return r.load(dispatch_t{}, i, j) + simd_t::load_aligned(tmp.data());
@@ -298,8 +333,12 @@ namespace nda {
             }
           } else if constexpr (r_is_scalar) {
             using simd_t = native_simd<R_t>;
+            // Check if the diagonal element's index `diff` is outside the bounds of our SIMD chunk
             if (diff < 0 or diff > simd_t::size - 1) return l.load(dispatch_t{}, i, j);
+            // A diagonal element is in this block at index `diff`.
+            // Create a temporary, zero-initialized array on the stack.
             alignas(simd_t::arch_type::alignment()) std::array<R_t, simd_t::size> tmp{};
+            // Place the scalar value `r` only at the diagonal position.
             tmp[diff] = r;
             if constexpr (OP == '+') {
               return l.load(dispatch_t{}, i, j) + simd_t::load_aligned(tmp.data());
@@ -394,7 +433,6 @@ namespace nda {
                     "Load tag can only be vectorize or emulate");
       return _call_load<decltype(simd_tag)>(args...);
     }
-
   };
 
   /**

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -69,8 +69,13 @@ namespace nda {
     }
 
     template <typename... Args>
-    auto load(Args &&...args) const {
-      return -(a.load(std::forward<Args>(args)...));
+    auto load(simd::vectorize_t, Args &&...args) const {
+      return -(a.load(simd::vectorize, std::forward<Args>(args)...));
+    }
+
+    template <typename... Args>
+    auto load(simd::emulate_t, Args &&...args) const {
+      return -(a.load(simd::emulate, std::forward<Args>(args)...));
     }
 
     /**
@@ -269,8 +274,10 @@ namespace nda {
       return operator()(std::forward<Arg>(arg));
     }
 
-    template <typename... Args>
-    auto load(Args const &...args) const {
+    private:
+    template <typename Tag, typename... Args>
+    auto _call_load(Args const &...args) const {
+      using dispatch_t   = Tag;
       auto diagonal_simd = [this](long i, long j) {
         // This lambda function can only be used when we have a matrix. This constexpr is needed because otherwise we might get compile errors.
         if constexpr (sizeof...(Args) == 2 and (Vectorizable<L_t> or Vectorizable<R_t>)) {
@@ -281,23 +288,23 @@ namespace nda {
           }
           if constexpr (l_is_scalar) {
             using simd_t = native_simd<L_t>;
-            if (diff < 0 or diff > simd_t::size - 1) return r.load(i, j);
+            if (diff < 0 or diff > simd_t::size - 1) return r.load(dispatch_t{}, i, j);
             alignas(simd_t::arch_type::alignment()) std::array<L_t, simd_t::size> tmp{};
             tmp[diff] = l;
             if constexpr (OP == '+') {
-              return r.load(i, j) + simd_t::load_aligned(tmp.data());
+              return r.load(dispatch_t{}, i, j) + simd_t::load_aligned(tmp.data());
             } else {
-              return r.load(i, j) - simd_t::load_aligned(tmp.data());
+              return r.load(dispatch_t{}, i, j) - simd_t::load_aligned(tmp.data());
             }
           } else if constexpr (r_is_scalar) {
             using simd_t = native_simd<R_t>;
-            if (diff < 0 or diff > simd_t::size - 1) return l.load(i, j);
+            if (diff < 0 or diff > simd_t::size - 1) return l.load(dispatch_t{}, i, j);
             alignas(simd_t::arch_type::alignment()) std::array<R_t, simd_t::size> tmp{};
             tmp[diff] = r;
             if constexpr (OP == '+') {
-              return l.load(i, j) + simd_t::load_aligned(tmp.data());
+              return l.load(dispatch_t{}, i, j) + simd_t::load_aligned(tmp.data());
             } else {
-              return l.load(i, j) - simd_t::load_aligned(tmp.data());
+              return l.load(dispatch_t{}, i, j) - simd_t::load_aligned(tmp.data());
             }
           }
         }
@@ -311,7 +318,7 @@ namespace nda {
             return diagonal_simd(args...);
           else
             // rhs is an array
-            return native_simd<L_t>(l) + r.load(args...);
+            return native_simd<L_t>(l) + r.load(dispatch_t{}, args...);
         } else if constexpr (r_is_scalar) {
           // rhs is a scalar
           if constexpr (algebra == 'M') {
@@ -319,10 +326,10 @@ namespace nda {
             return diagonal_simd(args...);
           } else
             // lhs is an array
-            return l.load(args...) + native_simd<R_t>(r);
+            return l.load(dispatch_t{}, args...) + native_simd<R_t>(r);
         } else
           // both are arrays or matrices
-          return l.load(args...) + r.load(args...);
+          return l.load(dispatch_t{}, args...) + r.load(dispatch_t{}, args...);
       }
 
       // subtraction
@@ -334,7 +341,7 @@ namespace nda {
             return diagonal_simd(args...);
           else
             // rhs is an array
-            return native_simd<L_t>(l) - r.load(args...);
+            return native_simd<L_t>(l) - r.load(dispatch_t{}, args...);
         } else if constexpr (r_is_scalar) {
           // rhs is a scalar
           if constexpr (algebra == 'M')
@@ -342,24 +349,24 @@ namespace nda {
             return diagonal_simd(args...);
           else
             // lhs is an array
-            return l.load(args...) - native_simd<R_t>(r);
+            return l.load(dispatch_t{}, args...) - native_simd<R_t>(r);
         } else
           // both are arrays or matrices
-          return l.load(args...) - r.load(args...);
+          return l.load(dispatch_t{}, args...) - r.load(dispatch_t{}, args...);
       }
 
       // multiplication
       if constexpr (OP == '*') {
         if constexpr (l_is_scalar)
           // lhs is a scalar
-          return native_simd<L_t>(l) * r.load(args...);
+          return native_simd<L_t>(l) * r.load(dispatch_t{}, args...);
         else if constexpr (r_is_scalar)
           // rhs is a scalar
-          return l.load(args...) * native_simd<R_t>(r);
+          return l.load(dispatch_t{}, args...) * native_simd<R_t>(r);
         else {
           // both are arrays (matrix product is not supported here)
           static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
-          return l.load(args...) * r.load(args...);
+          return l.load(dispatch_t{}, args...) * r.load(dispatch_t{}, args...);
         }
       }
 
@@ -368,16 +375,27 @@ namespace nda {
         if constexpr (l_is_scalar) {
           // lhs is a scalar
           static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
-          return native_simd<L_t>(l) / r.load(args...);
+          return native_simd<L_t>(l) / r.load(dispatch_t{}, args...);
         } else if constexpr (r_is_scalar)
           // rhs is a scalar
-          return l.load(args...) / native_simd<R_t>(r);
+          return l.load(dispatch_t{}, args...) / native_simd<R_t>(r);
         else {
           // both are arrays (matrix division is not supported here)
           static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
-          return l.load(args...) / r.load(args...);
+          return l.load(dispatch_t{}, args...) / r.load(dispatch_t{}, args...);
         }
       }
+    }
+
+    public:
+    template <typename... Args>
+    auto load(simd::vectorize_t, Args const &...args) const {
+      return _call_load<simd::vectorize_t>(args...);
+    }
+
+    template <typename... Args>
+    auto load(simd::emulate_t, Args const &...args) const {
+      return _call_load<simd::emulate_t>(args...);
     }
   };
 

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -18,6 +18,7 @@
 #include "./macros.hpp"
 #include "./stdutil/complex.hpp"
 #include "./traits.hpp"
+#include "./simd.hpp"
 
 #include <functional>
 #include <type_traits>
@@ -65,6 +66,11 @@ namespace nda {
     template <typename... Args>
     auto operator()(Args &&...args) const {
       return -a(std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    auto load(Args &&...args) const {
+      return -(a.load(std::forward<Args>(args)...));
     }
 
     /**
@@ -259,6 +265,117 @@ namespace nda {
     auto operator[](Arg &&arg) const {
       static_assert(get_rank<expr> == 1, "Error in nda::expr: Subscript operator only available for expressions of rank 1");
       return operator()(std::forward<Arg>(arg));
+    }
+
+    template <typename... Args>
+    auto load(Args const &...args) const {
+      auto diagonal_simd = [this](long i, long j) {
+        // This lambda function can only be used when we have a matrix. This constexpr is needed because otherwise we might get compile errors.
+        if constexpr (sizeof...(Args) == 2 and (Vectorizable<L_t> or Vectorizable<R_t>)) {
+          long diff = i - j;
+          if constexpr ((l_is_scalar and get_layout_info<R>.stride_order == Fortran_stride_order<2>)
+                        or (r_is_scalar and get_layout_info<L>.stride_order == Fortran_stride_order<2>)) {
+            diff = -diff;
+          }
+          if constexpr (l_is_scalar) {
+            using simd_t = native_simd<L_t>;
+            if (diff < 0 or diff > simd_t::size - 1) return r.load(i, j);
+            alignas(simd_t::arch_type::alignment()) std::array<L_t, simd_t::size> tmp{};
+            tmp[diff] = l;
+            if constexpr (OP == '+') {
+              return r.load(i, j) + simd_t::load_aligned(tmp.data());
+            } else {
+              return r.load(i, j) - simd_t::load_aligned(tmp.data());
+            }
+          } else if constexpr (r_is_scalar) {
+            using simd_t = native_simd<R_t>;
+            if (diff < 0 or diff > simd_t::size - 1) return l.load(i, j);
+            alignas(simd_t::arch_type::alignment()) std::array<R_t, simd_t::size> tmp{};
+            tmp[diff] = r;
+            if constexpr (OP == '+') {
+              return l.load(i, j) + simd_t::load_aligned(tmp.data());
+            } else {
+              return l.load(i, j) - simd_t::load_aligned(tmp.data());
+            }
+          }
+        }
+      };
+      // addition
+      if constexpr (OP == '+') {
+        if constexpr (l_is_scalar) {
+          // lhs is a scalar
+          if constexpr (algebra == 'M')
+            // rhs is a matrix
+            return diagonal_simd(args...);
+          else
+            // rhs is an array
+            return native_simd<L_t>(l) + r.load(args...);
+        } else if constexpr (r_is_scalar) {
+          // rhs is a scalar
+          if constexpr (algebra == 'M') {
+            // lhs is a matrix
+            return diagonal_simd(args...);
+          } else
+            // lhs is an array
+            return l.load(args...) + native_simd<R_t>(r);
+        } else
+          // both are arrays or matrices
+          return l.load(args...) + r.load(args...);
+      }
+
+      // subtraction
+      if constexpr (OP == '-') {
+        if constexpr (l_is_scalar) {
+          // lhs is a scalar
+          if constexpr (algebra == 'M')
+            // rhs is a matrix
+            return diagonal_simd(args...);
+          else
+            // rhs is an array
+            return native_simd<L_t>(l) - r.load(args...);
+        } else if constexpr (r_is_scalar) {
+          // rhs is a scalar
+          if constexpr (algebra == 'M')
+            // lhs is a matrix
+            return diagonal_simd(args...);
+          else
+            // lhs is an array
+            return l.load(args...) - native_simd<R_t>(r);
+        } else
+          // both are arrays or matrices
+          return l.load(args...) - r.load(args...);
+      }
+
+      // multiplication
+      if constexpr (OP == '*') {
+        if constexpr (l_is_scalar)
+          // lhs is a scalar
+          return native_simd<L_t>(l) * r.load(args...);
+        else if constexpr (r_is_scalar)
+          // rhs is a scalar
+          return l.load(args...) * native_simd<R_t>(r);
+        else {
+          // both are arrays (matrix product is not supported here)
+          static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
+          return l.load(args...) * r.load(args...);
+        }
+      }
+
+      // division
+      if constexpr (OP == '/') {
+        if constexpr (l_is_scalar) {
+          // lhs is a scalar
+          static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
+          return native_simd<L_t>(l) / r.load(args...);
+        } else if constexpr (r_is_scalar)
+          // rhs is a scalar
+          return l.load(args...) / native_simd<R_t>(r);
+        else {
+          // both are arrays (matrix division is not supported here)
+          static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
+          return l.load(args...) / r.load(args...);
+        }
+      }
     }
   };
 

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -127,9 +127,11 @@ namespace nda {
      * @return nda::layout_info_t object.
      */
     static constexpr layout_info_t compute_layout_info() {
-      if (l_is_scalar) return (algebra == 'A' ? get_layout_info<R> : layout_info_t{}); // 1 as an array has all flags, it is just 1
-      if (r_is_scalar) return (algebra == 'A' ? get_layout_info<L> : layout_info_t{}); // 1 as a matrix does not, as it is diagonal only.
-      return get_layout_info<R> & get_layout_info<L>;                                  // default case. Take the logical and of all flags
+      if (l_is_scalar)
+        return get_layout_info<R>; //(algebra == 'A' ? get_layout_info<R> : layout_info_t{}); // 1 as an array has all flags, it is just 1
+      if (r_is_scalar)
+        return get_layout_info<L>; //(algebra == 'A' ? get_layout_info<L> : layout_info_t{}); // 1 as a matrix does not, as it is diagonal only.
+      return get_layout_info<R> & get_layout_info<L>; // default case. Take the logical and of all flags
     }
 
     /**

--- a/c++/nda/concepts.hpp
+++ b/c++/nda/concepts.hpp
@@ -88,8 +88,7 @@ namespace nda {
   * @tparam S Type to check.
   */
   template <typename S>
-  concept Vectorizable = xsimd::has_simd_register<S>::value;
-
+  concept Vectorizable = xsimd::has_simd_register<std::remove_cvref_t<S>>::value;
   /**
    * @brief Check if a given type is either a double or complex type.
    * @tparam S Type to check.
@@ -128,7 +127,7 @@ namespace nda {
   concept LoadWithNativeSimd = requires(F const &f) {
     requires Vectorizable<T>;
     {
-      []<auto... Is>(std::index_sequence<Is...>, auto const &aa) -> decltype(aa.load(native_simd<T>((static_cast<T>(Is)))...)) {
+      []<auto... Is>(std::index_sequence<Is...>, auto const & aa) -> decltype(aa.load(native_simd<T>((static_cast<T>(Is)))...)) {
         return (aa.load(native_simd<T>((static_cast<T>(Is)))...));
       }(std::make_index_sequence<R>{}, f)
     } -> std::same_as<native_simd<T>>;

--- a/c++/nda/concepts.hpp
+++ b/c++/nda/concepts.hpp
@@ -119,6 +119,16 @@ namespace nda {
   template <typename T, typename... Us>
   concept AnyOf = is_any_of<T, Us...>;
 
+  template <typename F, typename T, size_t R>
+  concept LoadWithNativeSimd = requires(F const &f) {
+    requires Vectorizable<T>;
+    {
+      []<auto... Is>(std::index_sequence<Is...>, auto const &aa) -> decltype(aa.load(native_simd<T>((static_cast<T>(Is)))...)) {
+        return (aa.load(native_simd<T>((static_cast<T>(Is)))...));
+      }(std::make_index_sequence<R>{}, f)
+    } -> std::same_as<native_simd<T>>;
+  };
+
   /** @} */
 
   namespace mem {

--- a/c++/nda/concepts.hpp
+++ b/c++/nda/concepts.hpp
@@ -12,6 +12,7 @@
 
 #include "./stdutil/concepts.hpp"
 #include "./traits.hpp"
+#include "./simd/simd.hpp"
 
 #include <array>
 #include <concepts>
@@ -81,6 +82,13 @@ namespace nda {
    */
   template <typename S>
   concept Scalar = nda::is_scalar_v<S>;
+
+  /**
+  * @brief Check if a given type is supported by simd class or complex type.
+  * @tparam S Type to check.
+  */
+  template <typename S>
+  concept Vectorizable = xsimd::has_simd_register<S>::value;
 
   /**
    * @brief Check if a given type is either a double or complex type.

--- a/c++/nda/concepts.hpp
+++ b/c++/nda/concepts.hpp
@@ -119,6 +119,11 @@ namespace nda {
   template <typename T, typename... Us>
   concept AnyOf = is_any_of<T, Us...>;
 
+  namespace simd {
+    template <typename Derived, Vectorizable T>
+    struct mock_simd;
+  }
+
   template <typename F, typename T, size_t R>
   concept LoadWithNativeSimd = requires(F const &f) {
     requires Vectorizable<T>;
@@ -127,7 +132,7 @@ namespace nda {
         return (aa.load(native_simd<T>((static_cast<T>(Is)))...));
       }(std::make_index_sequence<R>{}, f)
     } -> std::same_as<native_simd<T>>;
-  };
+  } or std::is_base_of_v<simd::mock_simd<F, T>, F>;
 
   /** @} */
 

--- a/c++/nda/declarations.hpp
+++ b/c++/nda/declarations.hpp
@@ -18,6 +18,7 @@
 #include "./mem/address_space.hpp"
 #include "./mem/policies.hpp"
 #include "./traits.hpp"
+#include "simd/simd_cost.hpp"
 
 #include <array>
 #include <cstddef>
@@ -404,59 +405,7 @@ namespace nda {
   inline constexpr layout_info_t get_layout_info<expr_call<F, As...>> = (get_layout_info<As> & ...);
 
   template <typename A, typename T = get_value_t<A>>
-  struct is_simd_enabled {
-    static constexpr bool value = false;
-  };
-
-  // Redirect if A is a reference or cv-qualified
-  template <typename A, typename T>
-    requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
-  struct is_simd_enabled<A, T> {
-    static constexpr bool value = is_simd_enabled<std::remove_cvref_t<A>, T>::value;
-  };
-
-  // Specialization for basic_array
-  template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
-  struct is_simd_enabled<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
-    static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<T, ValueType>
-       and get_layout_info<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>>.prop == layout_prop_e::contiguous;
-  };
-
-  // Specialization for basic_array_view
-  template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
-  struct is_simd_enabled<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
-    static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<T, ValueType>
-       and get_layout_info<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>>.prop == layout_prop_e::contiguous;
-  };
-
-  // Specialization for expr_call
-  template <typename F, Array... As, typename T>
-  struct is_simd_enabled<expr_call<F, As...>, T> {
-    static constexpr bool value = LoadWithNativeSimd<F, T, sizeof...(As)> and (is_simd_enabled<As, T>::value and ...)
-       and get_layout_info<expr_call<F, As...>>.stride_order != static_cast<uint64_t>(-1)
-       and get_layout_info<expr_call<F, As...>>.prop == layout_prop_e::contiguous;
-  };
-
-  // Specialization for expr_unary
-  template <char OP, Array A, typename T>
-  struct is_simd_enabled<expr_unary<OP, A>, T> {
-    static constexpr bool value = is_simd_enabled<A, T>::value and get_layout_info<expr_unary<OP, A>>.stride_order != static_cast<uint64_t>(-1)
-       and get_layout_info<expr_unary<OP, A>>.prop == layout_prop_e::contiguous;
-  };
-
-  // Specialization for expr binary
-  template <char OP, typename L, typename R, typename T>
-  struct is_simd_enabled<expr<OP, L, R>, T> {
-    static constexpr bool value = (is_scalar_v<L>    ? (is_simd_enabled<R, T>::value and std::is_same_v<T, std::remove_cvref_t<L>>) :
-                                      is_scalar_v<R> ? (is_simd_enabled<L, T>::value and std::is_same_v<T, std::remove_cvref_t<R>>) :
-                                                       (is_simd_enabled<L, T>::value and is_simd_enabled<R, T>::value))
-       and get_layout_info<expr<OP, L, R>>.stride_order != static_cast<uint64_t>(-1)
-       and get_layout_info<expr<OP, L, R>>.prop == layout_prop_e::contiguous;
-  };
-
-  // Convenience variable template
-  template <typename A, typename T = get_value_t<A>>
-  inline constexpr bool is_simd_enabled_v = is_simd_enabled<A, T>::value;
+  inline constexpr bool is_simd_enabled_v = std::is_same_v<simd::dispatch_policy_t<A, T>, simd::vectorize_t>;
 
   /** @} */
 

--- a/c++/nda/declarations.hpp
+++ b/c++/nda/declarations.hpp
@@ -400,6 +400,64 @@ namespace nda {
   template <char OP, typename L, typename R>
   inline constexpr layout_info_t get_layout_info<expr<OP, L, R>> = expr<OP, L, R>::compute_layout_info();
 
+  template <typename F, Array... As>
+  inline constexpr layout_info_t get_layout_info<expr_call<F, As...>> = (get_layout_info<As> & ...);
+
+  template <typename A, typename T = get_value_t<A>>
+  struct is_simd_enabled {
+    static constexpr bool value = false;
+  };
+
+  // Redirect if A is a reference or cv-qualified
+  template <typename A, typename T>
+    requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
+  struct is_simd_enabled<A, T> {
+    static constexpr bool value = is_simd_enabled<std::remove_cvref_t<A>, T>::value;
+  };
+
+  // Specialization for basic_array
+  template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
+  struct is_simd_enabled<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
+    static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<T, ValueType>
+       and get_layout_info<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>>.prop == layout_prop_e::contiguous;
+  };
+
+  // Specialization for basic_array_view
+  template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
+  struct is_simd_enabled<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
+    static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<T, ValueType>
+       and get_layout_info<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>>.prop == layout_prop_e::contiguous;
+  };
+
+  // Specialization for expr_call
+  template <typename F, Array... As, typename T>
+  struct is_simd_enabled<expr_call<F, As...>, T> {
+    static constexpr bool value = LoadWithNativeSimd<F, T, sizeof...(As)> and (is_simd_enabled<As, T>::value and ...)
+       and get_layout_info<expr_call<F, As...>>.stride_order != static_cast<uint64_t>(-1)
+       and get_layout_info<expr_call<F, As...>>.prop == layout_prop_e::contiguous;
+  };
+
+  // Specialization for expr_unary
+  template <char OP, Array A, typename T>
+  struct is_simd_enabled<expr_unary<OP, A>, T> {
+    static constexpr bool value = is_simd_enabled<A, T>::value and get_layout_info<expr_unary<OP, A>>.stride_order != static_cast<uint64_t>(-1)
+       and get_layout_info<expr_unary<OP, A>>.prop == layout_prop_e::contiguous;
+  };
+
+  // Specialization for expr binary
+  template <char OP, typename L, typename R, typename T>
+  struct is_simd_enabled<expr<OP, L, R>, T> {
+    static constexpr bool value = (is_scalar_v<L>    ? (is_simd_enabled<R, T>::value and std::is_same_v<T, std::remove_cvref_t<L>>) :
+                                      is_scalar_v<R> ? (is_simd_enabled<L, T>::value and std::is_same_v<T, std::remove_cvref_t<R>>) :
+                                                       (is_simd_enabled<L, T>::value and is_simd_enabled<R, T>::value))
+       and get_layout_info<expr<OP, L, R>>.stride_order != static_cast<uint64_t>(-1)
+       and get_layout_info<expr<OP, L, R>>.prop == layout_prop_e::contiguous;
+  };
+
+  // Convenience variable template
+  template <typename A, typename T = get_value_t<A>>
+  inline constexpr bool is_simd_enabled_v = is_simd_enabled<A, T>::value;
+
   /** @} */
 
 } // namespace nda

--- a/c++/nda/layout/for_each.hpp
+++ b/c++/nda/layout/for_each.hpp
@@ -72,6 +72,38 @@ namespace nda {
       }
     }
 
+    template <int I, uint64_t StaticExtents, uint64_t StrideOrder, size_t SIMD_SIZE, typename F_SIMD, typename F_SCALAR, size_t R,
+              std::integral Int = long>
+    FORCEINLINE void for_each_static_impl(std::array<Int, R> const &shape, std::array<long, R> &idxs, F_SIMD &f_simd, F_SCALAR &f_scalar) {
+      // Only difference from scalar implementation is that in the last dimension we call f_simd whenever we can.
+      if constexpr (I == R - 1) {
+        static constexpr int J = index_from_stride_order<R>(StrideOrder, I);
+        const long imax        = get_extent<J, R, StaticExtents>(shape);
+        size_t i               = 0;
+        for (; i + SIMD_SIZE <= imax; i += SIMD_SIZE) {
+          std::apply(f_simd, idxs);
+          idxs[J] += SIMD_SIZE;
+        }
+        for (; i < imax; ++i) {
+          std::apply(f_scalar, idxs);
+          ++idxs[J];
+        }
+        idxs[J] = 0;
+      } else {
+        // get the dimension over which to iterate and its extent
+        static constexpr int J = index_from_stride_order<R>(StrideOrder, I);
+        const long imax        = get_extent<J, R, StaticExtents>(shape);
+
+        // loop over all indices of the current dimension
+        for (long i = 0; i < imax; ++i) {
+          // recursive call for the next dimension
+          for_each_static_impl<I + 1, StaticExtents, StrideOrder, SIMD_SIZE>(shape, idxs, f_simd, f_scalar);
+          ++idxs[J];
+        }
+        idxs[J] = 0;
+      }
+    }
+
   } // namespace detail
 
   /**
@@ -97,6 +129,12 @@ namespace nda {
     detail::for_each_static_impl<0, StaticExtents, StrideOrder>(shape, idxs, f);
   }
 
+  template <uint64_t StaticExtents, uint64_t StrideOrder, size_t SIMD_SIZE, typename F_SIMD, typename F_SCALAR, auto R, std::integral Int = long>
+  FORCEINLINE void for_each_static(std::array<Int, R> const &shape, F_SIMD &&f_simd, F_SCALAR &&f_scalar) { // NOLINT (we do not want to forward here)
+    auto idxs = nda::stdutil::make_initialized_array<R>(0l);
+    detail::for_each_static_impl<0, StaticExtents, StrideOrder, SIMD_SIZE>(shape, idxs, f_simd, f_scalar);
+  }
+
   /**
    * @brief Loop over all possible index values of a given shape and apply a function to them.
    *
@@ -116,6 +154,12 @@ namespace nda {
   FORCEINLINE void for_each(std::array<Int, R> const &shape, F &&f) { // NOLINT (we do not want to forward here)
     auto idxs = nda::stdutil::make_initialized_array<R>(0l);
     detail::for_each_static_impl<0, 0, 0>(shape, idxs, f);
+  }
+
+  template <size_t SIMD_SIZE, typename F_SIMD, typename F_SCALAR, auto R, std::integral Int = long>
+  FORCEINLINE void for_each(std::array<Int, R> const &shape, F_SIMD &&f_simd, F_SCALAR &&f_scalar) { // NOLINT
+    auto idxs = nda::stdutil::make_initialized_array<R>(0l);
+    detail::for_each_static_impl<0, 0, 0, SIMD_SIZE, F_SIMD, F_SCALAR>(shape, idxs, f_simd, f_scalar);
   }
 
   /** @} */

--- a/c++/nda/layout/for_each.hpp
+++ b/c++/nda/layout/for_each.hpp
@@ -80,7 +80,8 @@ namespace nda {
         static constexpr int J = index_from_stride_order<R>(StrideOrder, I);
         const long imax        = get_extent<J, R, StaticExtents>(shape);
         size_t i               = 0;
-        for (; i + SIMD_SIZE <= imax; i += SIMD_SIZE) {
+        const size_t ilim      = imax & -static_cast<int64_t>(SIMD_SIZE);
+        for (; i < ilim; i += SIMD_SIZE) {
           std::apply(f_simd, idxs);
           idxs[J] += SIMD_SIZE;
         }

--- a/c++/nda/layout/for_each.hpp
+++ b/c++/nda/layout/for_each.hpp
@@ -75,10 +75,11 @@ namespace nda {
     template <int I, uint64_t StaticExtents, uint64_t StrideOrder, size_t SIMD_SIZE, typename F_SIMD, typename F_SCALAR, size_t R,
               std::integral Int = long>
     FORCEINLINE void for_each_static_impl(std::array<Int, R> const &shape, std::array<long, R> &idxs, F_SIMD &f_simd, F_SCALAR &f_scalar) {
+      // get the dimension over which to iterate and its extent
+      static constexpr int J = index_from_stride_order<R>(StrideOrder, I);
+      const long imax        = get_extent<J, R, StaticExtents>(shape);
       // Only difference from scalar implementation is that in the last dimension we call f_simd whenever we can.
       if constexpr (I == R - 1) {
-        static constexpr int J = index_from_stride_order<R>(StrideOrder, I);
-        const long imax        = get_extent<J, R, StaticExtents>(shape);
         size_t i               = 0;
         const size_t ilim      = imax & -static_cast<int64_t>(SIMD_SIZE);
         for (; i < ilim; i += SIMD_SIZE) {
@@ -91,10 +92,6 @@ namespace nda {
         }
         idxs[J] = 0;
       } else {
-        // get the dimension over which to iterate and its extent
-        static constexpr int J = index_from_stride_order<R>(StrideOrder, I);
-        const long imax        = get_extent<J, R, StaticExtents>(shape);
-
         // loop over all indices of the current dimension
         for (long i = 0; i < imax; ++i) {
           // recursive call for the next dimension

--- a/c++/nda/map.hpp
+++ b/c++/nda/map.hpp
@@ -100,7 +100,7 @@ namespace nda {
     private:
     // Implementation of the function call operator.
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] [[nodiscard]] auto _call(std::index_sequence<Is...>, Args const &...args) const {
+    [[nodiscard]] FORCEINLINE auto _call(std::index_sequence<Is...>, Args const &...args) const {
       // if args contains a range, we need to return an expr_call on the resulting slice
       if constexpr ((is_range_or_ellipsis<Args> or ... or false)) {
         return mapped<F>{f}(std::get<Is>(a)(args...)...);
@@ -111,18 +111,18 @@ namespace nda {
 
     // Implementation of the subscript operator.
     template <size_t... Is, typename Arg>
-    [[gnu::always_inline]] auto _call_bra(std::index_sequence<Is...>, Arg const &arg) const {
+    FORCEINLINE auto _call_bra(std::index_sequence<Is...>, Arg const &arg) const {
       return f(std::get<Is>(a)[arg]...);
     }
 
     // Implementation of load operator.
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] auto _call_load(simd::vectorize_t, std::index_sequence<Is...>, Args const &...args) const {
+    FORCEINLINE auto _call_load(simd::vectorize_t, std::index_sequence<Is...>, Args const &...args) const {
       return f.load(std::get<Is>(a).load(simd::vectorize, args...)...);
     }
 
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] auto _call_load(simd::emulate_t, std::index_sequence<Is...>, Args const &...args) const {
+    FORCEINLINE auto _call_load(simd::emulate_t, std::index_sequence<Is...>, Args const &...args) const {
       static_assert(sizeof...(As) > 0);
       using FirstElementType = std::tuple_element_t<0, decltype(a)>;
       using ValueType        = get_value_t<FirstElementType>;

--- a/c++/nda/map.hpp
+++ b/c++/nda/map.hpp
@@ -101,6 +101,12 @@ namespace nda {
       return f(std::get<Is>(a)[arg]...);
     }
 
+    // Implementation of load operator.
+    template <size_t... Is, typename... Args>
+    [[gnu::always_inline]] auto _call_load(std::index_sequence<Is...>, Args const &...args) const {
+      return f.load(std::get<Is>(a).load(args...)...);
+    }
+
     public:
     /**
      * @brief Function call operator.
@@ -117,6 +123,11 @@ namespace nda {
     template <typename... Args>
     auto operator()(Args const &...args) const {
       return _call(std::make_index_sequence<sizeof...(As)>{}, args...);
+    }
+
+    template <typename... Args>
+    auto load(Args const &...args) const {
+      return _call_load(std::make_index_sequence<sizeof...(As)>{}, args...);
     }
 
     /**

--- a/c++/nda/map.hpp
+++ b/c++/nda/map.hpp
@@ -58,10 +58,10 @@ namespace nda {
     struct emulator : simd::mock_simd<emulator<F, ValueType>, ValueType> {
       F functor;
 
-      emulator(const F functor) : functor(functor) {}
+      FORCEINLINE emulator(const F functor) : functor(functor) {}
 
       template <typename... ValueTypeArgs>
-      auto operator()(ValueTypeArgs const &...values) const {
+      FORCEINLINE auto operator()(ValueTypeArgs const &...values) const {
         return functor(values...);
       }
     };
@@ -152,12 +152,12 @@ namespace nda {
     }
 
     template <typename... Args>
-    auto load(simd::vectorize_t, Args const &...args) const {
+    FORCEINLINE auto load(simd::vectorize_t, Args const &...args) const {
       return _call_load(simd::vectorize, std::make_index_sequence<sizeof...(As)>{}, args...);
     }
 
     template <typename... Args>
-    auto load(simd::emulate_t, Args const &...args) const {
+    FORCEINLINE auto load(simd::emulate_t, Args const &...args) const {
       return _call_load(simd::emulate, std::make_index_sequence<sizeof...(As)>{}, args...);
     }
 

--- a/c++/nda/map.hpp
+++ b/c++/nda/map.hpp
@@ -14,6 +14,7 @@
 #include "./layout/range.hpp"
 #include "./macros.hpp"
 #include "./traits.hpp"
+#include "./simd/simd_cost.hpp"
 
 #include <cstddef>
 #include <utility>
@@ -52,6 +53,19 @@ namespace nda {
   template <typename F, Array... As>
   constexpr char get_algebra<expr_call<F, As...>> = detail::_impl_find_common_algebra(get_algebra<As>...);
 
+  namespace detail {
+    template <typename F, typename ValueType>
+    struct emulator : simd::mock_simd<emulator<F, ValueType>, ValueType> {
+      F functor;
+
+      emulator(const F functor) : functor(functor) {}
+
+      template <typename... ValueTypeArgs>
+      auto operator()(ValueTypeArgs const &...values) const {
+        return functor(values...);
+      }
+    };
+  } // namespace detail
   /**
    * @addtogroup av_math
    * @{
@@ -103,8 +117,20 @@ namespace nda {
 
     // Implementation of load operator.
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] auto _call_load(std::index_sequence<Is...>, Args const &...args) const {
-      return f.load(std::get<Is>(a).load(args...)...);
+    [[gnu::always_inline]] auto _call_load(simd::vectorize_t, std::index_sequence<Is...>, Args const &...args) const {
+      return f.load(std::get<Is>(a).load(simd::vectorize, args...)...);
+    }
+
+    template <size_t... Is, typename... Args>
+    [[gnu::always_inline]] auto _call_load(simd::emulate_t, std::index_sequence<Is...>, Args const &...args) const {
+      static_assert(sizeof...(As) > 0);
+      using FirstElementType = std::tuple_element_t<0, decltype(a)>;
+      using ValueType        = get_value_t<FirstElementType>;
+      if constexpr (LoadWithNativeSimd<F, ValueType, sizeof...(As)>) {
+        return f.load(std::get<Is>(a).load(simd::emulate, args...)...);
+      } else {
+        return detail::emulator<F, ValueType>{f}.load(std::get<Is>(a).load(simd::emulate, args...)...);
+      }
     }
 
     public:
@@ -126,8 +152,13 @@ namespace nda {
     }
 
     template <typename... Args>
-    auto load(Args const &...args) const {
-      return _call_load(std::make_index_sequence<sizeof...(As)>{}, args...);
+    auto load(simd::vectorize_t, Args const &...args) const {
+      return _call_load(simd::vectorize, std::make_index_sequence<sizeof...(As)>{}, args...);
+    }
+
+    template <typename... Args>
+    auto load(simd::emulate_t, Args const &...args) const {
+      return _call_load(simd::emulate, std::make_index_sequence<sizeof...(As)>{}, args...);
     }
 
     /**

--- a/c++/nda/mapped_functions.hpp
+++ b/c++/nda/mapped_functions.hpp
@@ -62,6 +62,7 @@ namespace nda {
       auto operator()(auto const &x) const { return conj(x); };
 
       auto load(auto const &x) const {
+        //TODO: We need to change this check after custom complex class.
         if constexpr (xsimd::is_batch_complex<std::remove_cvref_t<decltype(x)>>::value) {
           return xsimd::conj(x);
         } else {
@@ -72,17 +73,21 @@ namespace nda {
 
     struct pow_f {
       double exponent;
-      auto operator()(auto const &x) const { return std::pow(x, exponent); }
+      auto operator()(auto const &x) const {
+        using std::pow;
+        return pow(x, exponent);
+      }
       auto load(auto const &x) const {
+        using xsimd::pow;
         using simd_t = std::remove_cvref_t<decltype(x)>;
-        return xsimd::pow(x, simd_t(exponent));
+        return pow(x, simd_t(exponent));
       }
     };
 
-    template <typename F_SCALAR, typename F_SIMD>
+    template <typename F>
     struct unary_functor {
-      auto operator()(auto const &x) const { return F_SCALAR{}(x); }
-      auto load(auto const &x) const { return F_SIMD{}(x); }
+      auto operator()(auto const &x) const { return F{}(x); }
+      auto load(auto const &x) const { return F{}(x); }
     };
   } // namespace detail
 

--- a/c++/nda/mapped_functions.hpp
+++ b/c++/nda/mapped_functions.hpp
@@ -60,8 +60,30 @@ namespace nda {
     // Functor for nda::detail::conj.
     struct conj_f {
       auto operator()(auto const &x) const { return conj(x); };
+
+      auto load(auto const &x) const {
+        if constexpr (xsimd::is_batch_complex<std::remove_cvref_t<decltype(x)>>::value) {
+          return xsimd::conj(x);
+        } else {
+          return x;
+        }
+      }
     };
 
+    struct pow_f {
+      double exponent;
+      auto operator()(auto const &x) const { return std::pow(x, exponent); }
+      auto load(auto const &x) const {
+        using simd_t = std::remove_cvref_t<decltype(x)>;
+        return xsimd::pow(x, simd_t(exponent));
+      }
+    };
+
+    template <typename F_SCALAR, typename F_SIMD>
+    struct unary_functor {
+      auto operator()(auto const &x) const { return F_SCALAR{}(x); }
+      auto load(auto const &x) const { return F_SIMD{}(x); }
+    };
   } // namespace detail
 
   /**
@@ -74,10 +96,7 @@ namespace nda {
    */
   template <ArrayOrScalar A>
   auto pow(A &&a, double p) {
-    return nda::map([p](auto const &x) {
-      using std::pow;
-      return pow(x, p);
-    })(std::forward<A>(a));
+    return nda::map(detail::pow_f{p})(std::forward<A>(a));
   }
 
   /**
@@ -91,10 +110,11 @@ namespace nda {
    */
   template <ArrayOrScalar A>
   decltype(auto) conj(A &&a) {
-    if constexpr (is_complex_v<get_value_t<A>>)
+    if constexpr (is_complex_v<get_value_t<A>>) {
       return nda::map(detail::conj_f{})(std::forward<A>(a));
-    else
+    } else {
       return std::forward<A>(a);
+    }
   }
 
   /** @} */

--- a/c++/nda/mapped_functions.hpp
+++ b/c++/nda/mapped_functions.hpp
@@ -73,11 +73,11 @@ namespace nda {
 
     struct pow_f {
       double exponent;
-      auto operator()(auto const &x) const {
+      FORCEINLINE auto operator()(auto const &x) const {
         using std::pow;
         return pow(x, exponent);
       }
-      auto load(auto const &x) const {
+      FORCEINLINE auto load(auto const &x) const {
         using xsimd::pow;
         using simd_t = std::remove_cvref_t<decltype(x)>;
         return pow(x, simd_t(exponent));
@@ -86,8 +86,8 @@ namespace nda {
 
     template <typename F>
     struct unary_functor {
-      auto operator()(auto const &x) const { return F{}(x); }
-      auto load(auto const &x) const { return F{}(x); }
+      FORCEINLINE auto operator()(auto const &x) const { return F{}(x); }
+      FORCEINLINE auto load(auto const &x) const { return F{}(x); }
     };
   } // namespace detail
 

--- a/c++/nda/mapped_functions.hxx
+++ b/c++/nda/mapped_functions.hxx
@@ -94,11 +94,14 @@ namespace nda {
   /// \return A lazy nda::expr_call object (nda::Array) or the result of `std::abs` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto abs(A &&a)  {
-    return nda::map(
-       [](auto const &x) {
-         using std::abs;
-         return abs(x);
-       })(std::forward<A>(a));
+    if constexpr (std::is_unsigned_v<get_value_t<A>>) {
+      return a;
+    } else {
+      return nda::map([](auto const &x) {
+        using std::abs;
+        return abs(x);
+      })(std::forward<A>(a));
+    }
   }
 
   /// \brief Function imag for nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).

--- a/c++/nda/mapped_functions.hxx
+++ b/c++/nda/mapped_functions.hxx
@@ -125,11 +125,10 @@ namespace nda {
   /// \return A lazy nda::expr_call object (nda::Array) or the result of `std::floor` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto floor(A &&a)  {
-    return nda::map(
-       [](auto const &x) {
-         using std::floor;
-         return floor(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::floor(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::floor(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function real for nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -172,11 +171,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::exp` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto exp(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::exp;
-         return exp(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::exp(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::exp(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function cos for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -186,11 +184,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::cos` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto cos(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::cos;
-         return cos(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::cos(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::cos(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function sin for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -200,11 +197,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::sin` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto sin(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::sin;
-         return sin(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::sin(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::sin(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function tan for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -214,11 +210,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::tan` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto tan(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::tan;
-         return tan(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::tan(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::tan(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function cosh for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -228,11 +223,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::cosh` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto cosh(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::cosh;
-         return cosh(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::cosh(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::cosh(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function sinh for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -242,11 +236,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::sinh` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto sinh(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::sinh;
-         return sinh(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::sinh(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::sinh(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function tanh for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -256,11 +249,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::tanh` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto tanh(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::tanh;
-         return tanh(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::tanh(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::tanh(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function acos for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -270,11 +262,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::acos` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto acos(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::acos;
-         return acos(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::acos(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::acos(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function asin for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -284,11 +275,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::asin` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto asin(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::asin;
-         return asin(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::asin(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::asin(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function atan for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -298,11 +288,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::atan` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto atan(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::atan;
-         return atan(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::atan(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::atan(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function log for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -312,11 +301,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::log` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto log(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::log;
-         return log(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::log(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::log(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function sqrt for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -326,11 +314,10 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::sqrt` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto sqrt(A &&a) requires(get_algebra<A> != 'M') {
-    return nda::map(
-       [](auto const &x) {
-         using std::sqrt;
-         return sqrt(x);
-       })(std::forward<A>(a));
+    auto scalar_lambda = [](auto const &x) { return std::sqrt(x); };
+    auto simd_lambda   = [](auto const &x) { return xsimd::sqrt(x); };
+
+    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
   }
 
   /** @} */

--- a/c++/nda/mapped_functions.hxx
+++ b/c++/nda/mapped_functions.hxx
@@ -95,7 +95,7 @@ namespace nda {
   template <ArrayOrScalar A>
   auto abs(A &&a)  {
     if constexpr (std::is_unsigned_v<get_value_t<A>>) {
-      return a;
+      return std::forward<A>(a);
     } else {
       return nda::map([](auto const &x) {
         using std::abs;
@@ -125,10 +125,13 @@ namespace nda {
   /// \return A lazy nda::expr_call object (nda::Array) or the result of `std::floor` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto floor(A &&a)  {
-    auto scalar_lambda = [](auto const &x) { return std::floor(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::floor(x); };
+    auto lambda = [](auto const &x) {
+      using std::floor;
+      using xsimd::floor;
+      return floor(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function real for nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -171,10 +174,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::exp` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto exp(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::exp(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::exp(x); };
+    auto lambda = [](auto const &x) {
+      using std::exp;
+      using xsimd::exp;
+      return exp(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function cos for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -184,10 +190,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::cos` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto cos(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::cos(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::cos(x); };
+    auto lambda = [](auto const &x) {
+      using std::cos;
+      using xsimd::cos;
+      return cos(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function sin for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -197,10 +206,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::sin` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto sin(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::sin(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::sin(x); };
+    auto lambda = [](auto const &x) {
+      using std::sin;
+      using xsimd::sin;
+      return sin(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function tan for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -210,10 +222,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::tan` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto tan(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::tan(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::tan(x); };
+    auto lambda = [](auto const &x) {
+      using std::tan;
+      using xsimd::tan;
+      return tan(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function cosh for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -223,10 +238,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::cosh` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto cosh(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::cosh(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::cosh(x); };
+    auto lambda = [](auto const &x) {
+      using std::cosh;
+      using xsimd::cosh;
+      return cosh(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function sinh for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -236,10 +254,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::sinh` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto sinh(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::sinh(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::sinh(x); };
+    auto lambda = [](auto const &x) {
+      using std::sinh;
+      using xsimd::sinh;
+      return sinh(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function tanh for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -249,10 +270,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::tanh` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto tanh(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::tanh(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::tanh(x); };
+    auto lambda = [](auto const &x) {
+      using std::tanh;
+      using xsimd::tanh;
+      return tanh(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function acos for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -262,10 +286,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::acos` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto acos(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::acos(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::acos(x); };
+    auto lambda = [](auto const &x) {
+      using std::acos;
+      using xsimd::acos;
+      return acos(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function asin for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -275,10 +302,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::asin` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto asin(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::asin(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::asin(x); };
+    auto lambda = [](auto const &x) {
+      using std::asin;
+      using xsimd::asin;
+      return asin(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function atan for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -288,10 +318,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::atan` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto atan(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::atan(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::atan(x); };
+    auto lambda = [](auto const &x) {
+      using std::atan;
+      using xsimd::atan;
+      return atan(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function log for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -301,10 +334,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::log` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto log(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::log(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::log(x); };
+    auto lambda = [](auto const &x) {
+      using std::log;
+      using xsimd::log;
+      return log(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /// \brief Function sqrt for non-matrix nda::ArrayOrScalar types (lazy and coefficient-wise for nda::Array types).
@@ -314,10 +350,13 @@ namespace nda {
   /// \return  A lazy nda::expr_call object (nda::Array) or the result of `std::sqrt` applied to the object (nda::Scalar).
   template <ArrayOrScalar A>
   auto sqrt(A &&a) requires(get_algebra<A> != 'M') {
-    auto scalar_lambda = [](auto const &x) { return std::sqrt(x); };
-    auto simd_lambda   = [](auto const &x) { return xsimd::sqrt(x); };
+    auto lambda = [](auto const &x) {
+      using std::sqrt;
+      using xsimd::sqrt;
+      return sqrt(x);
+    };
 
-    return nda::map(detail::unary_functor<decltype(scalar_lambda), decltype(simd_lambda)>{})(std::forward<A>(a));
+    return nda::map(detail::unary_functor<decltype(lambda)>{})(std::forward<A>(a));
   }
 
   /** @} */

--- a/c++/nda/mapped_functions.hxx
+++ b/c++/nda/mapped_functions.hxx
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 /**
  * @file
  * @brief Provides lazy, coefficient-wise array operations of standard mathematical functions together with overloads

--- a/c++/nda/mapped_functions.hxx
+++ b/c++/nda/mapped_functions.hxx
@@ -126,7 +126,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto floor(A &&a)  {
     auto lambda = [](auto const &x) {
-      using std::floor;
       using xsimd::floor;
       return floor(x);
     };
@@ -175,7 +174,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto exp(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::exp;
       using xsimd::exp;
       return exp(x);
     };
@@ -191,7 +189,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto cos(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::cos;
       using xsimd::cos;
       return cos(x);
     };
@@ -207,7 +204,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto sin(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::sin;
       using xsimd::sin;
       return sin(x);
     };
@@ -223,7 +219,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto tan(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::tan;
       using xsimd::tan;
       return tan(x);
     };
@@ -239,7 +234,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto cosh(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::cosh;
       using xsimd::cosh;
       return cosh(x);
     };
@@ -255,7 +249,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto sinh(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::sinh;
       using xsimd::sinh;
       return sinh(x);
     };
@@ -271,7 +264,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto tanh(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::tanh;
       using xsimd::tanh;
       return tanh(x);
     };
@@ -287,7 +279,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto acos(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::acos;
       using xsimd::acos;
       return acos(x);
     };
@@ -303,7 +294,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto asin(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::asin;
       using xsimd::asin;
       return asin(x);
     };
@@ -319,7 +309,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto atan(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::atan;
       using xsimd::atan;
       return atan(x);
     };
@@ -335,7 +324,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto log(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::log;
       using xsimd::log;
       return log(x);
     };
@@ -351,7 +339,6 @@ namespace nda {
   template <ArrayOrScalar A>
   auto sqrt(A &&a) requires(get_algebra<A> != 'M') {
     auto lambda = [](auto const &x) {
-      using std::sqrt;
       using xsimd::sqrt;
       return sqrt(x);
     };

--- a/c++/nda/nda.hpp
+++ b/c++/nda/nda.hpp
@@ -44,6 +44,7 @@
 #include "./print.hpp"
 #include "./stdutil.hpp"
 #include "./traits.hpp"
+#include "./simd.hpp"
 
 // If we are using c2py, include converters automatically
 #ifdef C2PY_INCLUDED

--- a/c++/nda/simd.hpp
+++ b/c++/nda/simd.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 #pragma once
 #include "simd/simd_fwd.hpp"
 #include "simd/simd.hpp"

--- a/c++/nda/simd.hpp
+++ b/c++/nda/simd.hpp
@@ -1,3 +1,4 @@
 #pragma once
 #include "simd/simd.hpp"
 #include "simd/mock_simd.hpp"
+#include "simd/simd_cost.hpp"

--- a/c++/nda/simd.hpp
+++ b/c++/nda/simd.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "simd/simd_fwd.hpp"
 #include "simd/simd.hpp"
 #include "simd/mock_simd.hpp"
 #include "simd/simd_cost.hpp"

--- a/c++/nda/simd.hpp
+++ b/c++/nda/simd.hpp
@@ -1,2 +1,3 @@
 #pragma once
 #include "simd/simd.hpp"
+#include "simd/mock_simd.hpp"

--- a/c++/nda/simd.hpp
+++ b/c++/nda/simd.hpp
@@ -1,0 +1,2 @@
+#pragma once
+#include "simd/simd.hpp"

--- a/c++/nda/simd/mock_simd.hpp
+++ b/c++/nda/simd/mock_simd.hpp
@@ -8,25 +8,25 @@ namespace nda::simd {
     using simd_t  = native_simd<T>;
 
     template <typename... Args>
-    value_t operator()(Args &&...args) const {
+    FORCEINLINE value_t operator()(Args &&...args) const {
       static_assert((std::is_same_v<value_t, std::remove_cvref_t<Args>> and ...), "All types have to be the same.");
       return static_cast<const Derived *>(this)->operator()(std::forward<Args>(args)...);
     }
 
     private:
-    [[gnu::always_inline]] std::array<value_t, simd_t::size> convert_simd_to_array(const simd_t &a) const  {
+    FORCEINLINE std::array<value_t, simd_t::size> convert_simd_to_array(const simd_t &a) const {
       alignas(simd_t::arch_type::alignment()) std::array<T, simd_t::size> result;
       a.store_aligned(result.data());
       return result;
     }
 
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] auto make_array_tuple(std::index_sequence<Is...>, const std::tuple<Args...> &args_tuple) const {
+    FORCEINLINE auto make_array_tuple(std::index_sequence<Is...>, const std::tuple<Args...> &args_tuple) const {
       return std::make_tuple(convert_simd_to_array(std::get<Is>(args_tuple))...);
     }
 
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] auto apply_function(std::index_sequence<Is...>, const std::tuple<Args...> &array_tuple) const {
+    FORCEINLINE auto apply_function(std::index_sequence<Is...>, const std::tuple<Args...> &array_tuple) const {
       alignas(simd_t::arch_type::alignment()) std::array<T, simd_t::size> result_array;
       for (int i = 0; i < simd_t::size; ++i) { result_array[i] = static_cast<const Derived *>(this)->operator()(std::get<Is>(array_tuple)[i]...); }
       return result_array;
@@ -34,7 +34,7 @@ namespace nda::simd {
 
     public:
     template <typename... Args>
-    simd_t load(Args &&...args) const {
+    FORCEINLINE simd_t load(Args &&...args) const {
       static_assert((std::is_same_v<simd_t, std::remove_cvref_t<Args>> and ...), "All types have to be the same.");
       constexpr size_t args_size        = sizeof...(Args);
       std::tuple<Args &&...> args_tuple = std::forward_as_tuple(std::forward<Args>(args)...);

--- a/c++/nda/simd/mock_simd.hpp
+++ b/c++/nda/simd/mock_simd.hpp
@@ -27,9 +27,15 @@ namespace nda::simd {
 
     template <size_t... Is, typename... Args>
     FORCEINLINE auto apply_function(std::index_sequence<Is...>, const std::tuple<Args...> &array_tuple) const {
-      alignas(simd_t::arch_type::alignment()) std::array<T, simd_t::size> result_array;
-      for (int i = 0; i < simd_t::size; ++i) { result_array[i] = static_cast<const Derived *>(this)->operator()(std::get<Is>(array_tuple)[i]...); }
-      return result_array;
+      auto build = [&]<size_t... Js>(std::index_sequence<Js...>) {
+        auto compute_one_element = [&](size_t i) -> T { return static_cast<const Derived *>(this)->operator()(std::get<Is>(array_tuple)[i]...); };
+
+        alignas(simd_t::arch_type::alignment()) std::array<T, simd_t::size> result_array = {compute_one_element(Js)...};
+
+        return result_array;
+      };
+
+      return build(std::make_index_sequence<simd_t::size>{});
     }
 
     public:

--- a/c++/nda/simd/mock_simd.hpp
+++ b/c++/nda/simd/mock_simd.hpp
@@ -1,0 +1,47 @@
+#pragma once
+#include "../concepts.hpp"
+
+namespace nda::simd {
+  template <typename Derived, Vectorizable T>
+  struct mock_simd {
+    using value_t = T;
+    using simd_t  = native_simd<T>;
+
+    template <typename... Args>
+    value_t operator()(Args &&...args) const {
+      static_assert((std::is_same_v<value_t, std::remove_cvref_t<Args>> and ...), "All types have to be the same.");
+      return static_cast<const Derived *>(this)->operator()(std::forward<Args>(args)...);
+    }
+
+    private:
+    [[gnu::always_inline]] std::array<value_t, simd_t::size> convert_simd_to_array(const simd_t &a) const  {
+      alignas(simd_t::arch_type::alignment()) std::array<T, simd_t::size> result;
+      a.store_aligned(result.data());
+      return result;
+    }
+
+    template <size_t... Is, typename... Args>
+    [[gnu::always_inline]] auto make_array_tuple(std::index_sequence<Is...>, const std::tuple<Args...> &args_tuple) const {
+      return std::make_tuple(convert_simd_to_array(std::get<Is>(args_tuple))...);
+    }
+
+    template <size_t... Is, typename... Args>
+    [[gnu::always_inline]] auto apply_function(std::index_sequence<Is...>, const std::tuple<Args...> &array_tuple) const {
+      alignas(simd_t::arch_type::alignment()) std::array<T, simd_t::size> result_array;
+      for (int i = 0; i < simd_t::size; ++i) { result_array[i] = static_cast<const Derived *>(this)->operator()(std::get<Is>(array_tuple)[i]...); }
+      return result_array;
+    }
+
+    public:
+    template <typename... Args>
+    simd_t load(Args &&...args) const {
+      static_assert((std::is_same_v<simd_t, std::remove_cvref_t<Args>> and ...), "All types have to be the same.");
+      constexpr size_t args_size        = sizeof...(Args);
+      std::tuple<Args &&...> args_tuple = std::forward_as_tuple(std::forward<Args>(args)...);
+      auto array_tuple                  = make_array_tuple(std::make_index_sequence<args_size>{}, args_tuple);
+      alignas(simd_t::arch_type::alignment()) std::array<value_t, simd_t::size> result_array;
+      result_array = apply_function(std::make_index_sequence<args_size>{}, array_tuple);
+      return simd_t::load_aligned(result_array.data());
+    }
+  };
+}

--- a/c++/nda/simd/mock_simd.hpp
+++ b/c++/nda/simd/mock_simd.hpp
@@ -44,4 +44,4 @@ namespace nda::simd {
       return simd_t::load_aligned(result_array.data());
     }
   };
-}
+} // namespace nda::simd

--- a/c++/nda/simd/mock_simd.hpp
+++ b/c++/nda/simd/mock_simd.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 #pragma once
 #include "../concepts.hpp"
 

--- a/c++/nda/simd/simd.hpp
+++ b/c++/nda/simd/simd.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <xsimd/xsimd.hpp>
+
+#include <type_traits>
+
+namespace nda {
+  // TODO: create custom complex class.
+  template <typename T>
+  using native_simd = xsimd::batch<std::remove_cvref_t<T>>;
+
+  template <typename T, size_t Width>
+  using fixed_size_simd = xsimd::make_sized_batch_t<std::remove_cvref_t<T>, Width>;
+
+} // namespace nda

--- a/c++/nda/simd/simd.hpp
+++ b/c++/nda/simd/simd.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 #pragma once
 
 #include <xsimd/xsimd.hpp>

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -20,180 +20,268 @@ namespace nda {
 
   template <typename F, Array... A>
   struct expr_call;
+
+  template <typename T>
+  concept IsBasicArray = requires {
+    []<typename ValueType, int Rank, typename Layout, char Algebra, typename ContainerPolicy>(
+       basic_array<ValueType, Rank, Layout, Algebra, ContainerPolicy>) {}(std::declval<T>());
+  };
+
+  template <typename T>
+  concept IsBasicArrayView = requires {
+    []<typename ValueType, int Rank, typename Layout, char Algebra, typename AccessorPolicy, typename OwningPolicy>(
+       basic_array_view<ValueType, Rank, Layout, Algebra, AccessorPolicy, OwningPolicy>) {}(std::declval<T>());
+  };
+
+  template <typename T>
+  concept IsExprUnary = requires { []<char OP, Array A>(expr_unary<OP, A>) {}(std::declval<T>()); };
+
+  template <typename T>
+  concept IsExprCall = requires { []<typename F, Array... As>(expr_call<F, As...>) {}(std::declval<T>()); };
+
+  template <typename T>
+  concept IsExpr = requires { []<char OP, typename L, typename R>(expr<OP, L, R>) {}(std::declval<T>()); };
+
   namespace simd {
-    //Forward declaration
-    template <typename A>
-    struct expr_cost;
+    /**
+     * @brief Computes the compile-time "cost" of evaluating an expression template.
+     *
+     * This function recursively traverses the expression tree defined by the
+     * template type `E` and calculates a cost based on the following rules:
+     *
+     * - **Cost 0:** Any non-array/expression type (e.g., scalars) has zero cost.
+     * - **Cost 1:** Terminal nodes (basic_array or basic_array_view) have a cost of 1,
+     * as they represent one leaf variable.
+     * - **Cost 1 + children:** Unary, binary, and function-call expressions have a
+     * cost of 1 (for the operation itself) plus the sum of the costs of all
+     * their child expressions.
+     *
+     * This `consteval` function replaces the C++17 struct-based template
+     * metaprogramming. It uses `if constexpr` to branch at compile time and
+     * template lambdas to "pattern match" and extract sub-expression types.
+     */
+    template <typename A_in>
+    static consteval size_t expr_cost() {
+      using A = std::remove_cvref_t<A_in>;
+      // Case 1 & 2: basic_array and basic_array_view (Terminals)
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
+        return 1;
+      }
+      // Case 3: expr_unary
+      else if constexpr (IsExprUnary<A>) {
+        return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return 1 + expr_cost<E>(); }(std::type_identity<A>{});
+      }
+      // Case 4: expr_call
+      else if constexpr (IsExprCall<A>) {
+        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) { return 1 + (expr_cost<As>() + ...); }(std::type_identity<A>{});
+      }
+      // Case 5: expr (binary)
+      else if constexpr (IsExpr<A>) {
+        return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
+          return 1 + expr_cost<L>() + expr_cost<R>();
+        }(std::type_identity<A>{});
+      }
+      // Case 0: Base case for any other type (like int, double, etc.)
+      else {
+        return 0;
+      }
+    }
 
-    namespace detail {
-
-      template <typename A>
-      struct expr_cost_impl {
-        static constexpr size_t value = 0;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy>
-      struct expr_cost_impl<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>> {
-        static constexpr size_t value = 1;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy>
-      struct expr_cost_impl<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>> {
-        static constexpr size_t value = 1;
-      };
-
-      template <char OP, Array A>
-      struct expr_cost_impl<expr_unary<OP, A>> {
-        static constexpr size_t value = 1 + expr_cost<A>::value;
-      };
-
-      template <typename F, Array... As>
-      struct expr_cost_impl<expr_call<F, As...>> {
-        static constexpr size_t value = 1 + (expr_cost<As>::value + ...);
-      };
-
-      template <char OP, typename L, typename R>
-      struct expr_cost_impl<expr<OP, L, R>> {
-        static constexpr size_t value = 1 + expr_cost<L>::value + expr_cost<R>::value;
-      };
-
-    } // namespace detail
-
-    template <typename A>
-    struct expr_cost {
-      static constexpr size_t value = detail::expr_cost_impl<std::remove_cvref_t<A>>::value;
-    };
-    template <typename A>
-    inline constexpr size_t expr_cost_v = expr_cost<A>::value;
-
+    /**
+     * @brief Decides the evaluation strategy for an expression based on its cost.
+     *
+     * This class models the cost of evaluating an expression tree. It uses
+     * `expression_cost<A>()` to calculate the actual cost of the tree.
+     *
+     * A `MAX_COST` threshold is defined. If the expression's cost is too high
+     * (>= MAX_COST), the `emulate()` function will return true.
+     *
+     * This signals in the case where vectorized evaluation is not possible,
+     * that a simple scalar evaluation is too costly according to expression cost model.
+     * In such cases, we might opt for an "emulated" vectorized evaluation
+     * for the entire expression.
+     *
+     */
     template <typename A>
     struct simd_cost_model {
-      static constexpr size_t MAX_COST = 16; // TODO: tune it
-      static constexpr size_t cost() { return expr_cost_v<A>; }
+      /*
+       *TODO: This Threshold needs to be tuned in the future by running benchmarks on different expression trees with different Threshold costs
+       * and see which threshold number gives the best performance. This threshold number is also dependent on how the cost of the expression tree
+       * is calculated therefore when the model changes we have to rerun the benchmarks to decide the threshold cost.
+       */
+
+      static constexpr size_t MAX_COST = 16;
+      static constexpr size_t cost() { return expr_cost<A>(); }
       static constexpr bool emulate() { return cost() >= MAX_COST; }
     };
 
-    namespace detail {
-      template <typename A>
-      struct has_same_layout {
-        static constexpr bool value = false;
-      };
+    /**
+     * @brief Checks at compile-time if an expression tree maintains a
+     * consistent, known memory layout.
+     *
+     * This function recursively traverses the expression tree defined by `E`.
+     *
+     * - **false:** Default case. Any unknown type is assumed to not have a
+     * consistent layout.
+     * - **true:** Terminal nodes (basic_array, basic_array_view) always have a
+     * known layout.
+     * - **Recursive:** For unary expressions (expr_unary), the layout is
+     * determined by the layout of its single child expression.
+     * - **Direct Check:** For binary (expr) and function-call (expr_call)
+     * expressions, the layout is determined by checking a separate trait,
+     * `get_layout_info`, on the expression type itself.
+     */
+    template <typename A_in>
+    static consteval bool has_same_layout() {
+      using A = std::remove_cvref_t<A_in>;
+      // Case 1 & 2: basic_array and basic_array_view (Terminals)
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
+        return true;
+      }
+      // Case 3: expr_unary
+      else if constexpr (IsExprUnary<A>) {
+        return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return has_same_layout<E>(); }(std::type_identity<A>{});
+      }
+      // Case 4: expr_call
+      else if constexpr (IsExprCall<A>) {
+        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
+          return get_layout_info<expr_call<F, As...>>.stride_order != static_cast<uint64_t>(-1);
+        }(std::type_identity<A>{});
+      }
+      // Case 5: expr (binary)
+      else if constexpr (IsExpr<A>) {
+        return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
+          return get_layout_info<expr<OP, L, R>>.stride_order != static_cast<uint64_t>(-1);
+        }(std::type_identity<A>{});
+      }
+      // Case 0: Base case for any other type (like int, double, etc.)
+      else {
+        return false;
+      }
+    }
+    /**
+     * @brief A compile-time function to check if an expression tree is vectorizable.
+     *
+     * This function recursively traverses an expression tree (`A_in`) to determine if
+     * it can be evaluated using SIMD operations. It returns true if and only if
+     * every single node in the tree meets two criteria:
+     *
+     * 1. **Consistent Type:** All arrays, views, and scalar operands in the
+     * expression must have the *exact same* scalar type (e.g., `double`).
+     * This target type (`T`) is automatically deduced from the top-level
+     * expression (`A_in`).
+     *
+     * 2. **Vectorizable Type:** The common scalar type must satisfy the
+     * `Vectorizable` concept (e.g., it is an arithmetic type like `double`
+     * or `int`, not `std::string`).
+     *
+     * @details
+     * The logic is implemented as follows:
+     * - **Base Cases (Arrays/Views):** Check if `ValueType` is `Vectorizable` and
+     * `is_same_v<ValueType, T>`.
+     * - **Recursive Cases (Unary/Call):** Check if all children recursively
+     * satisfy `has_vectorizable_type<Child, T>()`.
+     * - **Binary Case:** Checks if both children are valid. If one child is a
+     * scalar, it ensures the scalar's type is also `is_same_v<ScalarType, T>`.
+     * - **Default Case:** All other types are not vectorizable.
+     */
+    template <typename A_in, typename T_in = get_value_t<A_in>>
+    static consteval bool has_vectorizable_type() {
+      using A         = std::remove_cvref_t<A_in>;
+      using T         = std::remove_cvref_t<T_in>;
+      using ValueType = get_value_t<A>;
+      // Case 1 & 2: basic_array and basic_array_view (Terminals)
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
+        return Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
+      }
+      // Case 3: expr_unary
+      else if constexpr (IsExprUnary<A>) {
+        return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return has_vectorizable_type<E>(); }(std::type_identity<A>{});
+      }
+      // Case 4: expr_call
+      else if constexpr (IsExprCall<A>) {
+        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
+          return (has_vectorizable_type<As, T>() and ...);
+        }(std::type_identity<A>{});
+      }
+      // Case 5: expr (binary)
+      else if constexpr (IsExpr<A>) {
+        return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
+          if constexpr (is_scalar_v<L>) {
+            return has_vectorizable_type<R, T>() and std::is_same_v<T, std::remove_cvref_t<L>>;
+          } else if constexpr (is_scalar_v<R>) {
+            return has_vectorizable_type<L, T>() and std::is_same_v<T, std::remove_cvref_t<R>>;
+          } else {
+            return has_vectorizable_type<L, T>() and has_vectorizable_type<R, T>();
+          }
+        }(std::type_identity<A>{});
+      }
+      // Case 0: Base case for any other type (like int, double, etc.)
+      else {
+        return false;
+      }
+    }
 
-      template <typename A>
-        requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
-      struct has_same_layout<A> {
-        static constexpr bool value = has_same_layout<std::remove_cvref_t<A>>::value;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy>
-      struct has_same_layout<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>> {
-        static constexpr bool value = true;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy>
-      struct has_same_layout<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>> {
-        static constexpr bool value = true;
-      };
-
-      template <typename F, Array... As>
-      struct has_same_layout<expr_call<F, As...>> {
-        static constexpr bool value = get_layout_info<expr_call<F, As...>>.stride_order != static_cast<uint64_t>(-1);
-      };
-
-      template <char OP, Array A>
-      struct has_same_layout<expr_unary<OP, A>> {
-        static constexpr bool value = has_same_layout<A>::value;
-      };
-
-      template <char OP, typename L, typename R>
-      struct has_same_layout<expr<OP, L, R>> {
-        static constexpr bool value = get_layout_info<expr<OP, L, R>>.stride_order != static_cast<uint64_t>(-1);
-      };
-
-      template <typename A>
-      inline constexpr bool has_same_layout_v = has_same_layout<A>::value;
-
-      template <typename A, typename T = get_value_t<A>>
-      struct has_vectorizable_type {
-        static constexpr bool value = false;
-      };
-
-      template <typename A, typename T>
-        requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
-      struct has_vectorizable_type<A, T> {
-        static constexpr bool value = has_vectorizable_type<std::remove_cvref_t<A>, T>::value;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
-      struct has_vectorizable_type<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
-        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
-      struct has_vectorizable_type<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
-        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
-      };
-
-      template <typename F, Array... As, typename T>
-      struct has_vectorizable_type<expr_call<F, As...>, T> {
-        static constexpr bool value = (has_vectorizable_type<As, T>::value and ...);
-      };
-
-      template <char OP, Array A, typename T>
-      struct has_vectorizable_type<expr_unary<OP, A>, T> {
-        static constexpr bool value = has_vectorizable_type<A, T>::value;
-      };
-
-      template <char OP, typename L, typename R, typename T>
-      struct has_vectorizable_type<expr<OP, L, R>, T> {
-        static constexpr bool value = (is_scalar_v<L>    ? (has_vectorizable_type<R, T>::value and std::is_same_v<T, std::remove_cvref_t<L>>) :
-                                          is_scalar_v<R> ? (has_vectorizable_type<L, T>::value and std::is_same_v<T, std::remove_cvref_t<R>>) :
-                                                           (has_vectorizable_type<L, T>::value and has_vectorizable_type<R, T>::value));
-      };
-      template <typename A, typename T = get_value_t<A>>
-      inline constexpr bool has_vectorizable_type_v = has_vectorizable_type<A, T>::value;
-
-      template <typename A, typename T = get_value_t<A>>
-      struct has_load_function {
-        static constexpr bool value = false;
-      };
-
-      template <typename A, typename T>
-        requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
-      struct has_load_function<A, T> {
-        static constexpr bool value = has_load_function<std::remove_cvref_t<A>, T>::value;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
-      struct has_load_function<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
-        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
-      };
-
-      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
-      struct has_load_function<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
-        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
-      };
-
-      template <typename F, Array... As, typename T>
-      struct has_load_function<expr_call<F, As...>, T> {
-        static constexpr bool value = LoadWithNativeSimd<F, T, sizeof...(As)> and (has_load_function<As, T>::value and ...);
-      };
-
-      template <char OP, Array A, typename T>
-      struct has_load_function<expr_unary<OP, A>, T> {
-        static constexpr bool value = has_load_function<A, T>::value;
-      };
-
-      template <char OP, typename L, typename R, typename T>
-      struct has_load_function<expr<OP, L, R>, T> {
-        static constexpr bool value = (is_scalar_v<L>    ? (has_load_function<R, T>::value) :
-                                          is_scalar_v<R> ? (has_load_function<L, T>::value) :
-                                                           (has_load_function<L, T>::value and has_load_function<R, T>::value));
-      };
-      template <typename A, typename T = get_value_t<A>>
-      inline constexpr bool has_load_function_v = has_load_function<A, T>::value;
-
-    } // namespace detail
+    /**
+     * @brief Checks at compile-time if an expression tree can be evaluated using
+     * a native SIMD load function.
+     *
+     * This function recursively traverses an expression tree (`A_in`) to determine if
+     * it's eligible for a specialized  `load` function with type native_simd<T_in>.
+     *
+     * The logic is implemented as follows:
+     * - **Target Type (T):** The scalar type (e.g., `double`) is deduced from the
+     * top-level expression `A_in` and passed down recursively.
+     * - **Base Cases (Arrays/Views):** The array/view must be vectorizable AND
+     * its `ValueType` must match the target type `T`.
+     * - **Unary Case:** Recurses on the single child, passing `T` along.
+     * - **Call Case:** Checks two conditions:
+     * 1. The function object `F` itself must be marked as natively loadable via
+     * the `LoadWithNativeSimd` concept.
+     * 2. All arguments `As...` must also recursively satisfy `has_load_function`.
+     * - **Binary Case:**
+     * - If one operand is scalar, it is ignored (its type does not matter),
+     * and the check recurses only on the other (array) operand.
+     * - If both are array expressions, both must recursively satisfy
+     * `has_load_function`.
+     * - **Default Case:** All other types are not loadable.
+     */
+    template <typename A_in, typename T_in = get_value_t<A_in>>
+    static consteval bool has_load_function() {
+      using A         = std::remove_cvref_t<A_in>;
+      using T         = std::remove_cvref_t<T_in>;
+      using ValueType = get_value_t<A>;
+      // Case 1 & 2: basic_array and basic_array_view (Terminals)
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
+        return Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
+      }
+      // Case 3: expr_unary
+      else if constexpr (IsExprUnary<A>) {
+        return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return has_load_function<E, T>(); }(std::type_identity<A>{});
+      }
+      // Case 4: expr_call
+      else if constexpr (IsExprCall<A>) {
+        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
+          return LoadWithNativeSimd<F, T, sizeof...(As)> and (has_load_function<As, T>() and ...);
+        }(std::type_identity<A>{});
+      }
+      // Case 5: expr (binary)
+      else if constexpr (IsExpr<A>) {
+        return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
+          if constexpr (is_scalar_v<L>) {
+            return has_load_function<R, T>();
+          } else if constexpr (is_scalar_v<R>) {
+            return has_load_function<L, T>();
+          } else {
+            return has_load_function<L, T>() and has_load_function<R, T>();
+          }
+        }(std::type_identity<A>{});
+      }
+      // Case 0: Base case for any other type (like int, double, etc.)
+      else {
+        return false;
+      }
+    }
 
     struct vectorize_t {};
     struct emulate_t {};
@@ -205,14 +293,13 @@ namespace nda {
 
     template <typename A, typename T = get_value_t<A>>
     struct dispatch_policy {
-      static constexpr bool same_layout         = detail::has_same_layout_v<A>;
-      static constexpr bool contiguous_layout_v = has_contiguous_layout<A>;
-      static constexpr bool vectorizable_types  = detail::has_vectorizable_type_v<A, T>;
-      static constexpr bool load_available      = detail::has_load_function_v<A, T>;
+      static constexpr bool same_layout        = has_same_layout<A>();
+      static constexpr bool contiguous_layout  = has_contiguous_layout<A>;
+      static constexpr bool vectorizable_types = has_vectorizable_type<A, T>();
+      static constexpr bool load_available     = has_load_function<A, T>();
 
-      static constexpr bool emulate =
-         same_layout and contiguous_layout_v and vectorizable_types and !load_available and simd_cost_model<A>::emulate();
-      static constexpr bool vectorize = same_layout and contiguous_layout_v and vectorizable_types and load_available;
+      static constexpr bool emulate = same_layout and contiguous_layout and vectorizable_types and !load_available and simd_cost_model<A>::emulate();
+      static constexpr bool vectorize = same_layout and contiguous_layout and vectorizable_types and load_available;
 
       using type = std::conditional_t<vectorize, vectorize_t, std::conditional_t<emulate, emulate_t, scalar_t>>;
     };

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -69,7 +69,7 @@ namespace nda {
     template <typename A>
     struct simd_cost_model {
       static constexpr size_t MAX_COST = 16; // TODO: tune it
-      static constexpr size_t cost() { return expr_cost<A>::value; }
+      static constexpr size_t cost() { return expr_cost_v<A>; }
       static constexpr bool emulate() { return cost() >= MAX_COST; }
     };
 
@@ -166,12 +166,12 @@ namespace nda {
 
       template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
       struct has_load_function<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
-        static constexpr bool value = std::is_same_v<std::remove_cvref_t<ValueType>, T>;
+        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
       };
 
       template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
       struct has_load_function<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
-        static constexpr bool value = std::is_same_v<ValueType, T>;
+        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
       };
 
       template <typename F, Array... As, typename T>
@@ -207,7 +207,7 @@ namespace nda {
     struct dispatch_policy {
       static constexpr bool same_layout         = detail::has_same_layout_v<A>;
       static constexpr bool contiguous_layout_v = has_contiguous_layout<A>;
-      static constexpr bool vectorizable_types  = detail::has_vectorizable_type_v<A>;
+      static constexpr bool vectorizable_types  = detail::has_vectorizable_type_v<A, T>;
       static constexpr bool load_available      = detail::has_load_function_v<A, T>;
 
       static constexpr bool emulate =

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -1,26 +1,10 @@
 #pragma once
+#include "./simd_fwd.hpp"
 #include "../concepts.hpp"
 
 #include <type_traits>
 
 namespace nda {
-
-  //Forward declaration
-  template <typename ValueType, int Rank, typename Layout, char Algebra, typename ContainerPolicy>
-  class basic_array;
-
-  template <typename ValueType, int Rank, typename Layout, char Algebra, typename AccessorPolicy, typename OwningPolicy>
-  class basic_array_view;
-
-  template <char OP, Array A>
-  struct expr_unary;
-
-  template <char OP, ArrayOrScalar L, ArrayOrScalar R>
-  struct expr;
-
-  template <typename F, Array... A>
-  struct expr_call;
-
   template <typename T>
   concept IsBasicArray = requires {
     []<typename ValueType, int Rank, typename Layout, char Algebra, typename ContainerPolicy>(

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -28,42 +28,47 @@ namespace nda {
 
   namespace simd {
     /**
-     * @brief Computes the compile-time "cost" of evaluating an expression template.
+     * @brief Computes the expected performance gain of vectorizing an expression template.
      *
      * This function recursively traverses the expression tree defined by the
-     * template type `E` and calculates a cost based on the following rules:
+     * template type `A_in` and calculates a score indicating how advantageous
+     * vectorization would be.
      *
-     * - **Cost 0:** Any non-array/expression type (e.g., scalars) has zero cost.
-     * - **Cost 1:** Terminal nodes (basic_array or basic_array_view) have a cost of 1,
-     * as they represent one leaf variable.
-     * - **Cost 1 + children:** Unary, binary, and function-call expressions have a
-     * cost of 1 (for the operation itself) plus the sum of the costs of all
+     * The gain is calculated based on the following rules:
+     * Any non-array/expression type (e.g., scalars) has 0 gains.
+     * Terminal nodes (basic_array or basic_array_view) have a gain of GAIN_FACTOR_OPERAND.
+     * Unary, binary, and function-call expressions have a
+     * gain of GAIN_FACTOR_OPERATION (for the operation itself) plus the sum of the gains of all
      * their child expressions.
      *
-     * This `consteval` function replaces the C++17 struct-based template
-     * metaprogramming. It uses `if constexpr` to branch at compile time and
-     * template lambdas to "pattern match" and extract sub-expression types.
      */
     template <typename A_in>
-    static consteval size_t expr_cost() {
-      using A = std::remove_cvref_t<A_in>;
+    static consteval size_t simd_gain() {
+      [[maybe_unused]] constexpr size_t GAIN_FACTOR_OPERAND   = 1;
+      [[maybe_unused]] constexpr size_t GAIN_FACTOR_OPERATION = 1;
+      // Use std::remove_cvref_t to handle reference types passed in (e.g., Array&)
+      using T = std::remove_cvref_t<A_in>;
+
       // Case 1 & 2: basic_array and basic_array_view (Terminals)
-      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
-        return 1;
+      if constexpr (IsBasicArray<T> or IsBasicArrayView<T>) {
+        return GAIN_FACTOR_OPERAND;
       }
       // Case 3: expr_unary
-      else if constexpr (IsExprUnary<A>) {
-        return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return 1 + expr_cost<E>(); }(std::type_identity<A>{});
+      else if constexpr (IsExprUnary<T>) {
+        return
+           []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return GAIN_FACTOR_OPERATION + simd_gain<E>(); }(std::type_identity<T>{});
       }
       // Case 4: expr_call
-      else if constexpr (IsExprCall<A>) {
-        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) { return 1 + (expr_cost<As>() + ...); }(std::type_identity<A>{});
+      else if constexpr (IsExprCall<T>) {
+        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
+          return GAIN_FACTOR_OPERATION + (simd_gain<As>() + ...);
+        }(std::type_identity<T>{});
       }
       // Case 5: expr (binary)
-      else if constexpr (IsExpr<A>) {
+      else if constexpr (IsExpr<T>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
-          return 1 + expr_cost<L>() + expr_cost<R>();
-        }(std::type_identity<A>{});
+          return GAIN_FACTOR_OPERATION + simd_gain<L>() + simd_gain<R>();
+        }(std::type_identity<T>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)
       else {
@@ -72,31 +77,71 @@ namespace nda {
     }
 
     /**
+     * @brief Computes the compile-time "emulation cost" of an expression template.
+     *
+     * This function recursively traverses the expression tree defined by `A_in`
+     * and calculates a cost associated with evaluating it using an "emulated"
+     * SIMD strategy
+     *
+     * This cost model helps decide if an expression is so complex that, even
+     * if it doesn't support a full native SIMD kernel, it's still more
+     * efficient to evaluate it using an emulated SIMD load/store than to
+     * perform a standard scalar evaluation.
+     */
+    template <typename A_in, typename T_in = get_value_t<A_in>>
+    static consteval size_t emulation_cost() {
+      [[maybe_unused]] gconstexpr size_t MISSING_LOAD_PENALTY = 16;
+      // Use std::remove_cvref_t to handle reference types passed in (e.g., Array&)
+      using A = std::remove_cvref_t<A_in>;
+      using T = std::remove_cvref_t<T_in>;
+
+      // Case 1 & 2: basic_array and basic_array_view (Terminals)
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) { return 0; }
+      // Case 3: expr_unary
+      if constexpr (IsExprUnary<A>) {
+        return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return emulation_cost<E>(); }(std::type_identity<A>{});
+      }
+      // Case 4: expr_call
+      if constexpr (IsExprCall<A>) {
+        return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
+          if constexpr (!LoadWithNativeSimd<F, T, sizeof...(As)>) { return MISSING_LOAD_PENALTY + (emulation_cost<As>() + ...); }
+          return (emulation_cost<As>() + ...);
+        }(std::type_identity<A>{});
+      }
+      // Case 5: expr (binary)
+      if constexpr (IsExpr<A>) {
+        return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
+          return emulation_cost<L>() + emulation_cost<R>();
+        }(std::type_identity<A>{});
+      }
+      // Case 0: Base case for any other type (like int, double, etc.)
+      return 0;
+    }
+
+    /**
      * @brief Decides the evaluation strategy for an expression based on its cost.
      *
-     * This class models the cost of evaluating an expression tree. It uses
-     * `expression_cost<A>()` to calculate the actual cost of the tree.
+     * This class models the cost of evaluating an expression tree and provides
+     * a heuristic to decide whether an "emulated" vectorized evaluation
+     * is worthwhile.
      *
-     * A `MAX_COST` threshold is defined. If the expression's cost is too high
-     * (>= MAX_COST), the `emulate()` function will return true.
+     * The `cost()` is defined as the `emulation_cost<A>()`, which represents
+     * the overhead of evaluating the expression into a temporary.
      *
-     * This signals in the case where vectorized evaluation is not possible,
-     * that a simple scalar evaluation is too costly according to expression cost model.
-     * In such cases, we might opt for an "emulated" vectorized evaluation
-     * for the entire expression.
+     * The `emulate()` function implements the decision logic. It returns true if
+     * the `simd_gain<A>()` (representing the total complexity/fusion benefit)
+     * is significantly larger than the `emulation_cost<A>()`.
      *
+     * This check (`simd_gain<A>() >= emulation_cost<A>()`) is used to decide if
+     * an expression is complex enough that an emulated vectorization is
+     * preferable to a (potentially slow) scalar evaluation, especially when
+     * a full native SIMD kernel is not available.
      */
-    template <typename A>
+    //TODO: The functions emulation_cost and simd_gains need to be tuned with different benchmarks and different algorithms, values to determine optimal model.
+    template <typename A, typename T = get_value_t<A>>
     struct simd_cost_model {
-      /*
-       *TODO: This Threshold needs to be tuned in the future by running benchmarks on different expression trees with different Threshold costs
-       * and see which threshold number gives the best performance. This threshold number is also dependent on how the cost of the expression tree
-       * is calculated therefore when the model changes we have to rerun the benchmarks to decide the threshold cost.
-       */
-
-      static constexpr size_t MAX_COST = 16;
-      static constexpr size_t cost() { return expr_cost<A>(); }
-      static constexpr bool emulate() { return cost() >= MAX_COST; }
+      static constexpr size_t cost() { return emulation_cost<A, T>(); }
+      static constexpr bool emulate() { return simd_gain<A>() >= emulation_cost<A, T>(); }
     };
 
     /**
@@ -119,29 +164,25 @@ namespace nda {
     static consteval bool has_same_layout() {
       using A = std::remove_cvref_t<A_in>;
       // Case 1 & 2: basic_array and basic_array_view (Terminals)
-      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
-        return true;
-      }
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) { return true; }
       // Case 3: expr_unary
-      else if constexpr (IsExprUnary<A>) {
+      if constexpr (IsExprUnary<A>) {
         return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return has_same_layout<E>(); }(std::type_identity<A>{});
       }
       // Case 4: expr_call
-      else if constexpr (IsExprCall<A>) {
+      if constexpr (IsExprCall<A>) {
         return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
           return get_layout_info<expr_call<F, As...>>.stride_order != static_cast<uint64_t>(-1);
         }(std::type_identity<A>{});
       }
       // Case 5: expr (binary)
-      else if constexpr (IsExpr<A>) {
+      if constexpr (IsExpr<A>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
           return get_layout_info<expr<OP, L, R>>.stride_order != static_cast<uint64_t>(-1);
         }(std::type_identity<A>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)
-      else {
-        return false;
-      }
+      return false;
     }
     /**
      * @brief A compile-time function to check if an expression tree is vectorizable.
@@ -175,21 +216,19 @@ namespace nda {
       using T         = std::remove_cvref_t<T_in>;
       using ValueType = get_value_t<A>;
       // Case 1 & 2: basic_array and basic_array_view (Terminals)
-      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
-        return Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
-      }
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) { return Vectorizable<ValueType> and std::is_same_v<ValueType, T>; }
       // Case 3: expr_unary
-      else if constexpr (IsExprUnary<A>) {
+      if constexpr (IsExprUnary<A>) {
         return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return has_vectorizable_type<E>(); }(std::type_identity<A>{});
       }
       // Case 4: expr_call
-      else if constexpr (IsExprCall<A>) {
+      if constexpr (IsExprCall<A>) {
         return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
           return (has_vectorizable_type<As, T>() and ...);
         }(std::type_identity<A>{});
       }
       // Case 5: expr (binary)
-      else if constexpr (IsExpr<A>) {
+      if constexpr (IsExpr<A>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
           if constexpr (is_scalar_v<L>) {
             return has_vectorizable_type<R, T>() and std::is_same_v<T, std::remove_cvref_t<L>>;
@@ -201,9 +240,7 @@ namespace nda {
         }(std::type_identity<A>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)
-      else {
-        return false;
-      }
+      return false;
     }
 
     /**
@@ -236,35 +273,27 @@ namespace nda {
       using T         = std::remove_cvref_t<T_in>;
       using ValueType = get_value_t<A>;
       // Case 1 & 2: basic_array and basic_array_view (Terminals)
-      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
-        return Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
-      }
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) { return Vectorizable<ValueType> and std::is_same_v<ValueType, T>; }
       // Case 3: expr_unary
-      else if constexpr (IsExprUnary<A>) {
+      if constexpr (IsExprUnary<A>) {
         return []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return has_load_function<E, T>(); }(std::type_identity<A>{});
       }
       // Case 4: expr_call
-      else if constexpr (IsExprCall<A>) {
+      if constexpr (IsExprCall<A>) {
         return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
           return LoadWithNativeSimd<F, T, sizeof...(As)> and (has_load_function<As, T>() and ...);
         }(std::type_identity<A>{});
       }
       // Case 5: expr (binary)
-      else if constexpr (IsExpr<A>) {
+      if constexpr (IsExpr<A>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
-          if constexpr (is_scalar_v<L>) {
-            return has_load_function<R, T>();
-          } else if constexpr (is_scalar_v<R>) {
-            return has_load_function<L, T>();
-          } else {
-            return has_load_function<L, T>() and has_load_function<R, T>();
-          }
+          if constexpr (is_scalar_v<L>) { return has_load_function<R, T>(); }
+          if constexpr (is_scalar_v<R>) { return has_load_function<L, T>(); }
+          return has_load_function<L, T>() and has_load_function<R, T>();
         }(std::type_identity<A>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)
-      else {
-        return false;
-      }
+      return false;
     }
 
     struct vectorize_t {};

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -1,0 +1,78 @@
+#pragma once
+#include "../concepts.hpp"
+
+#include <type_traits>
+
+namespace nda {
+
+  //Forward declaration
+  template <typename ValueType, int Rank, typename Layout, char Algebra, typename ContainerPolicy>
+  class basic_array;
+
+  template <typename ValueType, int Rank, typename Layout, char Algebra, typename AccessorPolicy, typename OwningPolicy>
+  class basic_array_view;
+
+  template <char OP, Array A>
+  struct expr_unary;
+
+  template <char OP, ArrayOrScalar L, ArrayOrScalar R>
+  struct expr;
+
+  template <typename F, Array... A>
+  struct expr_call;
+  namespace simd {
+    //Forward declaration
+    template <typename A>
+    struct expr_cost;
+
+    namespace detail {
+
+      template <typename A>
+      struct expr_cost_impl {
+        static constexpr size_t value = 0;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy>
+      struct expr_cost_impl<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>> {
+        static constexpr size_t value = 1;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy>
+      struct expr_cost_impl<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>> {
+        static constexpr size_t value = 1;
+      };
+
+      template <char OP, Array A>
+      struct expr_cost_impl<expr_unary<OP, A>> {
+        static constexpr size_t value = 1 + expr_cost<A>::value;
+      };
+
+      template <typename F, Array... As>
+      struct expr_cost_impl<expr_call<F, As...>> {
+        static constexpr size_t value = 1 + (expr_cost<As>::value + ...);
+      };
+
+      template <char OP, typename L, typename R>
+      struct expr_cost_impl<expr<OP, L, R>> {
+        static constexpr size_t value = 1 + expr_cost<L>::value + expr_cost<R>::value;
+      };
+
+    } // namespace detail
+
+    template <typename A>
+    struct expr_cost {
+      static constexpr size_t value = detail::expr_cost_impl<std::remove_cvref_t<A>>::value;
+    };
+    template <typename A>
+    inline constexpr size_t expr_cost_v = expr_cost<A>::value;
+
+    template <typename A>
+    struct simd_cost_model {
+      static constexpr size_t MAX_COST = 16; // TODO: tune it
+      static constexpr size_t cost() { return expr_cost<A>::value; }
+      static constexpr bool emulate() { return cost() >= MAX_COST; }
+    };
+
+
+  } // namespace simd
+} // namespace nda

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -90,7 +90,7 @@ namespace nda {
      */
     template <typename A_in, typename T_in = get_value_t<A_in>>
     static consteval size_t emulation_cost() {
-      [[maybe_unused]] gconstexpr size_t MISSING_LOAD_PENALTY = 16;
+      [[maybe_unused]] constexpr size_t MISSING_LOAD_PENALTY = 16;
       // Use std::remove_cvref_t to handle reference types passed in (e.g., Array&)
       using A = std::remove_cvref_t<A_in>;
       using T = std::remove_cvref_t<T_in>;

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -50,30 +50,26 @@ namespace nda {
       using A = std::remove_cvref_t<A_in>;
 
       // Case 1 & 2: basic_array and basic_array_view (Terminals)
-      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
-        return GAIN_FACTOR_OPERAND;
-      }
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) { return GAIN_FACTOR_OPERAND; }
       // Case 3: expr_unary
-      else if constexpr (IsExprUnary<A>) {
+      if constexpr (IsExprUnary<A>) {
         return
            []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return GAIN_FACTOR_OPERATION + simd_gain<E>(); }(std::type_identity<A>{});
       }
       // Case 4: expr_call
-      else if constexpr (IsExprCall<A>) {
+      if constexpr (IsExprCall<A>) {
         return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
           return GAIN_FACTOR_OPERATION + (simd_gain<As>() + ...);
         }(std::type_identity<A>{});
       }
       // Case 5: expr (binary)
-      else if constexpr (IsExpr<A>) {
+      if constexpr (IsExpr<A>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
           return GAIN_FACTOR_OPERATION + simd_gain<L>() + simd_gain<R>();
         }(std::type_identity<A>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)
-      else {
-        return 0;
-      }
+      return 0;
     }
 
     /**
@@ -230,13 +226,9 @@ namespace nda {
       // Case 5: expr (binary)
       if constexpr (IsExpr<A>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
-          if constexpr (is_scalar_v<L>) {
-            return has_vectorizable_type<R, T>() and std::is_same_v<T, std::remove_cvref_t<L>>;
-          } else if constexpr (is_scalar_v<R>) {
-            return has_vectorizable_type<L, T>() and std::is_same_v<T, std::remove_cvref_t<R>>;
-          } else {
-            return has_vectorizable_type<L, T>() and has_vectorizable_type<R, T>();
-          }
+          if constexpr (is_scalar_v<L>) { return has_vectorizable_type<R, T>() and std::is_same_v<T, std::remove_cvref_t<L>>; }
+          if constexpr (is_scalar_v<R>) { return has_vectorizable_type<L, T>() and std::is_same_v<T, std::remove_cvref_t<R>>; }
+          return has_vectorizable_type<L, T>() and has_vectorizable_type<R, T>();
         }(std::type_identity<A>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 #pragma once
 #include "./simd_fwd.hpp"
 #include "../concepts.hpp"

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -47,28 +47,28 @@ namespace nda {
       [[maybe_unused]] constexpr size_t GAIN_FACTOR_OPERAND   = 1;
       [[maybe_unused]] constexpr size_t GAIN_FACTOR_OPERATION = 1;
       // Use std::remove_cvref_t to handle reference types passed in (e.g., Array&)
-      using T = std::remove_cvref_t<A_in>;
+      using A = std::remove_cvref_t<A_in>;
 
       // Case 1 & 2: basic_array and basic_array_view (Terminals)
-      if constexpr (IsBasicArray<T> or IsBasicArrayView<T>) {
+      if constexpr (IsBasicArray<A> or IsBasicArrayView<A>) {
         return GAIN_FACTOR_OPERAND;
       }
       // Case 3: expr_unary
-      else if constexpr (IsExprUnary<T>) {
+      else if constexpr (IsExprUnary<A>) {
         return
-           []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return GAIN_FACTOR_OPERATION + simd_gain<E>(); }(std::type_identity<T>{});
+           []<char OP, Array E>(std::type_identity<expr_unary<OP, E>>) { return GAIN_FACTOR_OPERATION + simd_gain<E>(); }(std::type_identity<A>{});
       }
       // Case 4: expr_call
-      else if constexpr (IsExprCall<T>) {
+      else if constexpr (IsExprCall<A>) {
         return []<typename F, Array... As>(std::type_identity<expr_call<F, As...>>) {
           return GAIN_FACTOR_OPERATION + (simd_gain<As>() + ...);
-        }(std::type_identity<T>{});
+        }(std::type_identity<A>{});
       }
       // Case 5: expr (binary)
-      else if constexpr (IsExpr<T>) {
+      else if constexpr (IsExpr<A>) {
         return []<char OP, typename L, typename R>(std::type_identity<expr<OP, L, R>>) {
           return GAIN_FACTOR_OPERATION + simd_gain<L>() + simd_gain<R>();
-        }(std::type_identity<T>{});
+        }(std::type_identity<A>{});
       }
       // Case 0: Base case for any other type (like int, double, etc.)
       else {

--- a/c++/nda/simd/simd_cost.hpp
+++ b/c++/nda/simd/simd_cost.hpp
@@ -73,6 +73,150 @@ namespace nda {
       static constexpr bool emulate() { return cost() >= MAX_COST; }
     };
 
+    namespace detail {
+      template <typename A>
+      struct has_same_layout {
+        static constexpr bool value = false;
+      };
 
+      template <typename A>
+        requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
+      struct has_same_layout<A> {
+        static constexpr bool value = has_same_layout<std::remove_cvref_t<A>>::value;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy>
+      struct has_same_layout<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>> {
+        static constexpr bool value = true;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy>
+      struct has_same_layout<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>> {
+        static constexpr bool value = true;
+      };
+
+      template <typename F, Array... As>
+      struct has_same_layout<expr_call<F, As...>> {
+        static constexpr bool value = get_layout_info<expr_call<F, As...>>.stride_order != static_cast<uint64_t>(-1);
+      };
+
+      template <char OP, Array A>
+      struct has_same_layout<expr_unary<OP, A>> {
+        static constexpr bool value = has_same_layout<A>::value;
+      };
+
+      template <char OP, typename L, typename R>
+      struct has_same_layout<expr<OP, L, R>> {
+        static constexpr bool value = get_layout_info<expr<OP, L, R>>.stride_order != static_cast<uint64_t>(-1);
+      };
+
+      template <typename A>
+      inline constexpr bool has_same_layout_v = has_same_layout<A>::value;
+
+      template <typename A, typename T = get_value_t<A>>
+      struct has_vectorizable_type {
+        static constexpr bool value = false;
+      };
+
+      template <typename A, typename T>
+        requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
+      struct has_vectorizable_type<A, T> {
+        static constexpr bool value = has_vectorizable_type<std::remove_cvref_t<A>, T>::value;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
+      struct has_vectorizable_type<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
+        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
+      struct has_vectorizable_type<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
+        static constexpr bool value = Vectorizable<ValueType> and std::is_same_v<ValueType, T>;
+      };
+
+      template <typename F, Array... As, typename T>
+      struct has_vectorizable_type<expr_call<F, As...>, T> {
+        static constexpr bool value = (has_vectorizable_type<As, T>::value and ...);
+      };
+
+      template <char OP, Array A, typename T>
+      struct has_vectorizable_type<expr_unary<OP, A>, T> {
+        static constexpr bool value = has_vectorizable_type<A, T>::value;
+      };
+
+      template <char OP, typename L, typename R, typename T>
+      struct has_vectorizable_type<expr<OP, L, R>, T> {
+        static constexpr bool value = (is_scalar_v<L>    ? (has_vectorizable_type<R, T>::value and std::is_same_v<T, std::remove_cvref_t<L>>) :
+                                          is_scalar_v<R> ? (has_vectorizable_type<L, T>::value and std::is_same_v<T, std::remove_cvref_t<R>>) :
+                                                           (has_vectorizable_type<L, T>::value and has_vectorizable_type<R, T>::value));
+      };
+      template <typename A, typename T = get_value_t<A>>
+      inline constexpr bool has_vectorizable_type_v = has_vectorizable_type<A, T>::value;
+
+      template <typename A, typename T = get_value_t<A>>
+      struct has_load_function {
+        static constexpr bool value = false;
+      };
+
+      template <typename A, typename T>
+        requires(!std::is_same_v<A, std::remove_cvref_t<A>>)
+      struct has_load_function<A, T> {
+        static constexpr bool value = has_load_function<std::remove_cvref_t<A>, T>::value;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename ContainerPolicy, typename T>
+      struct has_load_function<basic_array<ValueType, Rank, LayoutPolicy, Algebra, ContainerPolicy>, T> {
+        static constexpr bool value = std::is_same_v<std::remove_cvref_t<ValueType>, T>;
+      };
+
+      template <typename ValueType, int Rank, typename LayoutPolicy, char Algebra, typename AccessorPolicy, typename OwningPolicy, typename T>
+      struct has_load_function<basic_array_view<ValueType, Rank, LayoutPolicy, Algebra, AccessorPolicy, OwningPolicy>, T> {
+        static constexpr bool value = std::is_same_v<ValueType, T>;
+      };
+
+      template <typename F, Array... As, typename T>
+      struct has_load_function<expr_call<F, As...>, T> {
+        static constexpr bool value = LoadWithNativeSimd<F, T, sizeof...(As)> and (has_load_function<As, T>::value and ...);
+      };
+
+      template <char OP, Array A, typename T>
+      struct has_load_function<expr_unary<OP, A>, T> {
+        static constexpr bool value = has_load_function<A, T>::value;
+      };
+
+      template <char OP, typename L, typename R, typename T>
+      struct has_load_function<expr<OP, L, R>, T> {
+        static constexpr bool value = (is_scalar_v<L>    ? (has_load_function<R, T>::value) :
+                                          is_scalar_v<R> ? (has_load_function<L, T>::value) :
+                                                           (has_load_function<L, T>::value and has_load_function<R, T>::value));
+      };
+      template <typename A, typename T = get_value_t<A>>
+      inline constexpr bool has_load_function_v = has_load_function<A, T>::value;
+
+    } // namespace detail
+
+    struct vectorize_t {};
+    struct emulate_t {};
+    struct scalar_t {};
+
+    inline static constexpr vectorize_t vectorize;
+    inline static constexpr emulate_t emulate;
+    inline static constexpr scalar_t scalar;
+
+    template <typename A, typename T = get_value_t<A>>
+    struct dispatch_policy {
+      static constexpr bool same_layout         = detail::has_same_layout_v<A>;
+      static constexpr bool contiguous_layout_v = has_contiguous_layout<A>;
+      static constexpr bool vectorizable_types  = detail::has_vectorizable_type_v<A>;
+      static constexpr bool load_available      = detail::has_load_function_v<A, T>;
+
+      static constexpr bool emulate =
+         same_layout and contiguous_layout_v and vectorizable_types and !load_available and simd_cost_model<A>::emulate();
+      static constexpr bool vectorize = same_layout and contiguous_layout_v and vectorizable_types and load_available;
+
+      using type = std::conditional_t<vectorize, vectorize_t, std::conditional_t<emulate, emulate_t, scalar_t>>;
+    };
+    template <typename A, typename T = get_value_t<A>>
+    using dispatch_policy_t = dispatch_policy<A, T>::type;
   } // namespace simd
 } // namespace nda

--- a/c++/nda/simd/simd_fwd.hpp
+++ b/c++/nda/simd/simd_fwd.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../concepts.hpp"
+
+namespace nda {
+  //Forward declaration
+  template <typename ValueType, int Rank, typename Layout, char Algebra, typename ContainerPolicy>
+  class basic_array;
+
+  template <typename ValueType, int Rank, typename Layout, char Algebra, typename AccessorPolicy, typename OwningPolicy>
+  class basic_array_view;
+
+  template <char OP, Array A>
+  struct expr_unary;
+
+  template <char OP, ArrayOrScalar L, ArrayOrScalar R>
+  struct expr;
+
+  template <typename F, Array... A>
+  struct expr_call;
+
+} // namespace nda

--- a/c++/nda/simd/simd_fwd.hpp
+++ b/c++/nda/simd/simd_fwd.hpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 #pragma once
 
 #include "../concepts.hpp"

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -101,6 +101,13 @@ if(MPISupport)
   )
 endif()
 
+# -- XSIMD --
+external_dependency(xsimd
+        GIT_REPO https://github.com/xtensor-stack/xsimd
+        GIT_TAG master
+        BUILD_ALWAYS
+)
+
 ## Pybind 11
 #find_package(Python)
 #add_subdirectory(pybind11)

--- a/deps/CMakeLists.txt
+++ b/deps/CMakeLists.txt
@@ -105,6 +105,7 @@ endif()
 external_dependency(xsimd
         GIT_REPO https://github.com/xtensor-stack/xsimd
         GIT_TAG master
+        VERSION 13.2.0
         BUILD_ALWAYS
 )
 

--- a/test/c++/CMakeLists.txt
+++ b/test/c++/CMakeLists.txt
@@ -53,6 +53,7 @@ foreach(test ${all_tests})
       --verbose
       --force
       --quiet
+      -march=native
       ${CMAKE_CURRENT_SOURCE_DIR}/${test}
     )
   endif()

--- a/test/c++/CMakeLists.txt
+++ b/test/c++/CMakeLists.txt
@@ -29,6 +29,7 @@ foreach(test ${all_tests})
     target_link_libraries(${test_name} hdf5::hdf5)
   endif()
   target_compile_options(${test_name}  PRIVATE "${ARGV1}")
+  target_compile_options(${test_name} PRIVATE -march=native)
   set_property(TARGET ${test_name} PROPERTY RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
   add_test(NAME ${test_name} COMMAND ${test_name} WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${test_dir})
   if(MPISupport AND test_name MATCHES "(mpi|nda_sym_grp)" AND NOT MSAN)
@@ -53,7 +54,6 @@ foreach(test ${all_tests})
       --verbose
       --force
       --quiet
-      -march=native
       ${CMAKE_CURRENT_SOURCE_DIR}/${test}
     )
   endif()

--- a/test/c++/nda_simd.cpp
+++ b/test/c++/nda_simd.cpp
@@ -1,0 +1,250 @@
+#include <gtest/gtest.h>
+#include <nda/gtest_tools.hpp>
+#include <type_traits>
+#include <cmath>
+#include <array>
+#include <complex>
+#include <algorithm>
+#include <bit>
+#include <nda/simd/mock_simd.hpp>
+#include <nda/simd/simd.hpp>
+using namespace nda;
+
+template <typename T>
+constexpr void expect_eq(const T a, const T b) {
+  using U = std::decay_t<decltype(a)>;
+  if constexpr (std::is_same_v<U, float>) {
+    EXPECT_FLOAT_EQ(a, b);
+  } else if constexpr (std::is_same_v<U, double>) {
+    EXPECT_DOUBLE_EQ(a, b);
+  } else if constexpr (std::is_same_v<U, std::complex<float>>) {
+    EXPECT_FLOAT_EQ(a.real(), b.real());
+    EXPECT_FLOAT_EQ(a.imag(), b.imag());
+  } else if constexpr (std::is_same_v<U, std::complex<double>>) {
+    EXPECT_DOUBLE_EQ(a.real(), b.real());
+    EXPECT_DOUBLE_EQ(a.imag(), b.imag());
+  } else {
+    EXPECT_EQ(a, b);
+  }
+}
+
+template <typename T, size_t R, typename Layout, char Algebra>
+void load_and_store() {
+
+  std::array<size_t, R> shape;
+  shape.fill(32);
+
+  using array_t = basic_array<T, R, Layout, Algebra, heap<>>;
+  array_t A     = rand(shape);
+  using idx_t   = std::array<long, R>;
+
+  // --- A.load/store tests ---
+  idx_t idx1{};
+  auto a              = std::apply([&](auto... args) { return A.load(args...); }, idx1);
+  constexpr auto size = decltype(a)::size;
+
+  for (size_t i = 0; i < size; ++i) {
+    std::apply([&](auto... args) { expect_eq(a.get(i), A(args...)); }, idx1);
+    ++idx1[A.stride_order()[R - 1]];
+  }
+
+  idx_t idx2{};
+  idx2[A.stride_order()[R - 1]] += size;
+  auto b = std::apply([&](auto... args) { return A.load(args...); }, idx2);
+  for (size_t i = 0; i < size; ++i) {
+    std::apply([&](auto... args) { expect_eq(b.get(i), A(args...)); }, idx2);
+    ++idx2[A.stride_order()[R - 1]];
+  }
+
+  idx_t idx3{};
+  auto c = a + b;
+  std::apply([&](auto... args) { A.store(c, args...); }, idx3);
+  for (size_t i = 0; i < size; ++i) {
+    std::apply([&](auto... args) { expect_eq(c.get(i), A(args...)); }, idx3);
+    ++idx3[A.stride_order()[R - 1]];
+  }
+
+  // --- Expression tests: B + C, B - C, B * C, B / C ---
+  array_t B = rand(shape);
+  array_t C = rand(shape);
+  for (auto &x : C) {
+    using value_t = std::decay_t<decltype(x)>;
+    if constexpr (std::is_arithmetic_v<value_t>) {
+      if (x == value_t(0)) x = value_t(1);
+    } else if constexpr (is_complex_v<value_t>) {
+      if (x == value_t(0, 0)) x = value_t(1, 2);
+    }
+  }
+
+  // Expression 1: B + C
+  auto e1 = B + C;
+  {
+    idx_t idx{};
+    auto v = std::apply([&](auto... args) { return e1.load(args...); }, idx);
+    for (size_t i = 0; i < size; ++i) {
+      std::apply([&](auto... args) { expect_eq(v.get(i), e1(args...)); }, idx);
+      ++idx[B.stride_order()[R - 1]];
+    }
+  }
+
+  // Expression 2: B - C
+  auto e2 = B - C;
+  {
+    idx_t idx{};
+    auto v = std::apply([&](auto... args) { return e2.load(args...); }, idx);
+    for (size_t i = 0; i < size; ++i) {
+      std::apply([&](auto... args) { expect_eq(v.get(i), e2(args...)); }, idx);
+      ++idx[B.stride_order()[R - 1]];
+    }
+  }
+
+  if constexpr (Algebra == 'A') {
+    // Expression 3: B * C
+    auto e3 = B * C;
+    {
+      idx_t idx{};
+      auto v = std::apply([&](auto... args) { return e3.load(args...); }, idx);
+      for (size_t i = 0; i < size; ++i) {
+        std::apply([&](auto... args) { expect_eq(v.get(i), e3(args...)); }, idx);
+        ++idx[B.stride_order()[R - 1]];
+      }
+    }
+    // Expression 4: B / C
+    auto e4 = B / C;
+    {
+      idx_t idx{};
+      auto v = std::apply([&](auto... args) { return e4.load(args...); }, idx);
+      for (size_t i = 0; i < size; ++i) {
+        std::apply([&](auto... args) { expect_eq(v.get(i), e4(args...)); }, idx);
+        ++idx[B.stride_order()[R - 1]];
+      }
+    }
+  }
+  if constexpr (Algebra == 'M') {
+    auto e5 = B + 5;
+    {
+      idx_t idx{};
+      auto v = std::apply([&](auto... args) { return e1.load(args...); }, idx);
+      for (size_t i = 0; i < size; ++i) {
+        std::apply([&](auto... args) { expect_eq(v.get(i), e1(args...)); }, idx);
+        ++idx[B.stride_order()[R - 1]];
+      }
+    }
+  }
+}
+
+template <typename T>
+struct scalar_f {
+  template <typename... Args>
+  T operator()(const Args &...args) const {
+    return (args + ...) + T{1};
+  }
+};
+
+template <typename T>
+struct emulated_f : simd::mock_simd<emulated_f<T>, T> {
+  template <typename... Args>
+  T operator()(const Args &...args) const {
+    return (args + ...) + T{1};
+  }
+};
+
+template <typename T, size_t Rank, typename Layout>
+void mock_simd_test() {
+  std::array<size_t, Rank> shape;
+  shape.fill(32);
+
+  using array_t = array<T, Rank, Layout>;
+  using idx_t   = std::array<long, Rank>;
+
+  array_t A = rand(shape);
+  array_t B = rand(shape);
+  array_t C = rand(shape);
+
+  // Generate expression results
+  auto r1 = map(emulated_f<T>{})(A);
+  auto r2 = map(emulated_f<T>{})(A, B);
+  auto r3 = map(emulated_f<T>{})(A, B, C);
+
+  auto s1 = map(scalar_f<T>{})(A);
+  auto s2 = map(scalar_f<T>{})(A, B);
+  auto s3 = map(scalar_f<T>{})(A, B, C);
+
+  auto check = [&](const auto &r, const auto &s) {
+    idx_t idx{};
+    auto v              = std::apply([&](auto... args) { return r.load(args...); }, idx);
+    constexpr auto size = decltype(v)::size;
+
+    for (size_t i = 0; i < size; ++i) {
+      std::apply([&](auto... args) { expect_eq(v.get(i), s(args...)); }, idx);
+      ++idx[A.stride_order()[Rank - 1]];
+    }
+  };
+  check(r1, s1);
+  check(r2, s2);
+  check(r3, s3);
+  EXPECT_ARRAY_NEAR(r1, s1);
+  EXPECT_ARRAY_NEAR(r2, s2);
+  EXPECT_ARRAY_NEAR(r3, s3);
+}
+
+TEST(NDA, LoadAndStore) {
+  // Macro to test all ranks (1 to 3) for a given type, layout, and algebra
+#define TEST_ALGEBRA_A(type, layout)                                                                                                                 \
+  load_and_store<type, 1, layout, 'A'>();                                                                                                            \
+  load_and_store<type, 2, layout, 'A'>();                                                                                                            \
+  load_and_store<type, 3, layout, 'A'>();
+
+#define TEST_ALGEBRA_M(type, layout) load_and_store<type, 2, layout, 'M'>(); // Only rank 2 for matrix algebra
+
+#define TEST_ALGEBRA_V(type, layout) load_and_store<type, 1, layout, 'V'>(); // Only rank 1 for vector algebra
+
+  // Macro to test all relevant algebra types (A, M, V) for a given type
+#define TEST_ALL_ALGEBRAS(type)                                                                                                                      \
+  TEST_ALGEBRA_A(type, C_layout)                                                                                                                     \
+  TEST_ALGEBRA_A(type, F_layout)                                                                                                                     \
+  TEST_ALGEBRA_M(type, C_layout)                                                                                                                     \
+  TEST_ALGEBRA_M(type, F_layout)                                                                                                                     \
+  TEST_ALGEBRA_V(type, C_layout)                                                                                                                     \
+  TEST_ALGEBRA_V(type, F_layout)
+
+  // Call tests for all relevant types
+  TEST_ALL_ALGEBRAS(int32_t)
+  TEST_ALL_ALGEBRAS(int64_t)
+  TEST_ALL_ALGEBRAS(uint32_t)
+  TEST_ALL_ALGEBRAS(uint64_t)
+  TEST_ALL_ALGEBRAS(float)
+  TEST_ALL_ALGEBRAS(double)
+  TEST_ALL_ALGEBRAS(std::complex<float>)
+  TEST_ALL_ALGEBRAS(std::complex<double>)
+
+#undef TEST_ALGEBRA_A
+#undef TEST_ALGEBRA_M
+#undef TEST_ALGEBRA_V
+#undef TEST_ALL_ALGEBRAS
+}
+
+TEST(NDA, MOCK_SIMD) {
+  // Run mock_simd_test for all ranks for a given type and layout
+#define TEST_ALL_RANKS(T, L)                                                                                                                         \
+  mock_simd_test<T, 1, L>();                                                                                                                         \
+  mock_simd_test<T, 2, L>();                                                                                                                         \
+  mock_simd_test<T, 3, L>();
+
+  // Run for both C and F layouts
+#define TEST_LAYOUTS(T)                                                                                                                              \
+  TEST_ALL_RANKS(T, C_layout)                                                                                                                        \
+  TEST_ALL_RANKS(T, F_layout)
+
+  TEST_LAYOUTS(int32_t)
+  TEST_LAYOUTS(int64_t)
+  TEST_LAYOUTS(uint32_t)
+  TEST_LAYOUTS(uint64_t)
+  TEST_LAYOUTS(float)
+  TEST_LAYOUTS(double)
+  TEST_LAYOUTS(std::complex<float>)
+  TEST_LAYOUTS(std::complex<double>)
+
+#undef TEST_ALL_RANKS
+#undef TEST_LAYOUTS
+}

--- a/test/c++/nda_simd.cpp
+++ b/test/c++/nda_simd.cpp
@@ -1,3 +1,8 @@
+// Copyright (c) 2023--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
 #include <gtest/gtest.h>
 #include <nda/gtest_tools.hpp>
 #include <type_traits>

--- a/test/c++/nda_simd.cpp
+++ b/test/c++/nda_simd.cpp
@@ -40,7 +40,7 @@ void load_and_store() {
 
   // --- A.load/store tests ---
   idx_t idx1{};
-  auto a              = std::apply([&](auto... args) { return A.load(args...); }, idx1);
+  auto a              = std::apply([&](auto... args) { return A.load(simd::vectorize, args...); }, idx1);
   constexpr auto size = decltype(a)::size;
 
   for (size_t i = 0; i < size; ++i) {
@@ -50,7 +50,7 @@ void load_and_store() {
 
   idx_t idx2{};
   idx2[A.stride_order()[R - 1]] += size;
-  auto b = std::apply([&](auto... args) { return A.load(args...); }, idx2);
+  auto b = std::apply([&](auto... args) { return A.load(simd::vectorize, args...); }, idx2);
   for (size_t i = 0; i < size; ++i) {
     std::apply([&](auto... args) { expect_eq(b.get(i), A(args...)); }, idx2);
     ++idx2[A.stride_order()[R - 1]];
@@ -80,7 +80,7 @@ void load_and_store() {
   auto e1 = B + C;
   {
     idx_t idx{};
-    auto v = std::apply([&](auto... args) { return e1.load(args...); }, idx);
+    auto v = std::apply([&](auto... args) { return e1.load(simd::vectorize, args...); }, idx);
     for (size_t i = 0; i < size; ++i) {
       std::apply([&](auto... args) { expect_eq(v.get(i), e1(args...)); }, idx);
       ++idx[B.stride_order()[R - 1]];
@@ -91,7 +91,7 @@ void load_and_store() {
   auto e2 = B - C;
   {
     idx_t idx{};
-    auto v = std::apply([&](auto... args) { return e2.load(args...); }, idx);
+    auto v = std::apply([&](auto... args) { return e2.load(simd::vectorize, args...); }, idx);
     for (size_t i = 0; i < size; ++i) {
       std::apply([&](auto... args) { expect_eq(v.get(i), e2(args...)); }, idx);
       ++idx[B.stride_order()[R - 1]];
@@ -103,7 +103,7 @@ void load_and_store() {
     auto e3 = B * C;
     {
       idx_t idx{};
-      auto v = std::apply([&](auto... args) { return e3.load(args...); }, idx);
+      auto v = std::apply([&](auto... args) { return e3.load(simd::vectorize, args...); }, idx);
       for (size_t i = 0; i < size; ++i) {
         std::apply([&](auto... args) { expect_eq(v.get(i), e3(args...)); }, idx);
         ++idx[B.stride_order()[R - 1]];
@@ -113,7 +113,7 @@ void load_and_store() {
     auto e4 = B / C;
     {
       idx_t idx{};
-      auto v = std::apply([&](auto... args) { return e4.load(args...); }, idx);
+      auto v = std::apply([&](auto... args) { return e4.load(simd::vectorize, args...); }, idx);
       for (size_t i = 0; i < size; ++i) {
         std::apply([&](auto... args) { expect_eq(v.get(i), e4(args...)); }, idx);
         ++idx[B.stride_order()[R - 1]];
@@ -124,7 +124,7 @@ void load_and_store() {
     auto e5 = B + 5;
     {
       idx_t idx{};
-      auto v = std::apply([&](auto... args) { return e1.load(args...); }, idx);
+      auto v = std::apply([&](auto... args) { return e1.load(simd::vectorize, args...); }, idx);
       for (size_t i = 0; i < size; ++i) {
         std::apply([&](auto... args) { expect_eq(v.get(i), e1(args...)); }, idx);
         ++idx[B.stride_order()[R - 1]];
@@ -172,7 +172,7 @@ void mock_simd_test() {
 
   auto check = [&](const auto &r, const auto &s) {
     idx_t idx{};
-    auto v              = std::apply([&](auto... args) { return r.load(args...); }, idx);
+    auto v              = std::apply([&](auto... args) { return r.load(simd::vectorize, args...); }, idx);
     constexpr auto size = decltype(v)::size;
 
     for (size_t i = 0; i < size; ++i) {

--- a/test/c++/nda_simd.cpp
+++ b/test/c++/nda_simd.cpp
@@ -248,3 +248,56 @@ TEST(NDA, MOCK_SIMD) {
 #undef TEST_ALL_RANKS
 #undef TEST_LAYOUTS
 }
+
+TEST(NDA, EXPR_COST) {
+  using namespace nda::simd;
+  std::array<size_t, 2> shape;
+  shape.fill(32);
+  using array_t = array<float, 2>;
+
+  array_t A = rand(shape);
+  array_t B = rand(shape);
+  array_t C = rand(shape);
+
+  static_assert(expr_cost_v<float> == 0);
+  static_assert(expr_cost_v<array_t> == 1);
+
+  auto e1 = A + B + C;
+  static_assert(expr_cost_v<decltype(e1)> == 5);
+
+  auto e2 = e1 + A;
+  static_assert(expr_cost_v<decltype(e2)> == 7);
+
+  auto e3 = nda::map([](auto const &x) { return x * x; })(e2);
+  static_assert(expr_cost_v<decltype(e3)> == 8);
+
+  auto e4 = -e3;
+  static_assert(expr_cost_v<decltype(e4)> == 9);
+
+  auto e5 = e4 + 5.0f;
+  static_assert(expr_cost_v<decltype(e5)> == 10);
+
+  auto e6 = 5.0f * e5;
+  static_assert(expr_cost_v<decltype(e6)> == 11);
+
+  auto e7 = e6 + e6;
+  static_assert(expr_cost_v<decltype(e7)> == 23);
+
+  auto e8 = nda::map([](auto const &x, auto const &y) { return x - y; })(e7, e3);
+  static_assert(expr_cost_v<decltype(e8)> == 32);
+
+  auto e9 = log(e8);
+  static_assert(expr_cost_v<decltype(e9)> == 33);
+
+  static_assert(std::is_same_v<dispatch_policy_t<float>, scalar_t>);
+  static_assert(std::is_same_v<dispatch_policy_t<array_t>, vectorize_t>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e1)>, vectorize_t>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e2)>, vectorize_t>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e3)>, std::conditional_t<simd_cost_model<decltype(e3)>::emulate(), emulate_t, scalar_t>>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e4)>, std::conditional_t<simd_cost_model<decltype(e4)>::emulate(), emulate_t, scalar_t>>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e5)>, std::conditional_t<simd_cost_model<decltype(e5)>::emulate(), emulate_t, scalar_t>>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e6)>, std::conditional_t<simd_cost_model<decltype(e6)>::emulate(), emulate_t, scalar_t>>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e7)>, std::conditional_t<simd_cost_model<decltype(e7)>::emulate(), emulate_t, scalar_t>>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e8)>, std::conditional_t<simd_cost_model<decltype(e8)>::emulate(), emulate_t, scalar_t>>);
+  static_assert(std::is_same_v<dispatch_policy_t<decltype(e9)>, std::conditional_t<simd_cost_model<decltype(e9)>::emulate(), emulate_t, scalar_t>>);
+}

--- a/test/c++/nda_simd.cpp
+++ b/test/c++/nda_simd.cpp
@@ -259,35 +259,35 @@ TEST(NDA, EXPR_COST) {
   array_t B = rand(shape);
   array_t C = rand(shape);
 
-  static_assert(expr_cost_v<float> == 0);
-  static_assert(expr_cost_v<array_t> == 1);
+  static_assert(expr_cost<float>() == 0);
+  static_assert(expr_cost<array_t>() == 1);
 
   auto e1 = A + B + C;
-  static_assert(expr_cost_v<decltype(e1)> == 5);
+  static_assert(expr_cost<decltype(e1)>() == 5);
 
   auto e2 = e1 + A;
-  static_assert(expr_cost_v<decltype(e2)> == 7);
+  static_assert(expr_cost<decltype(e2)>() == 7);
 
   auto e3 = nda::map([](auto const &x) { return x * x; })(e2);
-  static_assert(expr_cost_v<decltype(e3)> == 8);
+  static_assert(expr_cost<decltype(e3)>() == 8);
 
   auto e4 = -e3;
-  static_assert(expr_cost_v<decltype(e4)> == 9);
+  static_assert(expr_cost<decltype(e4)>() == 9);
 
   auto e5 = e4 + 5.0f;
-  static_assert(expr_cost_v<decltype(e5)> == 10);
+  static_assert(expr_cost<decltype(e5)>() == 10);
 
   auto e6 = 5.0f * e5;
-  static_assert(expr_cost_v<decltype(e6)> == 11);
+  static_assert(expr_cost<decltype(e6)>() == 11);
 
   auto e7 = e6 + e6;
-  static_assert(expr_cost_v<decltype(e7)> == 23);
+  static_assert(expr_cost<decltype(e7)>() == 23);
 
   auto e8 = nda::map([](auto const &x, auto const &y) { return x - y; })(e7, e3);
-  static_assert(expr_cost_v<decltype(e8)> == 32);
+  static_assert(expr_cost<decltype(e8)>() == 32);
 
   auto e9 = log(e8);
-  static_assert(expr_cost_v<decltype(e9)> == 33);
+  static_assert(expr_cost<decltype(e9)>() == 33);
 
   static_assert(std::is_same_v<dispatch_policy_t<float>, scalar_t>);
   static_assert(std::is_same_v<dispatch_policy_t<array_t>, vectorize_t>);

--- a/test/c++/nda_simd.cpp
+++ b/test/c++/nda_simd.cpp
@@ -249,7 +249,7 @@ TEST(NDA, MOCK_SIMD) {
 #undef TEST_LAYOUTS
 }
 
-TEST(NDA, EXPR_COST) {
+TEST(NDA, EXPR_TREE_MODEL) {
   using namespace nda::simd;
   std::array<size_t, 2> shape;
   shape.fill(32);
@@ -259,35 +259,35 @@ TEST(NDA, EXPR_COST) {
   array_t B = rand(shape);
   array_t C = rand(shape);
 
-  static_assert(expr_cost<float>() == 0);
-  static_assert(expr_cost<array_t>() == 1);
+  static_assert(simd_gain<float>() == 0);
+  static_assert(simd_gain<array_t>() == 1);
 
   auto e1 = A + B + C;
-  static_assert(expr_cost<decltype(e1)>() == 5);
+  static_assert(simd_gain<decltype(e1)>() == 5);
 
   auto e2 = e1 + A;
-  static_assert(expr_cost<decltype(e2)>() == 7);
+  static_assert(simd_gain<decltype(e2)>() == 7);
 
   auto e3 = nda::map([](auto const &x) { return x * x; })(e2);
-  static_assert(expr_cost<decltype(e3)>() == 8);
+  static_assert(simd_gain<decltype(e3)>() == 8);
 
   auto e4 = -e3;
-  static_assert(expr_cost<decltype(e4)>() == 9);
+  static_assert(simd_gain<decltype(e4)>() == 9);
 
   auto e5 = e4 + 5.0f;
-  static_assert(expr_cost<decltype(e5)>() == 10);
+  static_assert(simd_gain<decltype(e5)>() == 10);
 
   auto e6 = 5.0f * e5;
-  static_assert(expr_cost<decltype(e6)>() == 11);
+  static_assert(simd_gain<decltype(e6)>() == 11);
 
   auto e7 = e6 + e6;
-  static_assert(expr_cost<decltype(e7)>() == 23);
+  static_assert(simd_gain<decltype(e7)>() == 23);
 
   auto e8 = nda::map([](auto const &x, auto const &y) { return x - y; })(e7, e3);
-  static_assert(expr_cost<decltype(e8)>() == 32);
+  static_assert(simd_gain<decltype(e8)>() == 32);
 
   auto e9 = log(e8);
-  static_assert(expr_cost<decltype(e9)>() == 33);
+  static_assert(simd_gain<decltype(e9)>() == 33);
 
   static_assert(std::is_same_v<dispatch_policy_t<float>, scalar_t>);
   static_assert(std::is_same_v<dispatch_policy_t<array_t>, vectorize_t>);

--- a/test/c++/nda_traits.cpp
+++ b/test/c++/nda_traits.cpp
@@ -7,6 +7,7 @@
 
 #include <nda/nda.hpp>
 #include <nda/traits.hpp>
+#include <nda/simd/simd_cost.hpp>
 
 #include <complex>
 #include <vector>
@@ -140,6 +141,8 @@ TEST(NDA, TraitsNDASpecific) {
 template <typename T, typename Layout1, typename Layout2>
 void check_all_simd_traits() {
   using namespace nda;
+  using namespace nda::simd;
+  using namespace nda::simd::detail;
   constexpr int Rank = 2;
   std::array<long, Rank> shape;
   shape.fill(64);
@@ -149,6 +152,15 @@ void check_all_simd_traits() {
 
   A_t A(shape);
   B_t B(shape);
+
+  static_assert(has_same_layout_v<A_t>);
+  static_assert(has_same_layout_v<B_t>);
+
+  static_assert(has_vectorizable_type_v<A_t>);
+  static_assert(has_vectorizable_type_v<B_t>);
+
+  static_assert(has_load_function_v<A_t>);
+  static_assert(has_load_function_v<B_t>);
 
   static_assert(is_simd_enabled_v<A_t>);
   static_assert(is_simd_enabled_v<B_t>);
@@ -160,10 +172,45 @@ void check_all_simd_traits() {
   auto mul_expr = A * B;
   auto div_expr = A / B;
 
+  static_assert(has_same_layout_v<decltype(add_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(sub_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(mul_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(div_expr)> == layouts_match);
+
+  static_assert(has_vectorizable_type_v<decltype(add_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(sub_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(mul_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(div_expr)>);
+
+  static_assert(has_load_function_v<decltype(add_expr)>);
+  static_assert(has_load_function_v<decltype(sub_expr)>);
+  static_assert(has_load_function_v<decltype(mul_expr)>);
+  static_assert(has_load_function_v<decltype(div_expr)>);
+
+  static_assert(has_same_layout_v<decltype(add_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(sub_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(mul_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(div_expr)> == layouts_match);
+
   static_assert(is_simd_enabled_v<decltype(add_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype(sub_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype(mul_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype(div_expr)> == layouts_match);
+
+  static_assert(has_same_layout_v<decltype(add_expr * sub_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype((sub_expr / div_expr) + mul_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(mul_expr + mul_expr * add_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(-(-div_expr + T{3}) * T{2})> == layouts_match);
+
+  static_assert(has_vectorizable_type_v<decltype(add_expr * sub_expr)>);
+  static_assert(has_vectorizable_type_v<decltype((sub_expr / div_expr) + mul_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(mul_expr + mul_expr * add_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(-(-div_expr + T{3}) * T{2})>);
+
+  static_assert(has_load_function_v<decltype(add_expr * sub_expr)>);
+  static_assert(has_load_function_v<decltype((sub_expr / div_expr) + mul_expr)>);
+  static_assert(has_load_function_v<decltype(mul_expr + mul_expr * add_expr)>);
+  static_assert(has_load_function_v<decltype(-(-div_expr + T{3}) * T{2})>);
 
   static_assert(is_simd_enabled_v<decltype(add_expr * sub_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype((sub_expr / div_expr) + mul_expr)> == layouts_match);
@@ -172,22 +219,54 @@ void check_all_simd_traits() {
 
   auto s_mul      = A * T{2};
   auto s_mul_left = T{2} * A;
+
+  static_assert(has_same_layout_v<decltype(s_mul)>);
+  static_assert(has_same_layout_v<decltype(s_mul_left)>);
+
+  static_assert(has_vectorizable_type_v<decltype(s_mul)>);
+  static_assert(has_vectorizable_type_v<decltype(s_mul_left)>);
+
+  static_assert(has_load_function_v<decltype(s_mul)>);
+  static_assert(has_load_function_v<decltype(s_mul_left)>);
+
   static_assert(is_simd_enabled_v<decltype(s_mul)>);
   static_assert(is_simd_enabled_v<decltype(s_mul_left)>);
 
   auto neg_expr = -A;
+  static_assert(has_same_layout_v<decltype(neg_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(neg_expr)>);
+  static_assert(has_load_function_v<decltype(neg_expr)>);
   static_assert(is_simd_enabled_v<decltype(neg_expr)>);
 
   array<int16_t, Rank, Layout1> wrong(shape);
   auto mixed_expr = A + wrong;
+
+  static_assert(has_same_layout_v<decltype(mixed_expr)>);
+  static_assert(has_same_layout_v<decltype(mixed_expr * add_expr)> == layouts_match);
+  static_assert(has_same_layout_v<decltype(add_expr + mixed_expr - wrong)> == layouts_match);
+
+  static_assert(!has_vectorizable_type_v<decltype(mixed_expr)>);
+  static_assert(!has_vectorizable_type_v<decltype(mixed_expr * add_expr)>);
+  static_assert(!has_vectorizable_type_v<decltype(add_expr + mixed_expr - wrong)>);
+
+  static_assert(!has_load_function_v<decltype(mixed_expr)>);
+  static_assert(!has_load_function_v<decltype(mixed_expr * add_expr)>);
+  static_assert(!has_load_function_v<decltype(add_expr + mixed_expr - wrong)>);
+
   static_assert(!is_simd_enabled_v<decltype(mixed_expr)>);
   static_assert(!is_simd_enabled_v<decltype(mixed_expr * add_expr)>);
   static_assert(!is_simd_enabled_v<decltype(add_expr + mixed_expr - wrong)>);
 
   auto V = A(range(0, 16), 0);
-  static_assert(!is_simd_enabled_v<decltype(V)>);
+  static_assert(has_same_layout_v<decltype(V)>);
+  static_assert(has_vectorizable_type_v<decltype(V)>);
+  static_assert(has_load_function_v<decltype(V)>);
+  static_assert(!is_simd_enabled_v<decltype(V)>); // Not contiguous
   array<T, 1> slice_size(std::array{16});
   auto sliced_expr = V + slice_size;
+  static_assert(has_same_layout_v<decltype(sliced_expr)>);
+  static_assert(has_vectorizable_type_v<decltype(sliced_expr)>);
+  static_assert(has_load_function_v<decltype(sliced_expr)>);
   static_assert(!is_simd_enabled_v<decltype(sliced_expr)>);
 
   // ─── Map functors ──────────────────────────────────────
@@ -215,64 +294,124 @@ void check_all_simd_traits() {
   };
 
   auto m1 = map(no_load_f{})(A, B);
+  static_assert(has_same_layout_v<decltype(m1)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m1)>);
+  static_assert(!has_load_function_v<decltype(m1)>);
   static_assert(!is_simd_enabled_v<decltype(m1)>);
 
   auto m2 = map(mock_only_f{})(A, B);
+  static_assert(has_same_layout_v<decltype(m2)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m2)>);
+  static_assert(has_load_function_v<decltype(m2)>);
   static_assert(is_simd_enabled_v<decltype(m2)> == layouts_match);
 
   auto m3 = map(native_simd_f{})(A, B);
+  static_assert(has_same_layout_v<decltype(m3)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m3)>);
+  static_assert(has_load_function_v<decltype(m3)>);
   static_assert(is_simd_enabled_v<decltype(m3)> == layouts_match);
 
   auto m4 = map(wrong_sig_f{})(A, B);
+  static_assert(has_same_layout_v<decltype(m4)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m4)>);
+  static_assert(!has_load_function_v<decltype(m4)>);
   static_assert(!is_simd_enabled_v<decltype(m4)>);
 
   auto m5 = map(bad_load_return_simd{})(A, B);
+  static_assert(has_same_layout_v<decltype(m5)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m5)>);
+  static_assert(!has_load_function_v<decltype(m5)>);
   static_assert(!is_simd_enabled_v<decltype(m5)>);
 
   auto m6 = map(bad_load_return_scalar{})(A, B);
+  static_assert(has_same_layout_v<decltype(m6)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m6)>);
+  static_assert(!has_load_function_v<decltype(m6)>);
   static_assert(!is_simd_enabled_v<decltype(m6)>);
 
   auto deep_map_expr = map(native_simd_f{})(A, B) + A * B - T{3} + add_expr;
+  static_assert(has_same_layout_v<decltype(deep_map_expr)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(deep_map_expr)>);
+  static_assert(has_load_function_v<decltype(deep_map_expr)>);
   static_assert(is_simd_enabled_v<decltype(deep_map_expr)> == layouts_match);
 
   auto broken_expr = map(native_simd_f{})(A, B) + map(no_load_f{})(A, B) + mul_expr;
+  static_assert(has_same_layout_v<decltype(broken_expr)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(broken_expr)>);
+  static_assert(!has_load_function_v<decltype(broken_expr)>);
   static_assert(!is_simd_enabled_v<decltype(broken_expr)>);
 
   auto mock_combined = map(mock_only_f{})(A, B) * T{2} - T{1};
+  static_assert(has_same_layout_v<decltype(mock_combined)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(mock_combined)>);
+  static_assert(has_load_function_v<decltype(mock_combined)>);
   static_assert(is_simd_enabled_v<decltype(mock_combined)> == layouts_match);
 
   auto map_then_slice = map(native_simd_f{})(A, B)(range(0, 16), 0);
-  static_assert(!is_simd_enabled_v<decltype(map_then_slice)>);
+  static_assert(has_same_layout_v<decltype(map_then_slice)>);
+  static_assert(has_vectorizable_type_v<decltype(map_then_slice)>);
+  static_assert(has_load_function_v<decltype(map_then_slice)>);
+  static_assert(!is_simd_enabled_v<decltype(map_then_slice)>); // Not contiguous
 
   // ─── Map applied to expressions ────────────────────────────────
   auto map1 = map(no_load_f{})(add_expr, mul_expr);
+  static_assert(has_same_layout_v<decltype(map1)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(map1)>);
+  static_assert(!has_load_function_v<decltype(map1)>);
   static_assert(!is_simd_enabled_v<decltype(map1)>);
 
   auto map2 = map(wrong_sig_f{})(div_expr, B);
+  static_assert(has_same_layout_v<decltype(map2)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(map2)>);
+  static_assert(!has_load_function_v<decltype(map2)>);
   static_assert(!is_simd_enabled_v<decltype(map2)>);
 
   auto map3 = map(mock_only_f{})(A, sub_expr);
+  static_assert(has_same_layout_v<decltype(map3)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(map3)>);
+  static_assert(has_load_function_v<decltype(map3)>);
   static_assert(is_simd_enabled_v<decltype(map3)> == layouts_match);
 
   auto map4 = map(native_simd_f{})(add_expr, B);
+  static_assert(has_same_layout_v<decltype(map4)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(map4)>);
+  static_assert(has_load_function_v<decltype(map4)>);
   static_assert(is_simd_enabled_v<decltype(map4)> == layouts_match);
 
   auto m1_plus_mul = map(no_load_f{})(A, sub_expr) + mul_expr;
+  static_assert(has_same_layout_v<decltype(m1_plus_mul)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m1_plus_mul)>);
+  static_assert(!has_load_function_v<decltype(m1_plus_mul)>);
   static_assert(!is_simd_enabled_v<decltype(m1_plus_mul)>);
 
   auto m2_times_div = map(wrong_sig_f{})(add_expr, A) * div_expr;
+  static_assert(has_same_layout_v<decltype(m2_times_div)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m2_times_div)>);
+  static_assert(!has_load_function_v<decltype(m2_times_div)>);
   static_assert(!is_simd_enabled_v<decltype(m2_times_div)>);
 
   auto m3_plus_mul = map(mock_only_f{})(mul_expr, B) + sub_expr;
+  static_assert(has_same_layout_v<decltype(m3_plus_mul)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m3_plus_mul)>);
+  static_assert(has_load_function_v<decltype(m3_plus_mul)>);
   static_assert(is_simd_enabled_v<decltype(m3_plus_mul)> == layouts_match);
 
   auto m4_plus_sub = map(native_simd_f{})(A, div_expr) + sub_expr;
+  static_assert(has_same_layout_v<decltype(m4_plus_sub)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m4_plus_sub)>);
+  static_assert(has_load_function_v<decltype(m4_plus_sub)>);
   static_assert(is_simd_enabled_v<decltype(m4_plus_sub)> == layouts_match);
 
   auto m5_plus_add = map(bad_load_return_simd{})(add_expr, mul_expr) + A;
+  static_assert(has_same_layout_v<decltype(m5_plus_add)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m5_plus_add)>);
+  static_assert(!has_load_function_v<decltype(m5_plus_add)>);
   static_assert(!is_simd_enabled_v<decltype(m5_plus_add)>);
 
   auto m6_plus_sub = map(bad_load_return_scalar{})(sub_expr, B) + div_expr;
+  static_assert(has_same_layout_v<decltype(m6_plus_sub)> == layouts_match);
+  static_assert(has_vectorizable_type_v<decltype(m6_plus_sub)>);
+  static_assert(!has_load_function_v<decltype(m6_plus_sub)>);
   static_assert(!is_simd_enabled_v<decltype(m6_plus_sub)>);
 }
 
@@ -292,6 +431,19 @@ TEST(NDA, SIMD_TRAITS) {
   TEST_SIMD_TRAITS_FOR_LAYOUTS(double)
   TEST_SIMD_TRAITS_FOR_LAYOUTS(std::complex<float>)
   TEST_SIMD_TRAITS_FOR_LAYOUTS(std::complex<double>)
+
+  using array_t = nda::array<std::vector<int>, 2>;
+  static_assert(nda::simd::detail::has_same_layout_v<array_t>);
+  static_assert(!nda::simd::detail::has_vectorizable_type_v<array_t>);
+  static_assert(!nda::simd::detail::has_load_function_v<array_t>);
+  static_assert(!nda::is_simd_enabled_v<array_t>);
+
+  using array_t2 = nda::array<float*, 3>;
+  static_assert(nda::simd::detail::has_same_layout_v<array_t2>);
+  static_assert(!nda::simd::detail::has_vectorizable_type_v<array_t2>);
+  static_assert(!nda::simd::detail::has_load_function_v<array_t2>);
+  static_assert(!nda::is_simd_enabled_v<array_t2>);
+
 
 #undef TEST_SIMD_TRAITS_FOR_LAYOUTS
 }

--- a/test/c++/nda_traits.cpp
+++ b/test/c++/nda_traits.cpp
@@ -142,7 +142,6 @@ template <typename T, typename Layout1, typename Layout2>
 void check_all_simd_traits() {
   using namespace nda;
   using namespace nda::simd;
-  using namespace nda::simd::detail;
   constexpr int Rank = 2;
   std::array<long, Rank> shape;
   shape.fill(64);
@@ -153,14 +152,14 @@ void check_all_simd_traits() {
   A_t A(shape);
   B_t B(shape);
 
-  static_assert(has_same_layout_v<A_t>);
-  static_assert(has_same_layout_v<B_t>);
+  static_assert(has_same_layout<A_t>());
+  static_assert(has_same_layout<B_t>());
 
-  static_assert(has_vectorizable_type_v<A_t>);
-  static_assert(has_vectorizable_type_v<B_t>);
+  static_assert(has_vectorizable_type<A_t>());
+  static_assert(has_vectorizable_type<B_t>());
 
-  static_assert(has_load_function_v<A_t>);
-  static_assert(has_load_function_v<B_t>);
+  static_assert(has_load_function<A_t>());
+  static_assert(has_load_function<B_t>());
 
   static_assert(is_simd_enabled_v<A_t>);
   static_assert(is_simd_enabled_v<B_t>);
@@ -172,45 +171,45 @@ void check_all_simd_traits() {
   auto mul_expr = A * B;
   auto div_expr = A / B;
 
-  static_assert(has_same_layout_v<decltype(add_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(sub_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(mul_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(div_expr)> == layouts_match);
+  static_assert(has_same_layout<decltype(add_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(sub_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(mul_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(div_expr)>() == layouts_match);
 
-  static_assert(has_vectorizable_type_v<decltype(add_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(sub_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(mul_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(div_expr)>);
+  static_assert(has_vectorizable_type<decltype(add_expr)>());
+  static_assert(has_vectorizable_type<decltype(sub_expr)>());
+  static_assert(has_vectorizable_type<decltype(mul_expr)>());
+  static_assert(has_vectorizable_type<decltype(div_expr)>());
 
-  static_assert(has_load_function_v<decltype(add_expr)>);
-  static_assert(has_load_function_v<decltype(sub_expr)>);
-  static_assert(has_load_function_v<decltype(mul_expr)>);
-  static_assert(has_load_function_v<decltype(div_expr)>);
+  static_assert(has_load_function<decltype(add_expr)>());
+  static_assert(has_load_function<decltype(sub_expr)>());
+  static_assert(has_load_function<decltype(mul_expr)>());
+  static_assert(has_load_function<decltype(div_expr)>());
 
-  static_assert(has_same_layout_v<decltype(add_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(sub_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(mul_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(div_expr)> == layouts_match);
+  static_assert(has_same_layout<decltype(add_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(sub_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(mul_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(div_expr)>() == layouts_match);
 
   static_assert(is_simd_enabled_v<decltype(add_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype(sub_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype(mul_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype(div_expr)> == layouts_match);
 
-  static_assert(has_same_layout_v<decltype(add_expr * sub_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype((sub_expr / div_expr) + mul_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(mul_expr + mul_expr * add_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(-(-div_expr + T{3}) * T{2})> == layouts_match);
+  static_assert(has_same_layout<decltype(add_expr * sub_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype((sub_expr / div_expr) + mul_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(mul_expr + mul_expr * add_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(-(-div_expr + T{3}) * T{2})>() == layouts_match);
 
-  static_assert(has_vectorizable_type_v<decltype(add_expr * sub_expr)>);
-  static_assert(has_vectorizable_type_v<decltype((sub_expr / div_expr) + mul_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(mul_expr + mul_expr * add_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(-(-div_expr + T{3}) * T{2})>);
+  static_assert(has_vectorizable_type<decltype(add_expr * sub_expr)>());
+  static_assert(has_vectorizable_type<decltype((sub_expr / div_expr) + mul_expr)>());
+  static_assert(has_vectorizable_type<decltype(mul_expr + mul_expr * add_expr)>());
+  static_assert(has_vectorizable_type<decltype(-(-div_expr + T{3}) * T{2})>());
 
-  static_assert(has_load_function_v<decltype(add_expr * sub_expr)>);
-  static_assert(has_load_function_v<decltype((sub_expr / div_expr) + mul_expr)>);
-  static_assert(has_load_function_v<decltype(mul_expr + mul_expr * add_expr)>);
-  static_assert(has_load_function_v<decltype(-(-div_expr + T{3}) * T{2})>);
+  static_assert(has_load_function<decltype(add_expr * sub_expr)>());
+  static_assert(has_load_function<decltype((sub_expr / div_expr) + mul_expr)>());
+  static_assert(has_load_function<decltype(mul_expr + mul_expr * add_expr)>());
+  static_assert(has_load_function<decltype(-(-div_expr + T{3}) * T{2})>());
 
   static_assert(is_simd_enabled_v<decltype(add_expr * sub_expr)> == layouts_match);
   static_assert(is_simd_enabled_v<decltype((sub_expr / div_expr) + mul_expr)> == layouts_match);
@@ -220,53 +219,53 @@ void check_all_simd_traits() {
   auto s_mul      = A * T{2};
   auto s_mul_left = T{2} * A;
 
-  static_assert(has_same_layout_v<decltype(s_mul)>);
-  static_assert(has_same_layout_v<decltype(s_mul_left)>);
+  static_assert(has_same_layout<decltype(s_mul)>());
+  static_assert(has_same_layout<decltype(s_mul_left)>());
 
-  static_assert(has_vectorizable_type_v<decltype(s_mul)>);
-  static_assert(has_vectorizable_type_v<decltype(s_mul_left)>);
+  static_assert(has_vectorizable_type<decltype(s_mul)>());
+  static_assert(has_vectorizable_type<decltype(s_mul_left)>());
 
-  static_assert(has_load_function_v<decltype(s_mul)>);
-  static_assert(has_load_function_v<decltype(s_mul_left)>);
+  static_assert(has_load_function<decltype(s_mul)>());
+  static_assert(has_load_function<decltype(s_mul_left)>());
 
   static_assert(is_simd_enabled_v<decltype(s_mul)>);
   static_assert(is_simd_enabled_v<decltype(s_mul_left)>);
 
   auto neg_expr = -A;
-  static_assert(has_same_layout_v<decltype(neg_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(neg_expr)>);
-  static_assert(has_load_function_v<decltype(neg_expr)>);
+  static_assert(has_same_layout<decltype(neg_expr)>());
+  static_assert(has_vectorizable_type<decltype(neg_expr)>());
+  static_assert(has_load_function<decltype(neg_expr)>());
   static_assert(is_simd_enabled_v<decltype(neg_expr)>);
 
   array<int16_t, Rank, Layout1> wrong(shape);
   auto mixed_expr = A + wrong;
 
-  static_assert(has_same_layout_v<decltype(mixed_expr)>);
-  static_assert(has_same_layout_v<decltype(mixed_expr * add_expr)> == layouts_match);
-  static_assert(has_same_layout_v<decltype(add_expr + mixed_expr - wrong)> == layouts_match);
+  static_assert(has_same_layout<decltype(mixed_expr)>());
+  static_assert(has_same_layout<decltype(mixed_expr * add_expr)>() == layouts_match);
+  static_assert(has_same_layout<decltype(add_expr + mixed_expr - wrong)>() == layouts_match);
 
-  static_assert(!has_vectorizable_type_v<decltype(mixed_expr)>);
-  static_assert(!has_vectorizable_type_v<decltype(mixed_expr * add_expr)>);
-  static_assert(!has_vectorizable_type_v<decltype(add_expr + mixed_expr - wrong)>);
+  static_assert(!has_vectorizable_type<decltype(mixed_expr)>());
+  static_assert(!has_vectorizable_type<decltype(mixed_expr * add_expr)>());
+  static_assert(!has_vectorizable_type<decltype(add_expr + mixed_expr - wrong)>());
 
-  static_assert(!has_load_function_v<decltype(mixed_expr)>);
-  static_assert(!has_load_function_v<decltype(mixed_expr * add_expr)>);
-  static_assert(!has_load_function_v<decltype(add_expr + mixed_expr - wrong)>);
+  static_assert(!has_load_function<decltype(mixed_expr)>());
+  static_assert(!has_load_function<decltype(mixed_expr * add_expr)>());
+  static_assert(!has_load_function<decltype(add_expr + mixed_expr - wrong)>());
 
   static_assert(!is_simd_enabled_v<decltype(mixed_expr)>);
   static_assert(!is_simd_enabled_v<decltype(mixed_expr * add_expr)>);
   static_assert(!is_simd_enabled_v<decltype(add_expr + mixed_expr - wrong)>);
 
   auto V = A(range(0, 16), 0);
-  static_assert(has_same_layout_v<decltype(V)>);
-  static_assert(has_vectorizable_type_v<decltype(V)>);
-  static_assert(has_load_function_v<decltype(V)>);
+  static_assert(has_same_layout<decltype(V)>());
+  static_assert(has_vectorizable_type<decltype(V)>());
+  static_assert(has_load_function<decltype(V)>());
   static_assert(!is_simd_enabled_v<decltype(V)>); // Not contiguous
   array<T, 1> slice_size(std::array{16});
   auto sliced_expr = V + slice_size;
-  static_assert(has_same_layout_v<decltype(sliced_expr)>);
-  static_assert(has_vectorizable_type_v<decltype(sliced_expr)>);
-  static_assert(has_load_function_v<decltype(sliced_expr)>);
+  static_assert(has_same_layout<decltype(sliced_expr)>());
+  static_assert(has_vectorizable_type<decltype(sliced_expr)>());
+  static_assert(has_load_function<decltype(sliced_expr)>());
   static_assert(!is_simd_enabled_v<decltype(sliced_expr)>);
 
   // ─── Map functors ──────────────────────────────────────
@@ -294,124 +293,124 @@ void check_all_simd_traits() {
   };
 
   auto m1 = map(no_load_f{})(A, B);
-  static_assert(has_same_layout_v<decltype(m1)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m1)>);
-  static_assert(!has_load_function_v<decltype(m1)>);
+  static_assert(has_same_layout<decltype(m1)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m1)>());
+  static_assert(!has_load_function<decltype(m1)>());
   static_assert(!is_simd_enabled_v<decltype(m1)>);
 
   auto m2 = map(mock_only_f{})(A, B);
-  static_assert(has_same_layout_v<decltype(m2)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m2)>);
-  static_assert(has_load_function_v<decltype(m2)>);
+  static_assert(has_same_layout<decltype(m2)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m2)>());
+  static_assert(has_load_function<decltype(m2)>());
   static_assert(is_simd_enabled_v<decltype(m2)> == layouts_match);
 
   auto m3 = map(native_simd_f{})(A, B);
-  static_assert(has_same_layout_v<decltype(m3)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m3)>);
-  static_assert(has_load_function_v<decltype(m3)>);
+  static_assert(has_same_layout<decltype(m3)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m3)>());
+  static_assert(has_load_function<decltype(m3)>());
   static_assert(is_simd_enabled_v<decltype(m3)> == layouts_match);
 
   auto m4 = map(wrong_sig_f{})(A, B);
-  static_assert(has_same_layout_v<decltype(m4)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m4)>);
-  static_assert(!has_load_function_v<decltype(m4)>);
+  static_assert(has_same_layout<decltype(m4)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m4)>());
+  static_assert(!has_load_function<decltype(m4)>());
   static_assert(!is_simd_enabled_v<decltype(m4)>);
 
   auto m5 = map(bad_load_return_simd{})(A, B);
-  static_assert(has_same_layout_v<decltype(m5)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m5)>);
-  static_assert(!has_load_function_v<decltype(m5)>);
+  static_assert(has_same_layout<decltype(m5)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m5)>());
+  static_assert(!has_load_function<decltype(m5)>());
   static_assert(!is_simd_enabled_v<decltype(m5)>);
 
   auto m6 = map(bad_load_return_scalar{})(A, B);
-  static_assert(has_same_layout_v<decltype(m6)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m6)>);
-  static_assert(!has_load_function_v<decltype(m6)>);
+  static_assert(has_same_layout<decltype(m6)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m6)>());
+  static_assert(!has_load_function<decltype(m6)>());
   static_assert(!is_simd_enabled_v<decltype(m6)>);
 
   auto deep_map_expr = map(native_simd_f{})(A, B) + A * B - T{3} + add_expr;
-  static_assert(has_same_layout_v<decltype(deep_map_expr)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(deep_map_expr)>);
-  static_assert(has_load_function_v<decltype(deep_map_expr)>);
+  static_assert(has_same_layout<decltype(deep_map_expr)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(deep_map_expr)>());
+  static_assert(has_load_function<decltype(deep_map_expr)>());
   static_assert(is_simd_enabled_v<decltype(deep_map_expr)> == layouts_match);
 
   auto broken_expr = map(native_simd_f{})(A, B) + map(no_load_f{})(A, B) + mul_expr;
-  static_assert(has_same_layout_v<decltype(broken_expr)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(broken_expr)>);
-  static_assert(!has_load_function_v<decltype(broken_expr)>);
+  static_assert(has_same_layout<decltype(broken_expr)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(broken_expr)>());
+  static_assert(!has_load_function<decltype(broken_expr)>());
   static_assert(!is_simd_enabled_v<decltype(broken_expr)>);
 
   auto mock_combined = map(mock_only_f{})(A, B) * T{2} - T{1};
-  static_assert(has_same_layout_v<decltype(mock_combined)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(mock_combined)>);
-  static_assert(has_load_function_v<decltype(mock_combined)>);
+  static_assert(has_same_layout<decltype(mock_combined)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(mock_combined)>());
+  static_assert(has_load_function<decltype(mock_combined)>());
   static_assert(is_simd_enabled_v<decltype(mock_combined)> == layouts_match);
 
   auto map_then_slice = map(native_simd_f{})(A, B)(range(0, 16), 0);
-  static_assert(has_same_layout_v<decltype(map_then_slice)>);
-  static_assert(has_vectorizable_type_v<decltype(map_then_slice)>);
-  static_assert(has_load_function_v<decltype(map_then_slice)>);
+  static_assert(has_same_layout<decltype(map_then_slice)>());
+  static_assert(has_vectorizable_type<decltype(map_then_slice)>());
+  static_assert(has_load_function<decltype(map_then_slice)>());
   static_assert(!is_simd_enabled_v<decltype(map_then_slice)>); // Not contiguous
 
   // ─── Map applied to expressions ────────────────────────────────
   auto map1 = map(no_load_f{})(add_expr, mul_expr);
-  static_assert(has_same_layout_v<decltype(map1)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(map1)>);
-  static_assert(!has_load_function_v<decltype(map1)>);
+  static_assert(has_same_layout<decltype(map1)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(map1)>());
+  static_assert(!has_load_function<decltype(map1)>());
   static_assert(!is_simd_enabled_v<decltype(map1)>);
 
   auto map2 = map(wrong_sig_f{})(div_expr, B);
-  static_assert(has_same_layout_v<decltype(map2)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(map2)>);
-  static_assert(!has_load_function_v<decltype(map2)>);
+  static_assert(has_same_layout<decltype(map2)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(map2)>());
+  static_assert(!has_load_function<decltype(map2)>());
   static_assert(!is_simd_enabled_v<decltype(map2)>);
 
   auto map3 = map(mock_only_f{})(A, sub_expr);
-  static_assert(has_same_layout_v<decltype(map3)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(map3)>);
-  static_assert(has_load_function_v<decltype(map3)>);
+  static_assert(has_same_layout<decltype(map3)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(map3)>());
+  static_assert(has_load_function<decltype(map3)>());
   static_assert(is_simd_enabled_v<decltype(map3)> == layouts_match);
 
   auto map4 = map(native_simd_f{})(add_expr, B);
-  static_assert(has_same_layout_v<decltype(map4)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(map4)>);
-  static_assert(has_load_function_v<decltype(map4)>);
+  static_assert(has_same_layout<decltype(map4)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(map4)>());
+  static_assert(has_load_function<decltype(map4)>());
   static_assert(is_simd_enabled_v<decltype(map4)> == layouts_match);
 
   auto m1_plus_mul = map(no_load_f{})(A, sub_expr) + mul_expr;
-  static_assert(has_same_layout_v<decltype(m1_plus_mul)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m1_plus_mul)>);
-  static_assert(!has_load_function_v<decltype(m1_plus_mul)>);
+  static_assert(has_same_layout<decltype(m1_plus_mul)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m1_plus_mul)>());
+  static_assert(!has_load_function<decltype(m1_plus_mul)>());
   static_assert(!is_simd_enabled_v<decltype(m1_plus_mul)>);
 
   auto m2_times_div = map(wrong_sig_f{})(add_expr, A) * div_expr;
-  static_assert(has_same_layout_v<decltype(m2_times_div)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m2_times_div)>);
-  static_assert(!has_load_function_v<decltype(m2_times_div)>);
+  static_assert(has_same_layout<decltype(m2_times_div)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m2_times_div)>());
+  static_assert(!has_load_function<decltype(m2_times_div)>());
   static_assert(!is_simd_enabled_v<decltype(m2_times_div)>);
 
   auto m3_plus_mul = map(mock_only_f{})(mul_expr, B) + sub_expr;
-  static_assert(has_same_layout_v<decltype(m3_plus_mul)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m3_plus_mul)>);
-  static_assert(has_load_function_v<decltype(m3_plus_mul)>);
+  static_assert(has_same_layout<decltype(m3_plus_mul)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m3_plus_mul)>());
+  static_assert(has_load_function<decltype(m3_plus_mul)>());
   static_assert(is_simd_enabled_v<decltype(m3_plus_mul)> == layouts_match);
 
   auto m4_plus_sub = map(native_simd_f{})(A, div_expr) + sub_expr;
-  static_assert(has_same_layout_v<decltype(m4_plus_sub)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m4_plus_sub)>);
-  static_assert(has_load_function_v<decltype(m4_plus_sub)>);
+  static_assert(has_same_layout<decltype(m4_plus_sub)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m4_plus_sub)>());
+  static_assert(has_load_function<decltype(m4_plus_sub)>());
   static_assert(is_simd_enabled_v<decltype(m4_plus_sub)> == layouts_match);
 
   auto m5_plus_add = map(bad_load_return_simd{})(add_expr, mul_expr) + A;
-  static_assert(has_same_layout_v<decltype(m5_plus_add)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m5_plus_add)>);
-  static_assert(!has_load_function_v<decltype(m5_plus_add)>);
+  static_assert(has_same_layout<decltype(m5_plus_add)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m5_plus_add)>());
+  static_assert(!has_load_function<decltype(m5_plus_add)>());
   static_assert(!is_simd_enabled_v<decltype(m5_plus_add)>);
 
   auto m6_plus_sub = map(bad_load_return_scalar{})(sub_expr, B) + div_expr;
-  static_assert(has_same_layout_v<decltype(m6_plus_sub)> == layouts_match);
-  static_assert(has_vectorizable_type_v<decltype(m6_plus_sub)>);
-  static_assert(!has_load_function_v<decltype(m6_plus_sub)>);
+  static_assert(has_same_layout<decltype(m6_plus_sub)>() == layouts_match);
+  static_assert(has_vectorizable_type<decltype(m6_plus_sub)>());
+  static_assert(!has_load_function<decltype(m6_plus_sub)>());
   static_assert(!is_simd_enabled_v<decltype(m6_plus_sub)>);
 }
 
@@ -433,15 +432,15 @@ TEST(NDA, SIMD_TRAITS) {
   TEST_SIMD_TRAITS_FOR_LAYOUTS(std::complex<double>)
 
   using array_t = nda::array<std::vector<int>, 2>;
-  static_assert(nda::simd::detail::has_same_layout_v<array_t>);
-  static_assert(!nda::simd::detail::has_vectorizable_type_v<array_t>);
-  static_assert(!nda::simd::detail::has_load_function_v<array_t>);
+  static_assert(nda::simd::has_same_layout<array_t>());
+  static_assert(!nda::simd::has_vectorizable_type<array_t>());
+  static_assert(!nda::simd::has_load_function<array_t>());
   static_assert(!nda::is_simd_enabled_v<array_t>);
 
   using array_t2 = nda::array<float*, 3>;
-  static_assert(nda::simd::detail::has_same_layout_v<array_t2>);
-  static_assert(!nda::simd::detail::has_vectorizable_type_v<array_t2>);
-  static_assert(!nda::simd::detail::has_load_function_v<array_t2>);
+  static_assert(nda::simd::has_same_layout<array_t2>());
+  static_assert(!nda::simd::has_vectorizable_type<array_t2>());
+  static_assert(!nda::simd::has_load_function<array_t2>());
   static_assert(!nda::is_simd_enabled_v<array_t2>);
 
 

--- a/test/c++/nda_traits.cpp
+++ b/test/c++/nda_traits.cpp
@@ -136,3 +136,162 @@ TEST(NDA, TraitsNDASpecific) {
   static_assert((cinfo & sinfo_2).prop == nda::layout_prop_e::none);
   static_assert((cinfo & sinfo_2).stride_order == static_cast<uint64_t>(-1));
 }
+
+template <typename T, typename Layout1, typename Layout2>
+void check_all_simd_traits() {
+  using namespace nda;
+  constexpr int Rank = 2;
+  std::array<long, Rank> shape;
+  shape.fill(64);
+
+  using A_t = array<T, Rank, Layout1>;
+  using B_t = array<T, Rank, Layout2>;
+
+  A_t A(shape);
+  B_t B(shape);
+
+  static_assert(is_simd_enabled_v<A_t>);
+  static_assert(is_simd_enabled_v<B_t>);
+
+  constexpr bool layouts_match = std::is_same_v<Layout1, Layout2>;
+
+  auto add_expr = A + B;
+  auto sub_expr = A - B;
+  auto mul_expr = A * B;
+  auto div_expr = A / B;
+
+  static_assert(is_simd_enabled_v<decltype(add_expr)> == layouts_match);
+  static_assert(is_simd_enabled_v<decltype(sub_expr)> == layouts_match);
+  static_assert(is_simd_enabled_v<decltype(mul_expr)> == layouts_match);
+  static_assert(is_simd_enabled_v<decltype(div_expr)> == layouts_match);
+
+  static_assert(is_simd_enabled_v<decltype(add_expr * sub_expr)> == layouts_match);
+  static_assert(is_simd_enabled_v<decltype((sub_expr / div_expr) + mul_expr)> == layouts_match);
+  static_assert(is_simd_enabled_v<decltype(mul_expr + mul_expr * add_expr)> == layouts_match);
+  static_assert(is_simd_enabled_v<decltype(-(-div_expr + T{3}) * T{2})> == layouts_match);
+
+  auto s_mul      = A * T{2};
+  auto s_mul_left = T{2} * A;
+  static_assert(is_simd_enabled_v<decltype(s_mul)>);
+  static_assert(is_simd_enabled_v<decltype(s_mul_left)>);
+
+  auto neg_expr = -A;
+  static_assert(is_simd_enabled_v<decltype(neg_expr)>);
+
+  array<int16_t, Rank, Layout1> wrong(shape);
+  auto mixed_expr = A + wrong;
+  static_assert(!is_simd_enabled_v<decltype(mixed_expr)>);
+  static_assert(!is_simd_enabled_v<decltype(mixed_expr * add_expr)>);
+  static_assert(!is_simd_enabled_v<decltype(add_expr + mixed_expr - wrong)>);
+
+  auto V = A(range(0, 16), 0);
+  static_assert(!is_simd_enabled_v<decltype(V)>);
+  array<T, 1> slice_size(std::array{16});
+  auto sliced_expr = V + slice_size;
+  static_assert(!is_simd_enabled_v<decltype(sliced_expr)>);
+
+  // ─── Map functors ──────────────────────────────────────
+  struct no_load_f {
+    T operator()(T x, T y) const { return x + y; }
+  };
+  struct mock_only_f : simd::mock_simd<mock_only_f, T> {
+    T operator()(T x, T y) const { return x + y; }
+  };
+  struct native_simd_f {
+    T operator()(T x, T y) const { return x + y; }
+    native_simd<T> load(native_simd<T> x, native_simd<T> y) const { return x + y; }
+  };
+  struct wrong_sig_f {
+    T operator()(T x, T y) const { return x + y; }
+    T load(T x, T y) const { return x + y; }
+  };
+  struct bad_load_return_simd {
+    T operator()(T x, T y) const { return x + y; }
+    native_simd<T> load(T x, T y) const { return native_simd<T>{x + y}; }
+  };
+  struct bad_load_return_scalar {
+    T operator()(T x, T y) const { return x + y; }
+    T load(native_simd<T> x, native_simd<T> y) const { return (x + y).get(0); }
+  };
+
+  auto m1 = map(no_load_f{})(A, B);
+  static_assert(!is_simd_enabled_v<decltype(m1)>);
+
+  auto m2 = map(mock_only_f{})(A, B);
+  static_assert(is_simd_enabled_v<decltype(m2)> == layouts_match);
+
+  auto m3 = map(native_simd_f{})(A, B);
+  static_assert(is_simd_enabled_v<decltype(m3)> == layouts_match);
+
+  auto m4 = map(wrong_sig_f{})(A, B);
+  static_assert(!is_simd_enabled_v<decltype(m4)>);
+
+  auto m5 = map(bad_load_return_simd{})(A, B);
+  static_assert(!is_simd_enabled_v<decltype(m5)>);
+
+  auto m6 = map(bad_load_return_scalar{})(A, B);
+  static_assert(!is_simd_enabled_v<decltype(m6)>);
+
+  auto deep_map_expr = map(native_simd_f{})(A, B) + A * B - T{3} + add_expr;
+  static_assert(is_simd_enabled_v<decltype(deep_map_expr)> == layouts_match);
+
+  auto broken_expr = map(native_simd_f{})(A, B) + map(no_load_f{})(A, B) + mul_expr;
+  static_assert(!is_simd_enabled_v<decltype(broken_expr)>);
+
+  auto mock_combined = map(mock_only_f{})(A, B) * T{2} - T{1};
+  static_assert(is_simd_enabled_v<decltype(mock_combined)> == layouts_match);
+
+  auto map_then_slice = map(native_simd_f{})(A, B)(range(0, 16), 0);
+  static_assert(!is_simd_enabled_v<decltype(map_then_slice)>);
+
+  // ─── Map applied to expressions ────────────────────────────────
+  auto map1 = map(no_load_f{})(add_expr, mul_expr);
+  static_assert(!is_simd_enabled_v<decltype(map1)>);
+
+  auto map2 = map(wrong_sig_f{})(div_expr, B);
+  static_assert(!is_simd_enabled_v<decltype(map2)>);
+
+  auto map3 = map(mock_only_f{})(A, sub_expr);
+  static_assert(is_simd_enabled_v<decltype(map3)> == layouts_match);
+
+  auto map4 = map(native_simd_f{})(add_expr, B);
+  static_assert(is_simd_enabled_v<decltype(map4)> == layouts_match);
+
+  auto m1_plus_mul = map(no_load_f{})(A, sub_expr) + mul_expr;
+  static_assert(!is_simd_enabled_v<decltype(m1_plus_mul)>);
+
+  auto m2_times_div = map(wrong_sig_f{})(add_expr, A) * div_expr;
+  static_assert(!is_simd_enabled_v<decltype(m2_times_div)>);
+
+  auto m3_plus_mul = map(mock_only_f{})(mul_expr, B) + sub_expr;
+  static_assert(is_simd_enabled_v<decltype(m3_plus_mul)> == layouts_match);
+
+  auto m4_plus_sub = map(native_simd_f{})(A, div_expr) + sub_expr;
+  static_assert(is_simd_enabled_v<decltype(m4_plus_sub)> == layouts_match);
+
+  auto m5_plus_add = map(bad_load_return_simd{})(add_expr, mul_expr) + A;
+  static_assert(!is_simd_enabled_v<decltype(m5_plus_add)>);
+
+  auto m6_plus_sub = map(bad_load_return_scalar{})(sub_expr, B) + div_expr;
+  static_assert(!is_simd_enabled_v<decltype(m6_plus_sub)>);
+}
+
+TEST(NDA, SIMD_TRAITS) {
+
+#define TEST_SIMD_TRAITS_FOR_LAYOUTS(type)                                                                                                           \
+  check_all_simd_traits<type, nda::C_layout, nda::C_layout>();                                                                                       \
+  check_all_simd_traits<type, nda::C_layout, nda::F_layout>();                                                                                       \
+  check_all_simd_traits<type, nda::F_layout, nda::C_layout>();                                                                                       \
+  check_all_simd_traits<type, nda::F_layout, nda::F_layout>();
+
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(int32_t)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(int64_t)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(uint32_t)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(uint64_t)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(float)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(double)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(std::complex<float>)
+  TEST_SIMD_TRAITS_FOR_LAYOUTS(std::complex<double>)
+
+#undef TEST_SIMD_TRAITS_FOR_LAYOUTS
+}


### PR DESCRIPTION
This Pull Request introduces a comprehensive refactoring of the expression evaluation framework to support lazy SIMD processing across the library.
Key Features and Changes:

  -  Lazy SIMD Evaluation: Implemented full vectorization for existing algorithms and map functions by leveraging the XSIMD infrastructure.

  -  SIMD Emulation: Introduced the mock_simd class to emulate SIMD behavior. This is needed for structurally sound expressions that lack load functions.

   - Cost-Based Dispatch: Implemented an Expression Tree Cost Model (based on node count) that dynamically selects the optimal execution strategy at compile time:
   - Native SIMD: If all vectorization checks pass(layout compatibe, type compatible, contiguous layout, vectorizable types).
   - Emulated SIMD: If native load does not exist and the expression cost is above a set threshold (to justify emulation overhead).
   - Scalar Evaluation: If layouts or types are incompatible, or if expression cost is below the threshold. 