### PR TITLE
Add interface for LAPACK's geev routine and corresponding higher level wrapper functions

### DIFF
--- a/c++/nda/blas/interface/cublas_interface.cpp
+++ b/c++/nda/blas/interface/cublas_interface.cpp
@@ -82,115 +82,115 @@ namespace nda::blas::device {
     }                                                                                                                                                \
   }
 
-  void gemm(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, const double *B, int LDB, double beta, double *C,
-            int LDC) {
-    CUBLAS_CHECK(cublasDgemm, get_cublas_op(op_a), get_cublas_op(op_b), M, N, K, &alpha, A, LDA, B, LDB, &beta, C, LDC);
+  void gemm(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta, double *c,
+            int ldc) {
+    CUBLAS_CHECK(cublasDgemm, get_cublas_op(op_a), get_cublas_op(op_b), m, n, k, &alpha, a, lda, b, ldb, &beta, c, ldc);
   }
-  void gemm(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *B, int LDB, dcomplex beta,
-            dcomplex *C, int LDC) {
+  void gemm(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *b, int ldb, dcomplex beta,
+            dcomplex *c, int ldc) {
     auto alpha_cu = cucplx(alpha);
     auto beta_cu  = cucplx(beta);
-    CUBLAS_CHECK(cublasZgemm, get_cublas_op(op_a), get_cublas_op(op_b), M, N, K, &alpha_cu, cucplx(A), LDA, cucplx(B), LDB, &beta_cu, cucplx(C), LDC);
+    CUBLAS_CHECK(cublasZgemm, get_cublas_op(op_a), get_cublas_op(op_b), m, n, k, &alpha_cu, cucplx(a), lda, cucplx(b), ldb, &beta_cu, cucplx(c), ldc);
   }
 
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, double alpha, const double **A, int LDA, const double **B, int LDB, double beta,
-                  double **C, int LDC, int batch_count) {
-    CUBLAS_CHECK(cublasDgemmBatched, get_cublas_op(op_a), get_cublas_op(op_b), M, N, K, &alpha, A, LDA, B, LDB, &beta, C, LDC, batch_count);
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, double alpha, const double **a, int lda, const double **b, int ldb, double beta,
+                  double **c, int ldc, int batch_count) {
+    CUBLAS_CHECK(cublasDgemmBatched, get_cublas_op(op_a), get_cublas_op(op_b), m, n, k, &alpha, a, lda, b, ldb, &beta, c, ldc, batch_count);
   }
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex **A, int LDA, const dcomplex **B, int LDB, dcomplex beta,
-                  dcomplex **C, int LDC, int batch_count) {
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex **a, int lda, const dcomplex **b, int ldb, dcomplex beta,
+                  dcomplex **c, int ldc, int batch_count) {
     auto alpha_cu = cucplx(alpha);
     auto beta_cu  = cucplx(beta);
-    CUBLAS_CHECK(cublasZgemmBatched, get_cublas_op(op_a), get_cublas_op(op_b), M, N, K, &alpha_cu, cucplx(A), LDA, cucplx(B), LDB, &beta_cu,
-                 cucplx(C), LDC, batch_count);
+    CUBLAS_CHECK(cublasZgemmBatched, get_cublas_op(op_a), get_cublas_op(op_b), m, n, k, &alpha_cu, cucplx(a), lda, cucplx(b), ldb, &beta_cu,
+                 cucplx(c), ldc, batch_count);
   }
 
 #ifdef NDA_HAVE_MAGMA
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, double alpha, const double **A, int *LDA, const double **B, int *LDB, double beta,
-                   double **C, int *LDC, int batch_count) {
-    magmablas_dgemm_vbatched(get_magma_op(op_a), get_magma_op(op_b), M, N, K, alpha, A, LDA, B, LDB, beta, C, LDC, batch_count, get_magma_queue());
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, double alpha, const double **a, int *lda, const double **b, int *ldb, double beta,
+                   double **c, int *ldc, int batch_count) {
+    magmablas_dgemm_vbatched(get_magma_op(op_a), get_magma_op(op_b), m, n, k, alpha, a, lda, b, ldb, beta, c, ldc, batch_count, get_magma_queue());
     if (synchronize) magma_queue_sync(get_magma_queue());
     if (synchronize) cudaDeviceSynchronize();
   }
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, dcomplex alpha, const dcomplex **A, int *LDA, const dcomplex **B, int *LDB,
-                   dcomplex beta, dcomplex **C, int *LDC, int batch_count) {
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, dcomplex alpha, const dcomplex **a, int *lda, const dcomplex **b, int *ldb,
+                   dcomplex beta, dcomplex **c, int *ldc, int batch_count) {
     auto alpha_cu = cucplx(alpha);
     auto beta_cu  = cucplx(beta);
-    magmablas_zgemm_vbatched(get_magma_op(op_a), get_magma_op(op_b), M, N, K, alpha_cu, cucplx(A), LDA, cucplx(B), LDB, beta_cu, cucplx(C), LDC,
+    magmablas_zgemm_vbatched(get_magma_op(op_a), get_magma_op(op_b), m, n, k, alpha_cu, cucplx(a), lda, cucplx(b), ldb, beta_cu, cucplx(c), ldc,
                              batch_count, get_magma_queue());
     if (synchronize) magma_queue_sync(get_magma_queue());
     if (synchronize) cudaDeviceSynchronize();
   }
 #endif
 
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, int strideA, const double *B, int LDB,
-                          int strideB, double beta, double *C, int LDC, int strideC, int batch_count) {
-    CUBLAS_CHECK(cublasDgemmStridedBatched, get_cublas_op(op_a), get_cublas_op(op_b), M, N, K, &alpha, A, LDA, strideA, B, LDB, strideB, &beta, C,
-                 LDC, strideC, batch_count);
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, int stride_a, const double *b, int ldb,
+                          int stride_b, double beta, double *c, int ldc, int stride_c, int batch_count) {
+    CUBLAS_CHECK(cublasDgemmStridedBatched, get_cublas_op(op_a), get_cublas_op(op_b), m, n, k, &alpha, a, lda, stride_a, b, ldb, stride_b, &beta, c,
+                 ldc, stride_c, batch_count);
   }
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, int strideA, const dcomplex *B,
-                          int LDB, int strideB, dcomplex beta, dcomplex *C, int LDC, int strideC, int batch_count) {
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, int stride_a, const dcomplex *b,
+                          int ldb, int stride_b, dcomplex beta, dcomplex *c, int ldc, int stride_c, int batch_count) {
     auto alpha_cu = cucplx(alpha);
     auto beta_cu  = cucplx(beta);
-    CUBLAS_CHECK(cublasZgemmStridedBatched, get_cublas_op(op_a), get_cublas_op(op_b), M, N, K, &alpha_cu, cucplx(A), LDA, strideA, cucplx(B), LDB,
-                 strideB, &beta_cu, cucplx(C), LDC, strideC, batch_count);
+    CUBLAS_CHECK(cublasZgemmStridedBatched, get_cublas_op(op_a), get_cublas_op(op_b), m, n, k, &alpha_cu, cucplx(a), lda, stride_a, cucplx(b), ldb,
+                 stride_b, &beta_cu, cucplx(c), ldc, stride_c, batch_count);
   }
 
-  void axpy(int N, double alpha, const double *x, int incx, double *Y, int incy) { cublasDaxpy(get_handle(), N, &alpha, x, incx, Y, incy); }
-  void axpy(int N, dcomplex alpha, const dcomplex *x, int incx, dcomplex *Y, int incy) {
+  void axpy(int n, double alpha, const double *x, int incx, double *y, int incy) { cublasDaxpy(get_handle(), n, &alpha, x, incx, y, incy); }
+  void axpy(int n, dcomplex alpha, const dcomplex *x, int incx, dcomplex *y, int incy) {
     auto alpha_cu = cucplx(alpha);
-    CUBLAS_CHECK(cublasZaxpy, N, &alpha_cu, cucplx(x), incx, cucplx(Y), incy);
+    CUBLAS_CHECK(cublasZaxpy, n, &alpha_cu, cucplx(x), incx, cucplx(y), incy);
   }
 
-  void copy(int N, const double *x, int incx, double *Y, int incy) { cublasDcopy(get_handle(), N, x, incx, Y, incy); }
-  void copy(int N, const dcomplex *x, int incx, dcomplex *Y, int incy) { CUBLAS_CHECK(cublasZcopy, N, cucplx(x), incx, cucplx(Y), incy); }
+  void copy(int n, const double *x, int incx, double *y, int incy) { cublasDcopy(get_handle(), n, x, incx, y, incy); }
+  void copy(int n, const dcomplex *x, int incx, dcomplex *y, int incy) { CUBLAS_CHECK(cublasZcopy, n, cucplx(x), incx, cucplx(y), incy); }
 
-  double dot(int M, const double *x, int incx, const double *Y, int incy) {
+  double dot(int m, const double *x, int incx, const double *y, int incy) {
     double res{};
-    CUBLAS_CHECK(cublasDdot, M, x, incx, Y, incy, &res);
+    CUBLAS_CHECK(cublasDdot, m, x, incx, y, incy, &res);
     return res;
   }
-  dcomplex dot(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy) {
+  dcomplex dot(int m, const dcomplex *x, int incx, const dcomplex *y, int incy) {
     cuDoubleComplex res;
-    CUBLAS_CHECK(cublasZdotu, M, cucplx(x), incx, cucplx(Y), incy, &res);
+    CUBLAS_CHECK(cublasZdotu, m, cucplx(x), incx, cucplx(y), incy, &res);
     return {res.x, res.y};
   }
-  dcomplex dotc(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy) {
+  dcomplex dotc(int m, const dcomplex *x, int incx, const dcomplex *y, int incy) {
     cuDoubleComplex res;
-    CUBLAS_CHECK(cublasZdotc, M, cucplx(x), incx, cucplx(Y), incy, &res);
+    CUBLAS_CHECK(cublasZdotc, m, cucplx(x), incx, cucplx(y), incy, &res);
     return {res.x, res.y};
   }
 
-  void gemv(char op, int M, int N, double alpha, const double *A, int LDA, const double *x, int incx, double beta, double *Y, int incy) {
-    CUBLAS_CHECK(cublasDgemv, get_cublas_op(op), M, N, &alpha, A, LDA, x, incx, &beta, Y, incy);
+  void gemv(char op, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy) {
+    CUBLAS_CHECK(cublasDgemv, get_cublas_op(op), m, n, &alpha, a, lda, x, incx, &beta, y, incy);
   }
-  void gemv(char op, int M, int N, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *x, int incx, dcomplex beta, dcomplex *Y, int incy) {
+  void gemv(char op, int m, int n, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *x, int incx, dcomplex beta, dcomplex *y, int incy) {
     auto alpha_cu = cucplx(alpha);
     auto beta_cu  = cucplx(beta);
-    CUBLAS_CHECK(cublasZgemv, get_cublas_op(op), M, N, &alpha_cu, cucplx(A), LDA, cucplx(x), incx, &beta_cu, cucplx(Y), incy);
+    CUBLAS_CHECK(cublasZgemv, get_cublas_op(op), m, n, &alpha_cu, cucplx(a), lda, cucplx(x), incx, &beta_cu, cucplx(y), incy);
   }
 
-  void ger(int M, int N, double alpha, const double *x, int incx, const double *Y, int incy, double *A, int LDA) {
-    CUBLAS_CHECK(cublasDger, M, N, &alpha, x, incx, Y, incy, A, LDA);
+  void ger(int m, int n, double alpha, const double *x, int incx, const double *y, int incy, double *a, int lda) {
+    CUBLAS_CHECK(cublasDger, m, n, &alpha, x, incx, y, incy, a, lda);
   }
-  void ger(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA) {
+  void ger(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda) {
     auto alpha_cu = cucplx(alpha);
-    CUBLAS_CHECK(cublasZgeru, M, N, &alpha_cu, cucplx(x), incx, cucplx(Y), incy, cucplx(A), LDA);
+    CUBLAS_CHECK(cublasZgeru, m, n, &alpha_cu, cucplx(x), incx, cucplx(y), incy, cucplx(a), lda);
   }
-  void gerc(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA) {
+  void gerc(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda) {
     auto alpha_cu = cucplx(alpha);
-    CUBLAS_CHECK(cublasZgerc, M, N, &alpha_cu, cucplx(x), incx, cucplx(Y), incy, cucplx(A), LDA);
+    CUBLAS_CHECK(cublasZgerc, m, n, &alpha_cu, cucplx(x), incx, cucplx(y), incy, cucplx(a), lda);
   }
 
-  void scal(int M, double alpha, double *x, int incx) { CUBLAS_CHECK(cublasDscal, M, &alpha, x, incx); }
-  void scal(int M, dcomplex alpha, dcomplex *x, int incx) {
+  void scal(int m, double alpha, double *x, int incx) { CUBLAS_CHECK(cublasDscal, m, &alpha, x, incx); }
+  void scal(int m, dcomplex alpha, dcomplex *x, int incx) {
     auto alpha_cu = cucplx(alpha);
-    CUBLAS_CHECK(cublasZscal, M, &alpha_cu, cucplx(x), incx);
+    CUBLAS_CHECK(cublasZscal, m, &alpha_cu, cucplx(x), incx);
   }
 
-  void swap(int N, double *x, int incx, double *Y, int incy) { CUBLAS_CHECK(cublasDswap, N, x, incx, Y, incy); } // NOLINT (this is a BLAS swap)
-  void swap(int N, dcomplex *x, int incx, dcomplex *Y, int incy) {                                               // NOLINT (this is a BLAS swap)
-    CUBLAS_CHECK(cublasZswap, N, cucplx(x), incx, cucplx(Y), incy);
+  void swap(int n, double *x, int incx, double *y, int incy) { CUBLAS_CHECK(cublasDswap, n, x, incx, y, incy); } // NOLINT (this is a BLAS swap)
+  void swap(int n, dcomplex *x, int incx, dcomplex *y, int incy) {                                               // NOLINT (this is a BLAS swap)
+    CUBLAS_CHECK(cublasZswap, n, cucplx(x), incx, cucplx(y), incy);
   }
 
 } // namespace nda::blas::device

--- a/c++/nda/blas/interface/cublas_interface.hpp
+++ b/c++/nda/blas/interface/cublas_interface.hpp
@@ -22,31 +22,31 @@
 
 namespace nda::blas::device {
 
-  void axpy(int N, double alpha, const double *x, int incx, double *Y, int incy);
-  void axpy(int N, dcomplex alpha, const dcomplex *x, int incx, dcomplex *Y, int incy);
+  void axpy(int n, double alpha, const double *x, int incx, double *y, int incy);
+  void axpy(int n, dcomplex alpha, const dcomplex *x, int incx, dcomplex *y, int incy);
 
-  void copy(int N, const double *x, int incx, double *Y, int incy);
-  void copy(int N, const dcomplex *x, int incx, dcomplex *Y, int incy);
+  void copy(int n, const double *x, int incx, double *y, int incy);
+  void copy(int n, const dcomplex *x, int incx, dcomplex *y, int incy);
 
-  double dot(int M, const double *x, int incx, const double *Y, int incy);
-  dcomplex dot(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy);
-  dcomplex dotc(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy);
+  double dot(int m, const double *x, int incx, const double *y, int incy);
+  dcomplex dot(int m, const dcomplex *x, int incx, const dcomplex *y, int incy);
+  dcomplex dotc(int m, const dcomplex *x, int incx, const dcomplex *y, int incy);
 
-  void gemm(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, const double *B, int LDB, double beta, double *C,
-            int LDC);
-  void gemm(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *B, int LDB, dcomplex beta,
-            dcomplex *C, int LDC);
+  void gemm(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta, double *c,
+            int ldc);
+  void gemm(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *b, int ldb, dcomplex beta,
+            dcomplex *c, int ldc);
 
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, double alpha, const double **A, int LDA, const double **B, int LDB, double beta,
-                  double **C, int LDC, int batch_count);
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex **A, int LDA, const dcomplex **B, int LDB, dcomplex beta,
-                  dcomplex **C, int LDC, int batch_count);
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, double alpha, const double **a, int lda, const double **b, int ldb, double beta,
+                  double **c, int ldc, int batch_count);
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex **a, int lda, const dcomplex **b, int ldb, dcomplex beta,
+                  dcomplex **c, int ldc, int batch_count);
 
 #ifdef NDA_HAVE_MAGMA
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, double alpha, const double **A, int *LDA, const double **B, int *LDB, double beta,
-                   double **C, int *LDC, int batch_count);
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, dcomplex alpha, const dcomplex **A, int *LDA, const dcomplex **B, int *LDB,
-                   dcomplex beta, dcomplex **C, int *LDC, int batch_count);
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, double alpha, const double **a, int *lda, const double **b, int *ldb, double beta,
+                   double **c, int *ldc, int batch_count);
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, dcomplex alpha, const dcomplex **a, int *lda, const dcomplex **b, int *ldb,
+                   dcomplex beta, dcomplex **c, int *ldc, int batch_count);
 #else
   inline void gemm_vbatch(char, char, int *, int *, int *, double, const double **, int *, const double **, int *, double, double **, int *, int) {
     NDA_RUNTIME_ERROR << "nda::blas::device::gemmv_batch requires Magma [https://icl.cs.utk.edu/magma/]. Configure nda with -DUse_Magma=ON";
@@ -57,22 +57,22 @@ namespace nda::blas::device {
   }
 #endif
 
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, int strideA, const double *B, int LDB,
-                          int strideB, double beta, double *C, int LDC, int strideC, int batch_count);
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, int strideA, const dcomplex *B,
-                          int LDB, int srideB, dcomplex beta, dcomplex *C, int LDC, int strideC, int batch_count);
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, int stride_a, const double *b, int ldb,
+                          int stride_b, double beta, double *c, int ldc, int stride_c, int batch_count);
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, int stride_a, const dcomplex *b,
+                          int ldb, int stride_b, dcomplex beta, dcomplex *c, int ldc, int stride_c, int batch_count);
 
-  void gemv(char op, int M, int N, double alpha, const double *A, int LDA, const double *x, int incx, double beta, double *Y, int incy);
-  void gemv(char op, int M, int N, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *x, int incx, dcomplex beta, dcomplex *Y, int incy);
+  void gemv(char op, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy);
+  void gemv(char op, int m, int n, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *x, int incx, dcomplex beta, dcomplex *y, int incy);
 
-  void ger(int M, int N, double alpha, const double *x, int incx, const double *Y, int incy, double *A, int LDA);
-  void ger(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA);
-  void gerc(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA);
+  void ger(int m, int n, double alpha, const double *x, int incx, const double *y, int incy, double *a, int lda);
+  void ger(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda);
+  void gerc(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda);
 
-  void scal(int M, double alpha, double *x, int incx);
-  void scal(int M, dcomplex alpha, dcomplex *x, int incx);
+  void scal(int m, double alpha, double *x, int incx);
+  void scal(int m, dcomplex alpha, dcomplex *x, int incx);
 
-  void swap(int N, double *x, int incx, double *Y, int incy);     // NOLINT (this is a BLAS swap)
-  void swap(int N, dcomplex *x, int incx, dcomplex *Y, int incy); // NOLINT (this is a BLAS swap)
+  void swap(int n, double *x, int incx, double *y, int incy);     // NOLINT (this is a BLAS swap)
+  void swap(int n, dcomplex *x, int incx, dcomplex *y, int incy); // NOLINT (this is a BLAS swap)
 
 } // namespace nda::blas::device

--- a/c++/nda/blas/interface/cxx_interface.cpp
+++ b/c++/nda/blas/interface/cxx_interface.cpp
@@ -61,133 +61,133 @@ namespace nda::blas::f77 {
   inline auto **blacplx(dcomplex **c) { return reinterpret_cast<double **>(c); }             // NOLINT
   inline auto **blacplx(dcomplex const **c) { return reinterpret_cast<const double **>(c); } // NOLINT
 
-  void axpy(int N, double alpha, const double *x, int incx, double *Y, int incy) { F77_daxpy(&N, &alpha, x, &incx, Y, &incy); }
-  void axpy(int N, dcomplex alpha, const dcomplex *x, int incx, dcomplex *Y, int incy) {
-    F77_zaxpy(&N, blacplx(&alpha), blacplx(x), &incx, blacplx(Y), &incy);
+  void axpy(int n, double alpha, const double *x, int incx, double *y, int incy) { F77_daxpy(&n, &alpha, x, &incx, y, &incy); }
+  void axpy(int n, dcomplex alpha, const dcomplex *x, int incx, dcomplex *y, int incy) {
+    F77_zaxpy(&n, blacplx(&alpha), blacplx(x), &incx, blacplx(y), &incy);
   }
 
   // No Const In Wrapping!
-  void copy(int N, const double *x, int incx, double *Y, int incy) { F77_dcopy(&N, x, &incx, Y, &incy); }
-  void copy(int N, const dcomplex *x, int incx, dcomplex *Y, int incy) { F77_zcopy(&N, blacplx(x), &incx, blacplx(Y), &incy); }
+  void copy(int n, const double *x, int incx, double *y, int incy) { F77_dcopy(&n, x, &incx, y, &incy); }
+  void copy(int n, const dcomplex *x, int incx, dcomplex *y, int incy) { F77_zcopy(&n, blacplx(x), &incx, blacplx(y), &incy); }
 
-  double dot(int M, const double *x, int incx, const double *Y, int incy) { return F77_ddot(&M, x, &incx, Y, &incy); }
-  dcomplex dot(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy) {
+  double dot(int m, const double *x, int incx, const double *y, int incy) { return F77_ddot(&m, x, &incx, y, &incy); }
+  dcomplex dot(int m, const dcomplex *x, int incx, const dcomplex *y, int incy) {
 #ifdef NDA_USE_MKL
     MKL_Complex16 result;
-    cblas_zdotu_sub(M, mklcplx(x), incx, mklcplx(Y), incy, &result);
+    cblas_zdotu_sub(m, mklcplx(x), incx, mklcplx(y), incy, &result);
 #else
-    auto result = F77_zdotu(&M, blacplx(x), &incx, blacplx(Y), &incy);
+    auto result = F77_zdotu(&m, blacplx(x), &incx, blacplx(y), &incy);
 #endif
     return dcomplex{result.real, result.imag};
   }
-  dcomplex dotc(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy) {
+  dcomplex dotc(int m, const dcomplex *x, int incx, const dcomplex *y, int incy) {
 #ifdef NDA_USE_MKL
     MKL_Complex16 result;
-    cblas_zdotc_sub(M, mklcplx(x), incx, mklcplx(Y), incy, &result);
+    cblas_zdotc_sub(m, mklcplx(x), incx, mklcplx(y), incy, &result);
 #else
-    auto result = F77_zdotc(&M, blacplx(x), &incx, blacplx(Y), &incy);
+    auto result = F77_zdotc(&m, blacplx(x), &incx, blacplx(y), &incy);
 #endif
     return dcomplex{result.real, result.imag};
   }
 
-  void gemm(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, const double *B, int LDB, double beta, double *C,
-            int LDC) {
-    F77_dgemm(&op_a, &op_b, &M, &N, &K, &alpha, A, &LDA, B, &LDB, &beta, C, &LDC);
+  void gemm(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta, double *c,
+            int ldc) {
+    F77_dgemm(&op_a, &op_b, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc);
   }
-  void gemm(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *B, int LDB, dcomplex beta,
-            dcomplex *C, int LDC) {
-    F77_zgemm(&op_a, &op_b, &M, &N, &K, blacplx(&alpha), blacplx(A), &LDA, blacplx(B), &LDB, blacplx(&beta), blacplx(C), &LDC);
+  void gemm(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *b, int ldb, dcomplex beta,
+            dcomplex *c, int ldc) {
+    F77_zgemm(&op_a, &op_b, &m, &n, &k, blacplx(&alpha), blacplx(a), &lda, blacplx(b), &ldb, blacplx(&beta), blacplx(c), &ldc);
   }
 
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, double alpha, const double **A, int LDA, const double **B, int LDB, double beta,
-                  double **C, int LDC, int batch_count) {
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, double alpha, const double **a, int lda, const double **b, int ldb, double beta,
+                  double **c, int ldc, int batch_count) {
 #ifdef NDA_USE_MKL
     const int group_count = 1;
-    dgemm_batch(&op_a, &op_b, &M, &N, &K, &alpha, A, &LDA, B, &LDB, &beta, C, &LDC, &group_count, &batch_count);
+    dgemm_batch(&op_a, &op_b, &m, &n, &k, &alpha, a, &lda, b, &ldb, &beta, c, &ldc, &group_count, &batch_count);
 #else // Fallback to loop
-    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, M, N, K, alpha, A[i], LDA, B[i], LDB, beta, C[i], LDC);
+    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, m, n, k, alpha, a[i], lda, b[i], ldb, beta, c[i], ldc);
 #endif
   }
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex **A, int LDA, const dcomplex **B, int LDB, dcomplex beta,
-                  dcomplex **C, int LDC, int batch_count) {
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex **a, int lda, const dcomplex **b, int ldb, dcomplex beta,
+                  dcomplex **c, int ldc, int batch_count) {
 #ifdef NDA_USE_MKL
     const int group_count = 1;
-    zgemm_batch(&op_a, &op_b, &M, &N, &K, mklcplx(&alpha), mklcplx(A), &LDA, mklcplx(B), &LDB, mklcplx(&beta), mklcplx(C), &LDC, &group_count,
+    zgemm_batch(&op_a, &op_b, &m, &n, &k, mklcplx(&alpha), mklcplx(a), &lda, mklcplx(b), &ldb, mklcplx(&beta), mklcplx(c), &ldc, &group_count,
                 &batch_count);
 #else
-    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, M, N, K, alpha, A[i], LDA, B[i], LDB, beta, C[i], LDC);
+    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, m, n, k, alpha, a[i], lda, b[i], ldb, beta, c[i], ldc);
 #endif
   }
 
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, double alpha, const double **A, int *LDA, const double **B, int *LDB, double beta,
-                   double **C, int *LDC, int batch_count) {
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, double alpha, const double **a, int *lda, const double **b, int *ldb, double beta,
+                   double **c, int *ldc, int batch_count) {
 #ifdef NDA_USE_MKL
     nda::vector<int> group_size(batch_count, 1);
     nda::vector<char> ops_a(batch_count, op_a), ops_b(batch_count, op_b);
     nda::vector<double> alphas(batch_count, alpha), betas(batch_count, beta);
-    dgemm_batch(ops_a.data(), ops_b.data(), M, N, K, alphas.data(), A, LDA, B, LDB, betas.data(), C, LDC, &batch_count, group_size.data());
+    dgemm_batch(ops_a.data(), ops_b.data(), m, n, k, alphas.data(), a, lda, b, ldb, betas.data(), c, ldc, &batch_count, group_size.data());
 #else
-    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, M[i], N[i], K[i], alpha, A[i], LDA[i], B[i], LDB[i], beta, C[i], LDC[i]);
+    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, m[i], n[i], k[i], alpha, a[i], lda[i], b[i], ldb[i], beta, c[i], ldc[i]);
 #endif
   }
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, dcomplex alpha, const dcomplex **A, int *LDA, const dcomplex **B, int *LDB,
-                   dcomplex beta, dcomplex **C, int *LDC, int batch_count) {
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, dcomplex alpha, const dcomplex **a, int *lda, const dcomplex **b, int *ldb,
+                   dcomplex beta, dcomplex **c, int *ldc, int batch_count) {
 #ifdef NDA_USE_MKL
     nda::vector<int> group_size(batch_count, 1);
     nda::vector<char> ops_a(batch_count, op_a), ops_b(batch_count, op_b);
     nda::vector<dcomplex> alphas(batch_count, alpha), betas(batch_count, beta);
-    zgemm_batch(ops_a.data(), ops_b.data(), M, N, K, mklcplx(alphas.data()), mklcplx(A), LDA, mklcplx(B), LDB, mklcplx(betas.data()), mklcplx(C), LDC,
+    zgemm_batch(ops_a.data(), ops_b.data(), m, n, k, mklcplx(alphas.data()), mklcplx(a), lda, mklcplx(b), ldb, mklcplx(betas.data()), mklcplx(c), ldc,
                 &batch_count, group_size.data());
 #else
-    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, M[i], N[i], K[i], alpha, A[i], LDA[i], B[i], LDB[i], beta, C[i], LDC[i]);
+    for (int i = 0; i < batch_count; ++i) gemm(op_a, op_b, m[i], n[i], k[i], alpha, a[i], lda[i], b[i], ldb[i], beta, c[i], ldc[i]);
 #endif
   }
 
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, int strideA, const double *B, int LDB,
-                          int strideB, double beta, double *C, int LDC, int strideC, int batch_count) {
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, int stride_a, const double *b, int ldb,
+                          int stride_b, double beta, double *c, int ldc, int stride_c, int batch_count) {
 #if defined(NDA_USE_MKL) && INTEL_MKL_VERSION >= 20200002
-    dgemm_batch_strided(&op_a, &op_b, &M, &N, &K, &alpha, A, &LDA, &strideA, B, &LDB, &strideB, &beta, C, &LDC, &strideC, &batch_count);
+    dgemm_batch_strided(&op_a, &op_b, &m, &n, &k, &alpha, a, &lda, &stride_a, b, &ldb, &stride_b, &beta, c, &ldc, &stride_c, &batch_count);
 #else
     for (int i = 0; i < batch_count; ++i)
-      gemm(op_a, op_b, M, N, K, alpha, A + static_cast<ptrdiff_t>(i * strideA), LDA, B + static_cast<ptrdiff_t>(i * strideB), LDB, beta,
-           C + static_cast<ptrdiff_t>(i * strideC), LDC);
+      gemm(op_a, op_b, m, n, k, alpha, a + static_cast<ptrdiff_t>(i * stride_a), lda, b + static_cast<ptrdiff_t>(i * stride_b), ldb, beta,
+           c + static_cast<ptrdiff_t>(i * stride_c), ldc);
 #endif
   }
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, int strideA, const dcomplex *B,
-                          int LDB, int strideB, dcomplex beta, dcomplex *C, int LDC, int strideC, int batch_count) {
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, int stride_a, const dcomplex *b,
+                          int ldb, int stride_b, dcomplex beta, dcomplex *c, int ldc, int stride_c, int batch_count) {
 #if defined(NDA_USE_MKL) && INTEL_MKL_VERSION >= 20200002
-    zgemm_batch_strided(&op_a, &op_b, &M, &N, &K, mklcplx(&alpha), mklcplx(A), &LDA, &strideA, mklcplx(B), &LDB, &strideB, mklcplx(&beta), mklcplx(C),
-                        &LDC, &strideC, &batch_count);
+    zgemm_batch_strided(&op_a, &op_b, &m, &n, &k, mklcplx(&alpha), mklcplx(a), &lda, &stride_a, mklcplx(b), &ldb, &stride_b, mklcplx(&beta), mklcplx(c),
+                        &ldc, &stride_c, &batch_count);
 #else
     for (int i = 0; i < batch_count; ++i)
-      gemm(op_a, op_b, M, N, K, alpha, A + static_cast<ptrdiff_t>(i * strideA), LDA, B + static_cast<ptrdiff_t>(i * strideB), LDB, beta,
-           C + static_cast<ptrdiff_t>(i * strideC), LDC);
+      gemm(op_a, op_b, m, n, k, alpha, a + static_cast<ptrdiff_t>(i * stride_a), lda, b + static_cast<ptrdiff_t>(i * stride_b), ldb, beta,
+           c + static_cast<ptrdiff_t>(i * stride_c), ldc);
 #endif
   }
 
-  void gemv(char op, int M, int N, double alpha, const double *A, int LDA, const double *x, int incx, double beta, double *Y, int incy) {
-    F77_dgemv(&op, &M, &N, &alpha, A, &LDA, x, &incx, &beta, Y, &incy);
+  void gemv(char op, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy) {
+    F77_dgemv(&op, &m, &n, &alpha, a, &lda, x, &incx, &beta, y, &incy);
   }
-  void gemv(char op, int M, int N, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *x, int incx, dcomplex beta, dcomplex *Y, int incy) {
-    F77_zgemv(&op, &M, &N, blacplx(&alpha), blacplx(A), &LDA, blacplx(x), &incx, blacplx(&beta), blacplx(Y), &incy);
-  }
-
-  void ger(int M, int N, double alpha, const double *x, int incx, const double *Y, int incy, double *A, int LDA) {
-    F77_dger(&M, &N, &alpha, x, &incx, Y, &incy, A, &LDA);
-  }
-  void ger(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA) {
-    F77_zgeru(&M, &N, blacplx(&alpha), blacplx(x), &incx, blacplx(Y), &incy, blacplx(A), &LDA);
-  }
-  void gerc(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA) {
-    F77_zgerc(&M, &N, blacplx(&alpha), blacplx(x), &incx, blacplx(Y), &incy, blacplx(A), &LDA);
+  void gemv(char op, int m, int n, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *x, int incx, dcomplex beta, dcomplex *y, int incy) {
+    F77_zgemv(&op, &m, &n, blacplx(&alpha), blacplx(a), &lda, blacplx(x), &incx, blacplx(&beta), blacplx(y), &incy);
   }
 
-  void scal(int M, double alpha, double *x, int incx) { F77_dscal(&M, &alpha, x, &incx); }
-  void scal(int M, dcomplex alpha, dcomplex *x, int incx) { F77_zscal(&M, blacplx(&alpha), blacplx(x), &incx); }
+  void ger(int m, int n, double alpha, const double *x, int incx, const double *y, int incy, double *a, int lda) {
+    F77_dger(&m, &n, &alpha, x, &incx, y, &incy, a, &lda);
+  }
+  void ger(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda) {
+    F77_zgeru(&m, &n, blacplx(&alpha), blacplx(x), &incx, blacplx(y), &incy, blacplx(a), &lda);
+  }
+  void gerc(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda) {
+    F77_zgerc(&m, &n, blacplx(&alpha), blacplx(x), &incx, blacplx(y), &incy, blacplx(a), &lda);
+  }
 
-  void swap(int N, double *x, int incx, double *Y, int incy) { F77_dswap(&N, x, &incx, Y, &incy); } // NOLINT (this is a BLAS swap)
-  void swap(int N, dcomplex *x, int incx, dcomplex *Y, int incy) {                                  // NOLINT (this is a BLAS swap)
-    F77_zswap(&N, blacplx(x), &incx, blacplx(Y), &incy);
+  void scal(int m, double alpha, double *x, int incx) { F77_dscal(&m, &alpha, x, &incx); }
+  void scal(int m, dcomplex alpha, dcomplex *x, int incx) { F77_zscal(&m, blacplx(&alpha), blacplx(x), &incx); }
+
+  void swap(int n, double *x, int incx, double *y, int incy) { F77_dswap(&n, x, &incx, y, &incy); } // NOLINT (this is a BLAS swap)
+  void swap(int n, dcomplex *x, int incx, dcomplex *y, int incy) {                                  // NOLINT (this is a BLAS swap)
+    F77_zswap(&n, blacplx(x), &incx, blacplx(y), &incy);
   }
 
 } // namespace nda::blas::f77

--- a/c++/nda/blas/interface/cxx_interface.hpp
+++ b/c++/nda/blas/interface/cxx_interface.hpp
@@ -18,47 +18,47 @@
 
 namespace nda::blas::f77 {
 
-  void axpy(int N, double alpha, const double *x, int incx, double *Y, int incy);
-  void axpy(int N, dcomplex alpha, const dcomplex *x, int incx, dcomplex *Y, int incy);
+  void axpy(int n, double alpha, const double *x, int incx, double *y, int incy);
+  void axpy(int n, dcomplex alpha, const dcomplex *x, int incx, dcomplex *y, int incy);
 
-  void copy(int N, const double *x, int incx, double *Y, int incy);
-  void copy(int N, const dcomplex *x, int incx, dcomplex *Y, int incy);
+  void copy(int n, const double *x, int incx, double *y, int incy);
+  void copy(int n, const dcomplex *x, int incx, dcomplex *y, int incy);
 
-  double dot(int M, const double *x, int incx, const double *Y, int incy);
-  dcomplex dot(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy);
-  dcomplex dotc(int M, const dcomplex *x, int incx, const dcomplex *Y, int incy);
+  double dot(int m, const double *x, int incx, const double *y, int incy);
+  dcomplex dot(int m, const dcomplex *x, int incx, const dcomplex *y, int incy);
+  dcomplex dotc(int m, const dcomplex *x, int incx, const dcomplex *y, int incy);
 
-  void gemm(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, const double *B, int LDB, double beta, double *C,
-            int LDC);
-  void gemm(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *B, int LDB, dcomplex beta,
-            dcomplex *C, int LDC);
+  void gemm(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, const double *b, int ldb, double beta, double *c,
+            int ldc);
+  void gemm(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *b, int ldb, dcomplex beta,
+            dcomplex *c, int ldc);
 
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, double alpha, const double **A, int LDA, const double **B, int LDB, double beta,
-                  double **C, int LDC, int batch_count);
-  void gemm_batch(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex **A, int LDA, const dcomplex **B, int LDB, dcomplex beta,
-                  dcomplex **C, int LDC, int batch_count);
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, double alpha, const double **a, int lda, const double **b, int ldb, double beta,
+                  double **c, int ldc, int batch_count);
+  void gemm_batch(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex **a, int lda, const dcomplex **b, int ldb, dcomplex beta,
+                  dcomplex **c, int ldc, int batch_count);
 
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, double alpha, const double **A, int *LDA, const double **B, int *LDB, double beta,
-                   double **C, int *LDC, int batch_count);
-  void gemm_vbatch(char op_a, char op_b, int *M, int *N, int *K, dcomplex alpha, const dcomplex **A, int *LDA, const dcomplex **B, int *LDB,
-                   dcomplex beta, dcomplex **C, int *LDC, int batch_count);
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, double alpha, const double **a, int *lda, const double **b, int *ldb, double beta,
+                   double **c, int *ldc, int batch_count);
+  void gemm_vbatch(char op_a, char op_b, int *m, int *n, int *k, dcomplex alpha, const dcomplex **a, int *lda, const dcomplex **b, int *ldb,
+                   dcomplex beta, dcomplex **c, int *ldc, int batch_count);
 
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, double alpha, const double *A, int LDA, int strideA, const double *B, int LDB,
-                          int strideB, double beta, double *C, int LDC, int strideC, int batch_count);
-  void gemm_batch_strided(char op_a, char op_b, int M, int N, int K, dcomplex alpha, const dcomplex *A, int LDA, int strideA, const dcomplex *B,
-                          int LDB, int srideB, dcomplex beta, dcomplex *C, int LDC, int strideC, int batch_count);
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, double alpha, const double *a, int lda, int stride_a, const double *b, int ldb,
+                          int stride_b, double beta, double *c, int ldc, int stride_c, int batch_count);
+  void gemm_batch_strided(char op_a, char op_b, int m, int n, int k, dcomplex alpha, const dcomplex *a, int lda, int stride_a, const dcomplex *b,
+                          int ldb, int stride_b, dcomplex beta, dcomplex *c, int ldc, int stride_c, int batch_count);
 
-  void gemv(char op, int M, int N, double alpha, const double *A, int LDA, const double *x, int incx, double beta, double *Y, int incy);
-  void gemv(char op, int M, int N, dcomplex alpha, const dcomplex *A, int LDA, const dcomplex *x, int incx, dcomplex beta, dcomplex *Y, int incy);
+  void gemv(char op, int m, int n, double alpha, const double *a, int lda, const double *x, int incx, double beta, double *y, int incy);
+  void gemv(char op, int m, int n, dcomplex alpha, const dcomplex *a, int lda, const dcomplex *x, int incx, dcomplex beta, dcomplex *y, int incy);
 
-  void ger(int M, int N, double alpha, const double *x, int incx, const double *Y, int incy, double *A, int LDA);
-  void ger(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA);
-  void gerc(int M, int N, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *Y, int incy, dcomplex *A, int LDA);
+  void ger(int m, int n, double alpha, const double *x, int incx, const double *y, int incy, double *a, int lda);
+  void ger(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda);
+  void gerc(int m, int n, dcomplex alpha, const dcomplex *x, int incx, const dcomplex *y, int incy, dcomplex *a, int lda);
 
-  void scal(int M, double alpha, double *x, int incx);
-  void scal(int M, dcomplex alpha, dcomplex *x, int incx);
+  void scal(int m, double alpha, double *x, int incx);
+  void scal(int m, dcomplex alpha, dcomplex *x, int incx);
 
-  void swap(int N, double *x, int incx, double *Y, int incy);     // NOLINT (this is a BLAS swap)
-  void swap(int N, dcomplex *x, int incx, dcomplex *Y, int incy); // NOLINT (this is a BLAS swap)
+  void swap(int n, double *x, int incx, double *y, int incy);     // NOLINT (this is a BLAS swap)
+  void swap(int n, dcomplex *x, int incx, dcomplex *y, int incy); // NOLINT (this is a BLAS swap)
 
 } // namespace nda::blas::f77

--- a/c++/nda/lapack.hpp
+++ b/c++/nda/lapack.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "./lapack/interface/cxx_interface.hpp"
+#include "./lapack/geev.hpp"
 #include "./lapack/gelss.hpp"
 #include "./lapack/geqp3.hpp"
 #include "./lapack/gesvd.hpp"

--- a/c++/nda/lapack/geev.hpp
+++ b/c++/nda/lapack/geev.hpp
@@ -1,0 +1,200 @@
+// Copyright (c) 2024--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
+/**
+ * @file
+ * @brief Provides a generic interface to the LAPACK `geev` routine.
+ */
+
+#pragma once
+
+#include "./interface/cxx_interface.hpp"
+#include "../basic_array.hpp"
+#include "../basic_functions.hpp"
+#include "../concepts.hpp"
+#include "../declarations.hpp"
+#include "../macros.hpp"
+#include "../mem/address_space.hpp"
+#include "../traits.hpp"
+
+#include <cmath>
+#include <complex>
+#include <concepts>
+
+namespace nda::lapack {
+
+  /**
+   * @ingroup linalg_lapack
+   * @brief Interface to the LAPACK `geev` routine for real matrices.
+   *
+   * @details Computes for an \f$ n \times n \f$ real nonsymmetric matrix \f$ \mathbf{A} \f$, the eigenvalues and,
+   * optionally, the left and/or right eigenvectors.
+   *
+   * The right eigenvector \f$ \mathbf{v}_j \f$ of \f$ \mathbf{A} \f$ satisfies
+   * \f[
+   *   \mathbf{A} \mathbf{v}_j = \lambda_j \mathbf{v}_j
+   * \f]
+   * where \f$ \lambda_j \f$ is its eigenvalue.
+   *
+   * The left eigenvector \f$ \mathbf{u}_j \f$ of \f$ \mathbf{A} \f$ satisfies
+   * \f[
+   *   \mathbf{u}_j^T \mathbf{A} = \lambda_j \mathbf{u}_j^T
+   * \f]
+   * where \f$ \mathbf{u}_j^T \f$ denotes the conjugate-transpose of \f$ \mathbf{u}_j \f$.
+   *
+   * The computed eigenvectors are normalized to have Euclidean norm equal to 1 and largest component real.
+   *
+   * @note For real matrices, complex eigenvalues always occur in complex conjugate pairs and the corresponding 
+   * eigenvectors are stored in a special packed format (see nda::linalg::get_geev_eigenvectors).
+   *
+   * @tparam A nda::MemoryMatrix with double value type.
+   * @tparam WR nda::MemoryVector with double value type.
+   * @tparam WI nda::MemoryVector with double value type.
+   * @tparam VL nda::MemoryMatrix with double value type.
+   * @tparam VR nda::MemoryMatrix with double value type.
+   * @param a Input/output matrix. On entry, the matrix \f$ \mathbf{A} \f$. On exit, \f$ \mathbf{A} \f$ is overwritten.
+   * @param wr Output vector. The real parts of the computed eigenvalues.
+   * @param wi Output vector. The imaginary parts of the computed eigenvalues.
+   * @param vl Output matrix. If `jobvl = V`, the left eigenvectors (in packed format for complex pairs). If 
+   * `jobvl = N`, `vl` is not referenced.
+   * @param vr Output matrix. If `jobvr = V`, the right eigenvectors (in packed format for complex pairs). If
+   * `jobvr = N`, `vr` is not referenced.
+   * @param jobvl Character indicating whether to compute left eigenvectors ('V') or not ('N').
+   * @param jobvr Character indicating whether to compute right eigenvectors ('V') or not ('N').
+   * @return Integer return code from the LAPACK call.
+   */
+  template <MemoryMatrix A, MemoryVector WR, MemoryVector WI, MemoryMatrix VL, MemoryMatrix VR>
+    requires(mem::have_host_compatible_addr_space<A, WR, WI, VL, VR> and std::same_as<double, get_value_t<A>>
+             and have_same_value_type_v<A, WR, WI, VL, VR>)
+  int geev(A &&a, WR &&wr, WI &&wi, VL &&vl, VR &&vr, char jobvl = 'N', char jobvr = 'V') { // NOLINT (temporary views are allowed here)
+    static_assert(has_F_layout<A>, "Error in nda::lapack::geev: A must have Fortran layout");
+    static_assert(has_F_layout<VL>, "Error in nda::lapack::geev: VL must have Fortran layout");
+    static_assert(has_F_layout<VR>, "Error in nda::lapack::geev: VR must have Fortran layout");
+
+    // check the dimensions of the input/output arrays/views
+    auto const [m, n] = a.shape();
+    EXPECTS(m == n);
+    resize_or_check_if_view(wr, {n});
+    resize_or_check_if_view(wi, {n});
+
+    // check parameters
+    EXPECTS(jobvl == 'V' or jobvl == 'N');
+    EXPECTS(jobvr == 'V' or jobvr == 'N');
+
+    // resize eigenvector matrices if needed
+    int ldvl = 1;
+    int ldvr = 1;
+    if (jobvl == 'V') {
+      resize_or_check_if_view(vl, {n, n});
+      ldvl = get_ld(vl);
+    }
+    if (jobvr == 'V') {
+      resize_or_check_if_view(vr, {n, n});
+      ldvr = get_ld(vr);
+    }
+
+    // arrays/views must be LAPACK compatible
+    EXPECTS(a.indexmap().min_stride() == 1);
+    EXPECTS(wr.indexmap().min_stride() == 1);
+    EXPECTS(wi.indexmap().min_stride() == 1);
+    EXPECTS(jobvl == 'N' or vl.indexmap().min_stride() == 1);
+    EXPECTS(jobvr == 'N' or vr.indexmap().min_stride() == 1);
+
+    // first call to get the optimal buffer size
+    double tmp_lwork{};
+    int info = 0;
+    lapack::f77::geev(jobvl, jobvr, n, a.data(), get_ld(a), wr.data(), wi.data(), vl.data(), ldvl, vr.data(), ldvr, &tmp_lwork, -1, info);
+    int lwork = static_cast<int>(std::ceil(tmp_lwork));
+
+    // allocate work buffer and perform actual library call
+    array<double, 1> work(lwork);
+    lapack::f77::geev(jobvl, jobvr, n, a.data(), get_ld(a), wr.data(), wi.data(), vl.data(), ldvl, vr.data(), ldvr, work.data(), lwork, info);
+
+    return info;
+  }
+
+  /**
+   * @ingroup linalg_lapack
+   * @brief Interface to the LAPACK `geev` routine for complex matrices.
+   *
+   * @details Computes for an \f$ n \times n \f$ complex nonsymmetric matrix \f$ \mathbf{A} \f$, the eigenvalues and,
+   * optionally, the left and/or right eigenvectors.
+   *
+   * The right eigenvector \f$ \mathbf{v}_j \f$ of \f$ \mathbf{A} \f$ satisfies
+   * \f[
+   *   \mathbf{A} \mathbf{v}_j = \lambda_j \mathbf{v}_j
+   * \f]
+   * where \f$ \lambda_j \f$ is its eigenvalue.
+   *
+   * The left eigenvector \f$ \mathbf{u}_j \f$ of \f$ \mathbf{A} \f$ satisfies
+   * \f[
+   *   \mathbf{u}_j^H \mathbf{A} = \lambda_j \mathbf{u}_j^H
+   * \f]
+   * where \f$ \mathbf{u}_j^H \f$ denotes the conjugate-transpose of \f$ \mathbf{u}_j \f$.
+   *
+   * The computed eigenvectors are normalized to have Euclidean norm equal to 1 and largest component real.
+   *
+   * @tparam A nda::MemoryMatrix with complex value type.
+   * @tparam W nda::MemoryVector with complex value type.
+   * @tparam VL nda::MemoryMatrix with complex value type.
+   * @tparam VR nda::MemoryMatrix with complex value type.
+   * @param a Input/output matrix. On entry, the matrix \f$ \mathbf{A} \f$. On exit, \f$ \mathbf{A} \f$ is overwritten.
+   * @param w Output vector. The computed eigenvalues.
+   * @param vl Output matrix. If `jobvl = V`, the left eigenvectors. If `jobvl = N`, `vl` is not referenced.
+   * @param vr Output matrix. If `jobvr = V`, the right eigenvectors. If `jobvl = N`, `vl` is not referenced.
+   * @param jobvl Character indicating whether to compute left eigenvectors ('V') or not ('N').
+   * @param jobvr Character indicating whether to compute right eigenvectors ('V') or not ('N').
+   * @return Integer return code from the LAPACK call.
+   */
+  template <MemoryMatrix A, MemoryVector W, MemoryMatrix VL, MemoryMatrix VR>
+    requires(mem::have_host_compatible_addr_space<A, W, VL, VR> and std::same_as<std::complex<double>, get_value_t<A>>
+             and have_same_value_type_v<A, W, VL, VR>)
+  int geev(A &&a, W &&w, VL &&vl, VR &&vr, char jobvl = 'N', char jobvr = 'V') { // NOLINT (temporary views are allowed here)
+    static_assert(has_F_layout<A>, "Error in nda::lapack::geev: A must have Fortran layout");
+    static_assert(has_F_layout<VL>, "Error in nda::lapack::geev: VL must have Fortran layout");
+    static_assert(has_F_layout<VR>, "Error in nda::lapack::geev: VR must have Fortran layout");
+
+    // check the dimensions of the input/output arrays/views
+    auto const [m, n] = a.shape();
+    EXPECTS(m == n);
+    resize_or_check_if_view(w, {n});
+
+    // check parameters
+    EXPECTS(jobvl == 'V' or jobvl == 'N');
+    EXPECTS(jobvr == 'V' or jobvr == 'N');
+
+    // resize eigenvector matrices if needed
+    int ldvl = 1;
+    int ldvr = 1;
+    if (jobvl == 'V') {
+      resize_or_check_if_view(vl, {n, n});
+      ldvl = get_ld(vl);
+    }
+    if (jobvr == 'V') {
+      resize_or_check_if_view(vr, {n, n});
+      ldvr = get_ld(vr);
+    }
+
+    // arrays/views must be LAPACK compatible
+    EXPECTS(a.indexmap().min_stride() == 1);
+    EXPECTS(w.indexmap().min_stride() == 1);
+    EXPECTS(jobvl == 'N' or vl.indexmap().min_stride() == 1);
+    EXPECTS(jobvr == 'N' or vr.indexmap().min_stride() == 1);
+
+    // first call to get the optimal buffer size
+    array<double, 1> rwork(2 * n);
+    std::complex<double> tmp_lwork{};
+    int info = 0;
+    lapack::f77::geev(jobvl, jobvr, n, a.data(), get_ld(a), w.data(), vl.data(), ldvl, vr.data(), ldvr, &tmp_lwork, -1, rwork.data(), info);
+    int lwork = static_cast<int>(std::ceil(std::real(tmp_lwork)));
+
+    // allocate work buffer and perform actual library call
+    array<std::complex<double>, 1> work(lwork);
+    lapack::f77::geev(jobvl, jobvr, n, a.data(), get_ld(a), w.data(), vl.data(), ldvl, vr.data(), ldvr, work.data(), lwork, rwork.data(), info);
+
+    return info;
+  }
+
+} // namespace nda::lapack

--- a/c++/nda/lapack/interface/cusolver_interface.cpp
+++ b/c++/nda/lapack/interface/cusolver_interface.cpp
@@ -58,48 +58,48 @@ namespace nda::lapack::device {
   }                                                                                                                                                  \
   info = *get_info_ptr();
 
-  void gesvd(char JOBU, char JOBVT, int M, int N, double *A, int LDA, double *S, double *U, int LDU, double *VT, int LDVT, double *WORK, int LWORK,
-             double *RWORK, int &INFO) {
+  void gesvd(char jobu, char jobvt, int m, int n, double *a, int lda, double *s, double *u, int ldu, double *vt, int ldvt, double *work, int lwork,
+             double *rwork, int &info) {
     // Replicate behavior of Netlib gesvd
-    if (LWORK == -1) {
+    if (lwork == -1) {
       int bufferSize = 0;
-      cusolverDnDgesvd_bufferSize(get_handle(), M, N, &bufferSize);
-      *WORK = bufferSize;
+      cusolverDnDgesvd_bufferSize(get_handle(), m, n, &bufferSize);
+      *work = bufferSize;
     } else {
-      CUSOLVER_CHECK(cusolverDnDgesvd, INFO, JOBU, JOBVT, M, N, A, LDA, S, U, LDU, VT, LDVT, WORK, LWORK, RWORK);
+      CUSOLVER_CHECK(cusolverDnDgesvd, info, jobu, jobvt, m, n, a, lda, s, u, ldu, vt, ldvt, work, lwork, rwork);
     }
   }
-  void gesvd(char JOBU, char JOBVT, int M, int N, dcomplex *A, int LDA, double *S, dcomplex *U, int LDU, dcomplex *VT, int LDVT, dcomplex *WORK,
-             int LWORK, double *RWORK, int &INFO) {
+  void gesvd(char jobu, char jobvt, int m, int n, dcomplex *a, int lda, double *s, dcomplex *u, int ldu, dcomplex *vt, int ldvt, dcomplex *work,
+             int lwork, double *rwork, int &info) {
     // Replicate behavior of Netlib gesvd
-    if (LWORK == -1) {
+    if (lwork == -1) {
       int bufferSize = 0;
-      cusolverDnZgesvd_bufferSize(get_handle(), M, N, &bufferSize);
-      *WORK = bufferSize;
+      cusolverDnZgesvd_bufferSize(get_handle(), m, n, &bufferSize);
+      *work = bufferSize;
     } else {
-      CUSOLVER_CHECK(cusolverDnZgesvd, INFO, JOBU, JOBVT, M, N, cucplx(A), LDA, S, cucplx(U), LDU, cucplx(VT), LDVT, cucplx(WORK), LWORK,
-                     RWORK); // NOLINT
+      CUSOLVER_CHECK(cusolverDnZgesvd, info, jobu, jobvt, m, n, cucplx(a), lda, s, cucplx(u), ldu, cucplx(vt), ldvt, cucplx(work), lwork,
+                     rwork); // NOLINT
     }
   }
 
-  void getrf(int M, int N, double *A, int LDA, int *ipiv, int &info) {
+  void getrf(int m, int n, double *a, int lda, int *ipiv, int &info) {
     int bufferSize = 0;
-    cusolverDnDgetrf_bufferSize(get_handle(), M, N, A, LDA, &bufferSize);
+    cusolverDnDgetrf_bufferSize(get_handle(), m, n, a, lda, &bufferSize);
     auto Workspace = nda::cuvector<double>(bufferSize);
-    CUSOLVER_CHECK(cusolverDnDgetrf, info, M, N, A, LDA, Workspace.data(), ipiv);
+    CUSOLVER_CHECK(cusolverDnDgetrf, info, m, n, a, lda, Workspace.data(), ipiv);
   }
-  void getrf(int M, int N, dcomplex *A, int LDA, int *ipiv, int &info) {
+  void getrf(int m, int n, dcomplex *a, int lda, int *ipiv, int &info) {
     int bufferSize = 0;
-    cusolverDnZgetrf_bufferSize(get_handle(), M, N, cucplx(A), LDA, &bufferSize);
+    cusolverDnZgetrf_bufferSize(get_handle(), m, n, cucplx(a), lda, &bufferSize);
     auto Workspace = nda::cuvector<dcomplex>(bufferSize);
-    CUSOLVER_CHECK(cusolverDnZgetrf, info, M, N, cucplx(A), LDA, cucplx(Workspace.data()), ipiv);
+    CUSOLVER_CHECK(cusolverDnZgetrf, info, m, n, cucplx(a), lda, cucplx(Workspace.data()), ipiv);
   }
 
-  void getrs(char op, int N, int NRHS, double const *A, int LDA, int const *ipiv, double *B, int LDB, int &info) {
-    CUSOLVER_CHECK(cusolverDnDgetrs, info, get_cublas_op(op), N, NRHS, A, LDA, ipiv, B, LDB);
+  void getrs(char op, int n, int nrhs, double const *a, int lda, int const *ipiv, double *b, int ldb, int &info) {
+    CUSOLVER_CHECK(cusolverDnDgetrs, info, get_cublas_op(op), n, nrhs, a, lda, ipiv, b, ldb);
   }
-  void getrs(char op, int N, int NRHS, dcomplex const *A, int LDA, int const *ipiv, dcomplex *B, int LDB, int &info) {
-    CUSOLVER_CHECK(cusolverDnZgetrs, info, get_cublas_op(op), N, NRHS, cucplx(A), LDA, ipiv, cucplx(B), LDB);
+  void getrs(char op, int n, int nrhs, dcomplex const *a, int lda, int const *ipiv, dcomplex *b, int ldb, int &info) {
+    CUSOLVER_CHECK(cusolverDnZgetrs, info, get_cublas_op(op), n, nrhs, cucplx(a), lda, ipiv, cucplx(b), ldb);
   }
 
 } // namespace nda::lapack::device

--- a/c++/nda/lapack/interface/cusolver_interface.hpp
+++ b/c++/nda/lapack/interface/cusolver_interface.hpp
@@ -18,15 +18,15 @@
 
 namespace nda::lapack::device {
 
-  void gesvd(char JOBU, char JOBVT, int M, int N, double *A, int LDA, double *S, double *U, int LDU, double *VT, int LDVT, double *WORK, int LWORK,
-             double *RWORK, int &INFO);
-  void gesvd(char JOBU, char JOBVT, int M, int N, dcomplex *A, int LDA, double *S, dcomplex *U, int LDU, dcomplex *VT, int LDVT, dcomplex *WORK,
-             int LWORK, double *RWORK, int &INFO);
+  void gesvd(char jobu, char jobvt, int m, int n, double *a, int lda, double *s, double *u, int ldu, double *vt, int ldvt, double *work, int lwork,
+             double *rwork, int &info);
+  void gesvd(char jobu, char jobvt, int m, int n, dcomplex *a, int lda, double *s, dcomplex *u, int ldu, dcomplex *vt, int ldvt, dcomplex *work,
+             int lwork, double *rwork, int &info);
 
-  void getrf(int M, int N, double *A, int LDA, int *ipiv, int &info);
-  void getrf(int M, int N, dcomplex *A, int LDA, int *ipiv, int &info);
+  void getrf(int m, int n, double *a, int lda, int *ipiv, int &info);
+  void getrf(int m, int n, dcomplex *a, int lda, int *ipiv, int &info);
 
-  void getrs(char op, int N, int NRHS, double const *A, int LDA, int const *ipiv, double *B, int LDB, int &info);
-  void getrs(char op, int N, int NRHS, dcomplex const *A, int LDA, int const *ipiv, dcomplex *B, int LDB, int &info);
+  void getrs(char op, int n, int nrhs, double const *a, int lda, int const *ipiv, double *b, int ldb, int &info);
+  void getrs(char op, int n, int nrhs, dcomplex const *a, int lda, int const *ipiv, dcomplex *b, int ldb, int &info);
 
 } // namespace nda::lapack::device

--- a/c++/nda/lapack/interface/cxx_interface.cpp
+++ b/c++/nda/lapack/interface/cxx_interface.cpp
@@ -94,4 +94,13 @@ namespace nda::lapack::f77 {
     LAPACK_zgetrs(&op, &N, &NRHS, A, &LDA, ipiv, B, &LDB, &info);
   }
 
+  void geev(char JOBVL, char JOBVR, int N, double *A, int LDA, double *WR, double *WI, double *VL, int LDVL, double *VR, int LDVR, double *work,
+            int lwork, int &info) {
+    LAPACK_dgeev(&JOBVL, &JOBVR, &N, A, &LDA, WR, WI, VL, &LDVL, VR, &LDVR, work, &lwork, &info);
+  }
+  void geev(char JOBVL, char JOBVR, int N, std::complex<double> *A, int LDA, std::complex<double> *W, std::complex<double> *VL, int LDVL,
+            std::complex<double> *VR, int LDVR, std::complex<double> *work, int lwork, double *rwork, int &info) {
+    LAPACK_zgeev(&JOBVL, &JOBVR, &N, A, &LDA, W, VL, &LDVL, VR, &LDVR, work, &lwork, rwork, &info);
+  }
+
 } // namespace nda::lapack::f77

--- a/c++/nda/lapack/interface/cxx_interface.cpp
+++ b/c++/nda/lapack/interface/cxx_interface.cpp
@@ -16,91 +16,91 @@
 
 namespace nda::lapack::f77 {
 
-  void gelss(int M, int N, int NRHS, double *A, int LDA, double *B, int LDB, double *S, double RCOND, int &RANK, double *WORK, int LWORK,
-             [[maybe_unused]] double *RWORK, int &INFO) {
-    LAPACK_dgelss(&M, &N, &NRHS, A, &LDA, B, &LDB, S, &RCOND, &RANK, WORK, &LWORK, &INFO);
+  void gelss(int m, int n, int nrhs, double *a, int lda, double *b, int ldb, double *s, double rcond, int &rank, double *work, int lwork,
+             [[maybe_unused]] double *rwork, int &info) {
+    LAPACK_dgelss(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, &rank, work, &lwork, &info);
   }
-  void gelss(int M, int N, int NRHS, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB, double *S, double RCOND, int &RANK,
-             std::complex<double> *WORK, int LWORK, double *RWORK, int &INFO) {
-    LAPACK_zgelss(&M, &N, &NRHS, A, &LDA, B, &LDB, S, &RCOND, &RANK, WORK, &LWORK, RWORK, &INFO);
-  }
-
-  void gesvd(char JOBU, char JOBVT, int M, int N, double *A, int LDA, double *S, double *U, int LDU, double *VT, int LDVT, double *WORK, int LWORK,
-             [[maybe_unused]] double *RWORK, int &INFO) {
-    LAPACK_dgesvd(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU, VT, &LDVT, WORK, &LWORK, &INFO);
-  }
-  void gesvd(char JOBU, char JOBVT, int M, int N, std::complex<double> *A, int LDA, double *S, std::complex<double> *U, int LDU,
-             std::complex<double> *VT, int LDVT, std::complex<double> *WORK, int LWORK, double *RWORK, int &INFO) {
-    LAPACK_zgesvd(&JOBU, &JOBVT, &M, &N, A, &LDA, S, U, &LDU, VT, &LDVT, WORK, &LWORK, RWORK, &INFO);
+  void gelss(int m, int n, int nrhs, std::complex<double> *a, int lda, std::complex<double> *b, int ldb, double *s, double rcond, int &rank,
+             std::complex<double> *work, int lwork, double *rwork, int &info) {
+    LAPACK_zgelss(&m, &n, &nrhs, a, &lda, b, &ldb, s, &rcond, &rank, work, &lwork, rwork, &info);
   }
 
-  void geqp3(int M, int N, double *A, int LDA, int *JPVT, double *TAU, double *WORK, int LWORK, [[maybe_unused]] double *RWORK, int &INFO) {
-    LAPACK_dgeqp3(&M, &N, A, &LDA, JPVT, TAU, WORK, &LWORK, &INFO);
+  void gesvd(char jobu, char jobvt, int m, int n, double *a, int lda, double *s, double *u, int ldu, double *vt, int ldvt, double *work, int lwork,
+             [[maybe_unused]] double *rwork, int &info) {
+    LAPACK_dgesvd(&jobu, &jobvt, &m, &n, a, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, &info);
   }
-  void geqp3(int M, int N, std::complex<double> *A, int LDA, int *JPVT, std::complex<double> *TAU, std::complex<double> *WORK, int LWORK,
-             double *RWORK, int &INFO) {
-    LAPACK_zgeqp3(&M, &N, A, &LDA, JPVT, TAU, WORK, &LWORK, RWORK, &INFO);
-  }
-
-  void orgqr(int M, int N, int K, double *A, int LDA, double const *TAU, double *WORK, int LWORK, int &INFO) {
-    LAPACK_dorgqr(&M, &N, &K, A, &LDA, TAU, WORK, &LWORK, &INFO);
+  void gesvd(char jobu, char jobvt, int m, int n, std::complex<double> *a, int lda, double *s, std::complex<double> *u, int ldu,
+             std::complex<double> *vt, int ldvt, std::complex<double> *work, int lwork, double *rwork, int &info) {
+    LAPACK_zgesvd(&jobu, &jobvt, &m, &n, a, &lda, s, u, &ldu, vt, &ldvt, work, &lwork, rwork, &info);
   }
 
-  void ungqr(int M, int N, int K, std::complex<double> *A, int LDA, std::complex<double> const *TAU, std::complex<double> *WORK, int LWORK,
-             int &INFO) {
-    LAPACK_zungqr(&M, &N, &K, A, &LDA, TAU, WORK, &LWORK, &INFO);
+  void geqp3(int m, int n, double *a, int lda, int *jpvt, double *tau, double *work, int lwork, [[maybe_unused]] double *rwork, int &info) {
+    LAPACK_dgeqp3(&m, &n, a, &lda, jpvt, tau, work, &lwork, &info);
+  }
+  void geqp3(int m, int n, std::complex<double> *a, int lda, int *jpvt, std::complex<double> *tau, std::complex<double> *work, int lwork,
+             double *rwork, int &info) {
+    LAPACK_zgeqp3(&m, &n, a, &lda, jpvt, tau, work, &lwork, rwork, &info);
   }
 
-  void getrf(int M, int N, double *A, int LDA, int *ipiv, int &info) { LAPACK_dgetrf(&M, &N, A, &LDA, ipiv, &info); }
-  void getrf(int M, int N, std::complex<double> *A, int LDA, int *ipiv, int &info) { LAPACK_zgetrf(&M, &N, A, &LDA, ipiv, &info); }
-
-  void getri(int N, double *A, int LDA, int const *ipiv, double *work, int lwork, int &info) {
-    LAPACK_dgetri(&N, A, &LDA, ipiv, work, &lwork, &info);
-  }
-  void getri(int N, std::complex<double> *A, int LDA, int const *ipiv, std::complex<double> *work, int lwork, int &info) {
-    LAPACK_zgetri(&N, A, &LDA, ipiv, work, &lwork, &info);
+  void orgqr(int m, int n, int k, double *a, int lda, double const *tau, double *work, int lwork, int &info) {
+    LAPACK_dorgqr(&m, &n, &k, a, &lda, tau, work, &lwork, &info);
   }
 
-  void gtsv(int N, int NRHS, double *DL, double *D, double *DU, double *B, int LDB, int &info) { LAPACK_dgtsv(&N, &NRHS, DL, D, DU, B, &LDB, &info); }
-  void gtsv(int N, int NRHS, std::complex<double> *DL, std::complex<double> *D, std::complex<double> *DU, std::complex<double> *B, int LDB,
+  void ungqr(int m, int n, int k, std::complex<double> *a, int lda, std::complex<double> const *tau, std::complex<double> *work, int lwork,
+             int &info) {
+    LAPACK_zungqr(&m, &n, &k, a, &lda, tau, work, &lwork, &info);
+  }
+
+  void getrf(int m, int n, double *a, int lda, int *ipiv, int &info) { LAPACK_dgetrf(&m, &n, a, &lda, ipiv, &info); }
+  void getrf(int m, int n, std::complex<double> *a, int lda, int *ipiv, int &info) { LAPACK_zgetrf(&m, &n, a, &lda, ipiv, &info); }
+
+  void getri(int n, double *a, int lda, int const *ipiv, double *work, int lwork, int &info) {
+    LAPACK_dgetri(&n, a, &lda, ipiv, work, &lwork, &info);
+  }
+  void getri(int n, std::complex<double> *a, int lda, int const *ipiv, std::complex<double> *work, int lwork, int &info) {
+    LAPACK_zgetri(&n, a, &lda, ipiv, work, &lwork, &info);
+  }
+
+  void gtsv(int n, int nrhs, double *dl, double *d, double *du, double *b, int ldb, int &info) { LAPACK_dgtsv(&n, &nrhs, dl, d, du, b, &ldb, &info); }
+  void gtsv(int n, int nrhs, std::complex<double> *dl, std::complex<double> *d, std::complex<double> *du, std::complex<double> *b, int ldb,
             int &info) {
-    LAPACK_zgtsv(&N, &NRHS, DL, D, DU, B, &LDB, &info);
+    LAPACK_zgtsv(&n, &nrhs, dl, d, du, b, &ldb, &info);
   }
 
-  void stev(char J, int N, double *D, double *E, double *Z, int ldz, double *work, int &info) { LAPACK_dstev(&J, &N, D, E, Z, &ldz, work, &info); }
+  void stev(char j, int n, double *d, double *e, double *z, int ldz, double *work, int &info) { LAPACK_dstev(&j, &n, d, e, z, &ldz, work, &info); }
 
-  void syev(char JOBZ, char UPLO, int N, double *A, int LDA, double *W, double *work, int lwork, int &info) {
-    LAPACK_dsyev(&JOBZ, &UPLO, &N, A, &LDA, W, work, &lwork, &info);
+  void syev(char jobz, char uplo, int n, double *a, int lda, double *w, double *work, int lwork, int &info) {
+    LAPACK_dsyev(&jobz, &uplo, &n, a, &lda, w, work, &lwork, &info);
   }
 
-  void heev(char JOBZ, char UPLO, int N, std::complex<double> *A, int LDA, double *W, std::complex<double> *work, int lwork, double *rwork,
+  void heev(char jobz, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork, double *rwork,
             int &info) {
-    LAPACK_zheev(&JOBZ, &UPLO, &N, A, &LDA, W, work, &lwork, rwork, &info);
+    LAPACK_zheev(&jobz, &uplo, &n, a, &lda, w, work, &lwork, rwork, &info);
   }
 
-  void sygv(int ITYPE, char JOBZ, char UPLO, int N, double *A, int LDA, double *B, int LDB, double *W, double *work, int lwork, int &info) {
-    LAPACK_dsygv(&ITYPE, &JOBZ, &UPLO, &N, A, &LDA, B, &LDB, W, work, &lwork, &info);
+  void sygv(int itype, char jobz, char uplo, int n, double *a, int lda, double *b, int ldb, double *w, double *work, int lwork, int &info) {
+    LAPACK_dsygv(&itype, &jobz, &uplo, &n, a, &lda, b, &ldb, w, work, &lwork, &info);
   }
 
-  void hegv(int ITYPE, char JOBZ, char UPLO, int N, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB, double *W,
+  void hegv(int itype, char jobz, char uplo, int n, std::complex<double> *a, int lda, std::complex<double> *b, int ldb, double *w,
             std::complex<double> *work, int lwork, double *rwork, int &info) {
-    LAPACK_zhegv(&ITYPE, &JOBZ, &UPLO, &N, A, &LDA, B, &LDB, W, work, &lwork, rwork, &info);
+    LAPACK_zhegv(&itype, &jobz, &uplo, &n, a, &lda, b, &ldb, w, work, &lwork, rwork, &info);
   }
 
-  void getrs(char op, int N, int NRHS, double const *A, int LDA, int const *ipiv, double *B, int LDB, int &info) {
-    LAPACK_dgetrs(&op, &N, &NRHS, A, &LDA, ipiv, B, &LDB, &info);
+  void getrs(char op, int n, int nrhs, double const *a, int lda, int const *ipiv, double *b, int ldb, int &info) {
+    LAPACK_dgetrs(&op, &n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
   }
-  void getrs(char op, int N, int NRHS, std::complex<double> const *A, int LDA, int const *ipiv, std::complex<double> *B, int LDB, int &info) {
-    LAPACK_zgetrs(&op, &N, &NRHS, A, &LDA, ipiv, B, &LDB, &info);
+  void getrs(char op, int n, int nrhs, std::complex<double> const *a, int lda, int const *ipiv, std::complex<double> *b, int ldb, int &info) {
+    LAPACK_zgetrs(&op, &n, &nrhs, a, &lda, ipiv, b, &ldb, &info);
   }
 
-  void geev(char JOBVL, char JOBVR, int N, double *A, int LDA, double *WR, double *WI, double *VL, int LDVL, double *VR, int LDVR, double *work,
+  void geev(char jobvl, char jobvr, int n, double *a, int lda, double *wr, double *wi, double *vl, int ldvl, double *vr, int ldvr, double *work,
             int lwork, int &info) {
-    LAPACK_dgeev(&JOBVL, &JOBVR, &N, A, &LDA, WR, WI, VL, &LDVL, VR, &LDVR, work, &lwork, &info);
+    LAPACK_dgeev(&jobvl, &jobvr, &n, a, &lda, wr, wi, vl, &ldvl, vr, &ldvr, work, &lwork, &info);
   }
-  void geev(char JOBVL, char JOBVR, int N, std::complex<double> *A, int LDA, std::complex<double> *W, std::complex<double> *VL, int LDVL,
-            std::complex<double> *VR, int LDVR, std::complex<double> *work, int lwork, double *rwork, int &info) {
-    LAPACK_zgeev(&JOBVL, &JOBVR, &N, A, &LDA, W, VL, &LDVL, VR, &LDVR, work, &lwork, rwork, &info);
+  void geev(char jobvl, char jobvr, int n, std::complex<double> *a, int lda, std::complex<double> *w, std::complex<double> *vl, int ldvl,
+            std::complex<double> *vr, int ldvr, std::complex<double> *work, int lwork, double *rwork, int &info) {
+    LAPACK_zgeev(&jobvl, &jobvr, &n, a, &lda, w, vl, &ldvl, vr, &ldvr, work, &lwork, rwork, &info);
   }
 
 } // namespace nda::lapack::f77

--- a/c++/nda/lapack/interface/cxx_interface.hpp
+++ b/c++/nda/lapack/interface/cxx_interface.hpp
@@ -20,54 +20,54 @@
 
 namespace nda::lapack::f77 {
 
-  void gelss(int M, int N, int NRHS, double *A, int LDA, double *B, int LDB, double *S, double RCOND, int &RANK, double *WORK, int LWORK,
-             double *RWORK, int &INFO);
-  void gelss(int M, int N, int NRHS, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB, double *S, double RCOND, int &RANK,
-             std::complex<double> *WORK, int LWORK, double *RWORK, int &INFO);
+  void gelss(int m, int n, int nrhs, double *a, int lda, double *b, int ldb, double *s, double rcond, int &rank, double *work, int lwork,
+             double *rwork, int &info);
+  void gelss(int m, int n, int nrhs, std::complex<double> *a, int lda, std::complex<double> *b, int ldb, double *s, double rcond, int &rank,
+             std::complex<double> *work, int lwork, double *rwork, int &info);
 
-  void gesvd(char JOBU, char JOBVT, int M, int N, double *A, int LDA, double *S, double *U, int LDU, double *VT, int LDVT, double *WORK, int LWORK,
-             double *RWORK, int &INFO);
-  void gesvd(char JOBU, char JOBVT, int M, int N, std::complex<double> *A, int LDA, double *S, std::complex<double> *U, int LDU,
-             std::complex<double> *VT, int LDVT, std::complex<double> *WORK, int LWORK, double *RWORK, int &INFO);
+  void gesvd(char jobu, char jobvt, int m, int n, double *a, int lda, double *s, double *u, int ldu, double *vt, int ldvt, double *work, int lwork,
+             double *rwork, int &info);
+  void gesvd(char jobu, char jobvt, int m, int n, std::complex<double> *a, int lda, double *s, std::complex<double> *u, int ldu,
+             std::complex<double> *vt, int ldvt, std::complex<double> *work, int lwork, double *rwork, int &info);
 
-  void geqp3(int M, int N, double *A, int LDA, int *JPVT, double *TAU, double *WORK, int LWORK, double *RWORK, int &INFO);
-  void geqp3(int M, int N, std::complex<double> *A, int LDA, int *JPVT, std::complex<double> *TAU, std::complex<double> *WORK, int LWORK,
-             double *RWORK, int &INFO);
+  void geqp3(int m, int n, double *a, int lda, int *jpvt, double *tau, double *work, int lwork, double *rwork, int &info);
+  void geqp3(int m, int n, std::complex<double> *a, int lda, int *jpvt, std::complex<double> *tau, std::complex<double> *work, int lwork,
+             double *rwork, int &info);
 
-  void orgqr(int M, int N, int K, double *A, int LDA, double const *TAU, double *WORK, int LWORK, int &INFO);
+  void orgqr(int m, int n, int k, double *a, int lda, double const *tau, double *work, int lwork, int &info);
 
-  void ungqr(int M, int N, int K, std::complex<double> *A, int LDA, std::complex<double> const *TAU, std::complex<double> *WORK, int LWORK,
-             int &INFO);
+  void ungqr(int m, int n, int k, std::complex<double> *a, int lda, std::complex<double> const *tau, std::complex<double> *work, int lwork,
+             int &info);
 
-  void getrf(int M, int N, double *A, int LDA, int *ipiv, int &info);
-  void getrf(int M, int N, std::complex<double> *A, int LDA, int *ipiv, int &info);
+  void getrf(int m, int n, double *a, int lda, int *ipiv, int &info);
+  void getrf(int m, int n, std::complex<double> *a, int lda, int *ipiv, int &info);
 
-  void getri(int N, double *A, int LDA, int const *ipiv, double *work, int lwork, int &info);
-  void getri(int N, std::complex<double> *A, int LDA, int const *ipiv, std::complex<double> *work, int lwork, int &info);
+  void getri(int n, double *a, int lda, int const *ipiv, double *work, int lwork, int &info);
+  void getri(int n, std::complex<double> *a, int lda, int const *ipiv, std::complex<double> *work, int lwork, int &info);
 
-  void gtsv(int N, int NRHS, double *DL, double *D, double *DU, double *B, int LDB, int &info);
-  void gtsv(int N, int NRHS, std::complex<double> *DL, std::complex<double> *D, std::complex<double> *DU, std::complex<double> *B, int LDB,
+  void gtsv(int n, int nrhs, double *dl, double *d, double *du, double *b, int ldb, int &info);
+  void gtsv(int n, int nrhs, std::complex<double> *dl, std::complex<double> *d, std::complex<double> *du, std::complex<double> *b, int ldb,
             int &info);
 
-  void stev(char J, int N, double *D, double *E, double *Z, int ldz, double *work, int &info);
+  void stev(char j, int n, double *d, double *e, double *z, int ldz, double *work, int &info);
 
-  void syev(char JOBZ, char UPLO, int N, double *A, int LDA, double *W, double *work, int lwork, int &info);
+  void syev(char jobz, char uplo, int n, double *a, int lda, double *w, double *work, int lwork, int &info);
 
-  void heev(char JOBZ, char UPLO, int N, std::complex<double> *A, int LDA, double *W, std::complex<double> *work, int lwork, double *rwork,
+  void heev(char jobz, char uplo, int n, std::complex<double> *a, int lda, double *w, std::complex<double> *work, int lwork, double *rwork,
             int &info);
 
-  void sygv(int ITYPE, char JOBZ, char UPLO, int N, double *A, int LDA, double *B, int LDB, double *W, double *work, int lwork, int &info);
+  void sygv(int itype, char jobz, char uplo, int n, double *a, int lda, double *b, int ldb, double *w, double *work, int lwork, int &info);
 
-  void hegv(int ITYPE, char JOBZ, char UPLO, int N, std::complex<double> *A, int LDA, std::complex<double> *B, int LDB, double *W,
+  void hegv(int itype, char jobz, char uplo, int n, std::complex<double> *a, int lda, std::complex<double> *b, int ldb, double *w,
             std::complex<double> *work, int lwork, double *rwork, int &info);
 
-  void getrs(char op, int N, int NRHS, double const *A, int LDA, int const *ipiv, double *B, int LDB, int &info);
-  void getrs(char op, int N, int NRHS, std::complex<double> const *A, int LDA, int const *ipiv, std::complex<double> *B, int LDB, int &info);
+  void getrs(char op, int n, int nrhs, double const *a, int lda, int const *ipiv, double *b, int ldb, int &info);
+  void getrs(char op, int n, int nrhs, std::complex<double> const *a, int lda, int const *ipiv, std::complex<double> *b, int ldb, int &info);
 
-  void geev(char JOBVL, char JOBVR, int N, double *A, int LDA, double *WR, double *WI, double *VL, int LDVL, double *VR, int LDVR, double *work,
+  void geev(char jobvl, char jobvr, int n, double *a, int lda, double *wr, double *wi, double *vl, int ldvl, double *vr, int ldvr, double *work,
             int lwork, int &info);
-  void geev(char JOBVL, char JOBVR, int N, std::complex<double> *A, int LDA, std::complex<double> *W, std::complex<double> *VL, int LDVL,
-            std::complex<double> *VR, int LDVR, std::complex<double> *work, int lwork, double *rwork, int &info);
+  void geev(char jobvl, char jobvr, int n, std::complex<double> *a, int lda, std::complex<double> *w, std::complex<double> *vl, int ldvl,
+            std::complex<double> *vr, int ldvr, std::complex<double> *work, int lwork, double *rwork, int &info);
 
 } // namespace nda::lapack::f77
 

--- a/c++/nda/lapack/interface/cxx_interface.hpp
+++ b/c++/nda/lapack/interface/cxx_interface.hpp
@@ -64,6 +64,11 @@ namespace nda::lapack::f77 {
   void getrs(char op, int N, int NRHS, double const *A, int LDA, int const *ipiv, double *B, int LDB, int &info);
   void getrs(char op, int N, int NRHS, std::complex<double> const *A, int LDA, int const *ipiv, std::complex<double> *B, int LDB, int &info);
 
+  void geev(char JOBVL, char JOBVR, int N, double *A, int LDA, double *WR, double *WI, double *VL, int LDVL, double *VR, int LDVR, double *work,
+            int lwork, int &info);
+  void geev(char JOBVL, char JOBVR, int N, std::complex<double> *A, int LDA, std::complex<double> *W, std::complex<double> *VL, int LDVL,
+            std::complex<double> *VR, int LDVR, std::complex<double> *work, int lwork, double *rwork, int &info);
+
 } // namespace nda::lapack::f77
 
 // Useful routines from the BLAS interface

--- a/c++/nda/linalg.hpp
+++ b/c++/nda/linalg.hpp
@@ -16,6 +16,7 @@
 #include "./linalg/cross_product.hpp"
 #include "./linalg/det.hpp"
 #include "./linalg/dot.hpp"
+#include "./linalg/eig.hpp"
 #include "./linalg/eigh.hpp"
 #include "./linalg/inv.hpp"
 #include "./linalg/lu.hpp"

--- a/c++/nda/linalg/eig.hpp
+++ b/c++/nda/linalg/eig.hpp
@@ -1,0 +1,272 @@
+// Copyright (c) 2024--present, The Simons Foundation
+// This file is part of TRIQS/nda and is licensed under the Apache License, Version 2.0.
+// SPDX-License-Identifier: Apache-2.0
+// See LICENSE in the root of this distribution for details.
+
+/**
+ * @file
+ * @brief Provides functions to solve eigenvalue problems for general (non-symmetric) matrices.
+ */
+
+#pragma once
+
+#include "./utils.hpp"
+#include "../basic_array.hpp"
+#include "../blas/tools.hpp"
+#include "../concepts.hpp"
+#include "../declarations.hpp"
+#include "../exceptions.hpp"
+#include "../lapack/geev.hpp"
+#include "../layout/policies.hpp"
+#include "../macros.hpp"
+#include "../matrix_functions.hpp"
+#include "../mem/address_space.hpp"
+#include "../traits.hpp"
+
+#include <array>
+#include <cmath>
+#include <complex>
+#include <concepts>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+
+namespace nda::linalg {
+
+  /**
+   * @addtogroup linalg_tools
+   * @{
+   */
+
+  /**
+   * @brief Get the complex eigenvalues from nda::lapack::geev output for real matrices.
+   *
+   * @details For real matrices, nda::lapack::geev stores the computed eigenvalues in two real vectors, \f$
+   * \mathbf{w}^{(r)} \f$ and \f$ \mathbf{w}^{(i)} \f$.
+   *
+   * The actual (complex) eigenvalues \f$ \lambda_j \f$ are given by \f$ \lambda_j = w^{(r)}_j + i w^{(i)}_j \f$.
+   *
+   * Use nda::linalg::get_geev_eigenvectors to get eigenvectors.
+   *
+   * @tparam WR nda::Vector with double value type.
+   * @tparam WI nda::Vector with double value type.
+   * @param wr The real parts of the computed eigenvalues.
+   * @param wi The imaginary parts of the computed eigenvalues.
+   * @return An nda::array containing the complex eigenvalues.
+   */
+  template <Vector WR, Vector WI>
+    requires(mem::have_host_compatible_addr_space<WR, WI> and std::same_as<double, get_value_t<WR>> and have_same_value_type_v<WR, WI>)
+  auto get_geev_eigenvalues(const WR &wr, const WI &wi) {
+    // check the dimensions of the input arrays/views
+    auto const n = wr.size();
+    EXPECTS(n == wi.size());
+
+    // generate eigenvalues
+    auto lambda = array<std::complex<double>, 1>(n);
+    for (long i = 0; i < n; ++i) lambda(i) = std::complex<double>(wr(i), wi(i));
+    return lambda;
+  }
+
+  /**
+   * @brief Get the complex left/right eigenvectors from nda::lapack::geev output for real matrices.
+   *
+   * @details For real matrices, nda::lapack::geev stores the computed complex eigenvalues in two real vectors, \f$
+   * \mathbf{w}^{(r)} \f$ and \f$ \mathbf{w}^{(i)} \f$, and the left/right eigenvectors in packed format in the columns
+   * \f$ \mathbf{v}^{(l)}_j \f$/\f$ \mathbf{v}^{(r)}_j \f$ of a real matrix.
+   *
+   * The complex eigenvalues \f$ \lambda_j \f$ are given by \f$ \lambda_j = w^{(r)}_j + i w^{(i)}_j \f$.
+   *
+   * The left/right eigenvectors \f$ \mathbf{x}_j \f$ are unpacked as follows:
+   * - If the eigenvalue \f$ \lambda_j \f$ is real, i.e. if \f$ w^{(i)}_j = 0 \f$, then the corresponding left/right
+   * eigenvector is given by \f$ \mathbf{x}_j = \mathbf{v}^{(\alpha)}_j \f$.
+   * - If the eigenvalues \f$ \lambda_j \f$ and \f$ \lambda_{j + 1} \f$ form a complex conjugate pair, i.e. if \f$
+   * w^{(i)}_j > 0 \f$, then the two corresponding left/right eigenvectors are given by \f$ \mathbf{x}_j =
+   * \mathbf{v}^{(\alpha)}_j + i \mathbf{v}^{(\alpha)}_{j+1} \f$ and \f$ \mathbf{x}_{j+1} = \mathbf{v}^{(\alpha)}_j - i
+   * \mathbf{v}^{(\alpha)}_{j+1} \f$.
+   *
+   * Use nda::linalg::get_geev_eigenvalues to get eigenvalues.
+   *
+   * @tparam WI nda::Vector with double value type.
+   * @tparam VA nda::Matrix with double value type.
+   * @param wi The imaginary parts of the computed eigenvalues.
+   * @param va The left/right eigenvectors in packed format.
+   * @return An nda::matrix containing the complex left/right eigenvectors.
+   */
+  template <Vector WI, Matrix VA>
+    requires(mem::have_host_compatible_addr_space<WI, VA> and std::same_as<double, get_value_t<WI>> and have_same_value_type_v<WI, VA>)
+  auto get_geev_eigenvectors(const WI &wi, const VA &va) {
+    using namespace std::complex_literals;
+    static_assert(nda::blas::has_F_layout<VA>, "Error in nda::linalg::get_geev_eigenvectors: VA must have Fortran layout");
+
+    // check the dimensions of the input arrays/views
+    auto const n = wi.size();
+    EXPECTS(va.shape() == (std::array<long, 2>{n, n}));
+
+    // unpack eigenvectors
+    auto X = matrix<std::complex<double>, F_layout>(n, n);
+    long j = 0;
+    while (j < n) {
+      if (wi(j) > 0.0) {
+        // complex conjugate eigenvalue pair --> we need to unpack the eigenvectors
+        for (long i = 0; i < n; ++i) {
+          X(i, j)     = std::complex<double>{va(i, j), va(i, j + 1)};
+          X(i, j + 1) = std::complex<double>{va(i, j), -va(i, j + 1)};
+        }
+        j += 2;
+      } else {
+        // real eigenvalue --> eigenvector is purely real
+        X(nda::range::all, j) = va(nda::range::all, j);
+        ++j;
+      }
+    }
+
+    return X;
+  }
+
+  namespace detail {
+
+    // Implementation for complex matrices - straightforward call to geev.
+    template <MemoryMatrix A>
+      requires(is_complex_v<get_value_t<A>>)
+    auto eig_impl(A &&a, char jobvl, char jobvr) { // NOLINT (temporary views are allowed here)
+      using arr_t  = array<get_value_t<A>, 1>;
+      using mat_t  = matrix<get_value_t<A>, F_layout>;
+      auto const n = a.extent(0);
+
+      // early return if the matrix is empty
+      if (a.empty()) return std::make_tuple(arr_t{}, mat_t{}, mat_t{});
+
+      // allocate outputs
+      auto lambda = arr_t(n);
+      auto U      = mat_t(jobvl == 'V' ? n : 0, jobvl == 'V' ? n : 0);
+      auto V      = mat_t(jobvr == 'V' ? n : 0, jobvr == 'V' ? n : 0);
+
+      // make the call to geev
+      int info = nda::lapack::geev(a, lambda, U, V, jobvl, jobvr);
+      if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::linalg::detail::eig_impl: geev routine failed: info = " << info;
+
+      return std::make_tuple(std::move(lambda), std::move(U), std::move(V));
+    }
+
+    // Implementation for real matrices.
+    template <MemoryMatrix A>
+      requires(std::same_as<double, get_value_t<A>>)
+    auto eig_impl(A &&a, char jobvl, char jobvr) { // NOLINT (temporary views are allowed here)
+      using arr_t  = array<std::complex<double>, 1>;
+      using mat_t  = matrix<std::complex<double>, F_layout>;
+      auto const n = a.extent(0);
+
+      // early return if the matrix is empty
+      if (a.empty()) return std::make_tuple(arr_t{}, mat_t{}, mat_t{});
+
+      // allocate outputs
+      auto wr = array<double, 1>(n);
+      auto wi = array<double, 1>(n);
+      auto vl = matrix<double, F_layout>(jobvl == 'V' ? n : 0, jobvl == 'V' ? n : 0);
+      auto vr = matrix<double, F_layout>(jobvr == 'V' ? n : 0, jobvr == 'V' ? n : 0);
+
+      // make the call to geev
+      int info = nda::lapack::geev(a, wr, wi, vl, vr, jobvl, jobvr);
+      if (info != 0) NDA_RUNTIME_ERROR << "Error in nda::linalg::detail::eig_impl: geev routine failed: info = " << info;
+
+      // get eigenvalues and eigenvectors from geev output
+      auto lambda = get_geev_eigenvalues(wr, wi);
+      auto U      = (jobvl == 'V') ? get_geev_eigenvectors(wi, vl) : mat_t{};
+      auto V      = (jobvr == 'V') ? get_geev_eigenvectors(wi, vr) : mat_t{};
+
+      return std::make_tuple(std::move(lambda), std::move(U), std::move(V));
+    }
+
+  } // namespace detail
+
+  /**
+   * @brief Compute the eigenvalues and right eigenvectors of a general matrix.
+   *
+   * @details It computes the right eigenvectors \f$ \mathbf{v}_j \f$ and eigenvalues \f$ \lambda_j \f$ of the matrix
+   * \f$ \mathbf{A} \f$ such that
+   * \f[
+   *  \mathbf{A} \mathbf{v}_j = \lambda_j \mathbf{v}_j \; .
+   * \f]
+   *
+   * It calls nda::lapack::geev and, for real matrices, retrieves the complex eigenvalues and eigenvectors using
+   * nda::linalg::get_geev_eigenvalues and nda::linalg::get_geev_eigenvectors.
+   *
+   * It throws an exception if the LAPACK call fails.
+   *
+   * @note The given matrix/view must have Fortran layout and is modified during the computation.
+   *
+   * @tparam A nda::MemoryMatrix type.
+   * @param a Input/output matrix. On entry, the matrix \f$ \mathbf{A} \f$. On exit, it is overwritten.
+   * @return `std::pair` containing an nda::array with the complex eigenvalues \f$ \lambda_j \f$ and a nda::matrix with
+   * the complex right eigenvectors \f$ \mathbf{v}_j \f$ as columns.
+   */
+  template <MemoryMatrix A>
+    requires(nda::mem::have_host_compatible_addr_space<A> and is_blas_lapack_v<get_value_t<A>> and nda::blas::has_F_layout<A>)
+  auto eig_in_place(A &&a) {
+    auto [lambda, U, V] = detail::eig_impl(std::forward<A>(a), 'N', 'V');
+    return std::make_pair(std::move(lambda), std::move(V));
+  }
+
+  /**
+   * @brief Compute the eigenvalues of a general matrix.
+   *
+   * @details It computes the eigenvalues \f$ \lambda_j \f$ of the matrix \f$ \mathbf{A} \f$, where
+   * \f[
+   *   \mathbf{A} \mathbf{v}_j = \lambda_j \mathbf{v}_j \; .
+   * \f]
+   *
+   * It calls nda::lapack::geev and, for real matrices, retrieves the complex eigenvalues using
+   * nda::linalg::get_geev_eigenvalues.
+   *
+   * It throws an exception if the LAPACK call fails.
+   *
+   * @note The given matrix/view must have Fortran layout and is modified during the computation.
+   *
+   * @tparam A nda::MemoryMatrix type.
+   * @param a Input/output matrix. On entry, the matrix \f$ \mathbf{A} \f$. On exit, it is overwritten.
+   * @return An nda::array with the complex eigenvalues \f$ \lambda_j \f$.
+   */
+  template <MemoryMatrix A>
+    requires(nda::mem::have_host_compatible_addr_space<A> and is_blas_lapack_v<get_value_t<A>> and nda::blas::has_F_layout<A>)
+  auto eigvals_in_place(A &&a) {
+    auto [lambda, U, V] = detail::eig_impl(std::forward<A>(a), 'N', 'N');
+    return lambda;
+  }
+
+  /**
+   * @brief Compute the eigenvalues and right eigenvectors of a general matrix.
+   *
+   * @details Same as nda::linalg::eig_in_place but makes a copy of the input matrix, leaving the original unchanged.
+   *
+   * @tparam A nda::Matrix type.
+   * @param a Input matrix. The matrix \f$ \mathbf{A} \f$.
+   * @return `std::pair` containing an nda::array with the complex eigenvalues \f$ \lambda_j \f$ and an nda::matrix with
+   * the complex right eigenvectors \f$ \mathbf{v}_j \f$ as columns.
+   */
+  template <MemoryMatrix A>
+    requires(nda::mem::have_host_compatible_addr_space<A> and is_blas_lapack_v<get_value_t<A>>)
+  auto eig(A const &a) {
+    auto m_copy = matrix<get_value_t<A>, F_layout>(a);
+    return eig_in_place(m_copy);
+  }
+
+  /**
+   * @brief Compute the eigenvalues of a general matrix.
+   *
+   * @details Same as nda::linalg::eigvals_in_place but makes a copy of the input matrix, leaving the original
+   * unchanged.
+   *
+   * @tparam A nda::Matrix type.
+   * @param a Input matrix. The matrix \f$ \mathbf{A} \f$.
+   * @return An nda::array with the complex eigenvalues \f$ \lambda_j \f$.
+   */
+  template <MemoryMatrix A>
+    requires(nda::mem::have_host_compatible_addr_space<A> and is_blas_lapack_v<get_value_t<A>>)
+  auto eigvals(A const &a) {
+    auto m_copy = matrix<get_value_t<A>, F_layout>(a);
+    return eigvals_in_place(m_copy);
+  }
+
+  /** @} */
+
+} // namespace nda::linalg

--- a/test/c++/nda_lapack.cpp
+++ b/test/c++/nda_lapack.cpp
@@ -14,6 +14,7 @@
 #include <numbers>
 #include <tuple>
 #include <type_traits>
+#include <vector>
 
 using namespace nda;
 using namespace std::complex_literals;
@@ -303,19 +304,21 @@ TEST(NDA, LAPACKGetrfWithRectangularMatrix) {
 }
 
 // Check that the eigenvectors/values are correct.
-void check_eigen(auto const &A, auto const &V, auto const &l) {
-  for (auto i : nda::range(0, A.extent(0))) { EXPECT_ARRAY_NEAR(A * V(nda::range::all, i), l(i) * V(nda::range::all, i)); }
+void check_eigen(auto const &A, auto const &V, auto const &l, bool is_left = false) {
+  if (not is_left) {
+    EXPECT_ARRAY_NEAR(A * V, V * nda::diag(l));
+  } else {
+    EXPECT_ARRAY_NEAR(nda::dagger(V) * A, nda::diag(l) * nda::dagger(V));
+  }
 }
 
 void check_eigen(auto const &A, auto const &B, auto const &V, auto const &l, int itype = 1) {
-  for (auto i : nda::range(0, A.extent(0))) {
-    if (itype == 1) {
-      EXPECT_ARRAY_NEAR(A * V(nda::range::all, i), l(i) * B * V(nda::range::all, i));
-    } else if (itype == 2) {
-      EXPECT_ARRAY_NEAR(A * B * V(nda::range::all, i), l(i) * V(nda::range::all, i));
-    } else {
-      EXPECT_ARRAY_NEAR(B * A * V(nda::range::all, i), l(i) * V(nda::range::all, i));
-    }
+  if (itype == 1) {
+    EXPECT_ARRAY_NEAR(A * V, B * V * nda::diag(l));
+  } else if (itype == 2) {
+    EXPECT_ARRAY_NEAR(A * B * V, V * nda::diag(l));
+  } else {
+    EXPECT_ARRAY_NEAR(B * A * V, V * nda::diag(l));
   }
 }
 
@@ -430,4 +433,102 @@ TEST(NDA, LAPACKSygvAndHegv) {
   test_sygv_hegv<std::complex<double>>(1, hegv);
   test_sygv_hegv<std::complex<double>>(2, hegv);
   test_sygv_hegv<std::complex<double>>(3, hegv);
+}
+
+// Test LAPACK geev function for real matrices.
+template <typename T>
+void test_geev_real() {
+  for (auto n : nda::range(1, 6)) {
+    auto A = nda::matrix<T, nda::F_layout>::rand(n, n);
+
+    // compute eigenvalues and eigenvectors
+    auto A1  = nda::matrix<T, nda::F_layout>{A};
+    auto wr  = nda::vector<T>(n);
+    auto wi  = nda::vector<T>(n);
+    auto vl  = nda::matrix<T, nda::F_layout>(n, n);
+    auto vr  = nda::matrix<T, nda::F_layout>(n, n);
+    int info = lapack::geev(A1, wr, wi, vl, vr, 'V', 'V');
+    EXPECT_EQ(info, 0);
+
+    // convert to complex eigenvalues and eigenvectors and check eigenvector equation
+    auto lambda = nda::linalg::get_geev_eigenvalues(wr, wi);
+    auto V      = nda::linalg::get_geev_eigenvectors(wi, vr);
+    auto U_H    = nda::linalg::get_geev_eigenvectors(wi, vl);
+    auto Acpx   = nda::matrix<std::complex<double>, nda::F_layout>{A};
+    check_eigen(Acpx, V, lambda);
+    check_eigen(Acpx, U_H, lambda, true);
+
+    // compute eigenvalues only
+    auto A2  = nda::matrix<T, nda::F_layout>{A};
+    auto wr2 = nda::vector<T>(n);
+    auto wi2 = nda::vector<T>(n);
+    auto vl2 = nda::matrix<T, nda::F_layout>{};
+    auto vr2 = nda::matrix<T, nda::F_layout>{};
+    info     = lapack::geev(A2, wr2, wi2, vl2, vr2, 'N', 'N');
+    EXPECT_EQ(info, 0);
+    EXPECT_ARRAY_NEAR(wr2, wr);
+    EXPECT_ARRAY_NEAR(wi2, wi);
+
+    // compute eigenvalues and eigenvectors of a view
+    if (n > 3) {
+      auto A3  = nda::matrix<T, nda::F_layout>{A};
+      auto rg  = nda::range(3);
+      auto wr3 = nda::vector<T>(3);
+      auto wi3 = nda::vector<T>(3);
+      auto vl3 = nda::matrix<T, nda::F_layout>(3, 3);
+      auto vr3 = nda::matrix<T, nda::F_layout>(3, 3);
+      info     = lapack::geev(A3(rg, rg), wr3, wi3, vl3, vr3, 'N', 'V');
+      EXPECT_EQ(info, 0);
+      auto lambda3 = nda::linalg::get_geev_eigenvalues(wr3, wi3);
+      auto V3      = nda::linalg::get_geev_eigenvectors(wi3, vr3);
+      auto Asub    = nda::matrix<std::complex<double>, nda::F_layout>{A(rg, rg)};
+      check_eigen(Asub, V3, lambda3);
+    }
+  }
+}
+
+// Test LAPACK geev function for complex matrices.
+template <typename T>
+void test_geev_complex() {
+  for (auto n : nda::range(1, 6)) {
+    auto A = nda::matrix<T, nda::F_layout>::rand(n, n);
+
+    // compute eigenvalues and eigenvectors
+    auto A1     = nda::matrix<T, nda::F_layout>{A};
+    auto lambda = nda::vector<T>(n);
+    auto U_H    = nda::matrix<T, nda::F_layout>(n, n);
+    auto V      = nda::matrix<T, nda::F_layout>(n, n);
+    int info    = lapack::geev(A1, lambda, U_H, V, 'V', 'V');
+    EXPECT_EQ(info, 0);
+
+    // check eigenvector equation
+    check_eigen(A, V, lambda);
+    check_eigen(A, U_H, lambda, true);
+
+    // compute eigenvalues only
+    auto A2  = nda::matrix<T, nda::F_layout>{A};
+    auto w2  = nda::vector<T>(n);
+    auto vl2 = nda::matrix<T, nda::F_layout>{};
+    auto vr2 = nda::matrix<T, nda::F_layout>{};
+    info     = lapack::geev(A2, w2, vl2, vr2, 'N', 'N');
+    EXPECT_EQ(info, 0);
+    EXPECT_ARRAY_NEAR(w2, lambda);
+
+    // compute eigenvalues and eigenvectors of a view
+    if (n > 3) {
+      auto A3      = nda::matrix<T, nda::F_layout>{A};
+      auto rg      = nda::range(3);
+      auto lambda3 = nda::vector<T>(3);
+      auto U_H3    = nda::matrix<T, nda::F_layout>(3, 3);
+      auto V_3     = nda::matrix<T, nda::F_layout>(3, 3);
+      info         = lapack::geev(A3(rg, rg), lambda3, U_H3, V_3, 'N', 'V');
+      EXPECT_EQ(info, 0);
+      check_eigen(A(rg, rg), V_3, lambda3);
+    }
+  }
+}
+
+TEST(NDA, LAPACKGeev) {
+  test_geev_real<double>();
+  test_geev_complex<std::complex<double>>();
 }

--- a/test/c++/nda_linear_algebra.cpp
+++ b/test/c++/nda_linear_algebra.cpp
@@ -289,19 +289,21 @@ TEST(NDA, LinearAlgebraInvAndDet) {
 }
 
 // Check that the eigenvectors/values are correct.
-void check_eigen(auto const &A, auto const &V, auto const &l) {
-  for (auto i : nda::range(0, A.extent(0))) { EXPECT_ARRAY_NEAR(A * V(nda::range::all, i), l(i) * V(nda::range::all, i)); }
+void check_eigen(auto const &A, auto const &V, auto const &l, bool is_left = false) {
+  if (not is_left) {
+    EXPECT_ARRAY_NEAR(A * V, V * nda::diag(l));
+  } else {
+    EXPECT_ARRAY_NEAR(nda::dagger(V) * A, nda::diag(l) * nda::dagger(V));
+  }
 }
 
 void check_eigen(auto const &A, auto const &B, auto const &V, auto const &l, int itype = 1) {
-  for (auto i : nda::range(0, A.extent(0))) {
-    if (itype == 1) {
-      EXPECT_ARRAY_NEAR(A * V(nda::range::all, i), l(i) * B * V(nda::range::all, i));
-    } else if (itype == 2) {
-      EXPECT_ARRAY_NEAR(A * B * V(nda::range::all, i), l(i) * V(nda::range::all, i));
-    } else {
-      EXPECT_ARRAY_NEAR(B * A * V(nda::range::all, i), l(i) * V(nda::range::all, i));
-    }
+  if (itype == 1) {
+    EXPECT_ARRAY_NEAR(A * V, B * V * nda::diag(l));
+  } else if (itype == 2) {
+    EXPECT_ARRAY_NEAR(A * B * V, V * nda::diag(l));
+  } else {
+    EXPECT_ARRAY_NEAR(B * A * V, V * nda::diag(l));
   }
 }
 
@@ -422,6 +424,80 @@ TEST(NDA, LinearAlgebraGeneralizedEighAndEigvalsh) {
   test_generalized_eigh_eigvalsh<std::complex<double>>(1);
   test_generalized_eigh_eigvalsh<std::complex<double>>(2);
   test_generalized_eigh_eigvalsh<std::complex<double>>(3);
+}
+
+// Helper to compare complex eigenvalues (they may be in different order).
+void expect_eigenvalues_near(auto const &lambda1, auto const &lambda2) {
+  ASSERT_EQ(lambda1.size(), lambda2.size());
+  std::vector<std::complex<double>> lambda1_sorted(lambda1.begin(), lambda1.end());
+  std::vector<std::complex<double>> lambda2_sorted(lambda2.begin(), lambda2.end());
+  auto cmp = [](auto a, auto b) {
+    if (std::abs(std::real(a) - std::real(b)) > 1e-10) return std::real(a) < std::real(b);
+    return std::imag(a) < std::imag(b);
+  };
+  std::sort(lambda1_sorted.begin(), lambda1_sorted.end(), cmp);
+  std::sort(lambda2_sorted.begin(), lambda2_sorted.end(), cmp);
+  for (size_t j = 0; j < lambda1_sorted.size(); ++j) { EXPECT_COMPLEX_NEAR(lambda1_sorted[j], lambda2_sorted[j]); }
+}
+
+// Test the eig and eigvals functions for general matrices.
+template <typename T>
+void test_eig_eigvals() {
+  for (auto i : nda::range(1, 6)) {
+    auto A    = nda::matrix<T, nda::F_layout>::rand(i, i);
+    auto Acpx = nda::matrix<std::complex<double>, nda::F_layout>(A);
+
+    // use eig to compute eigenvalues and eigenvectors
+    auto [lambda1, V1] = nda::linalg::eig(A);
+    check_eigen(Acpx, V1, lambda1);
+
+    // use eig_in_place to compute eigenvalues and eigenvectors
+    auto A2            = nda::matrix<T, nda::F_layout>(A);
+    auto [lambda2, V2] = nda::linalg::eig_in_place(A2);
+    check_eigen(Acpx, V2, lambda2);
+    expect_eigenvalues_near(lambda1, lambda2);
+
+    // use eigvals to compute eigenvalues only
+    auto lambda3 = nda::linalg::eigvals(A);
+    expect_eigenvalues_near(lambda1, lambda3);
+
+    // use eigvals_in_place to compute eigenvalues only
+    auto A4      = nda::matrix<T, nda::F_layout>(A);
+    auto lambda4 = nda::linalg::eigvals_in_place(A4);
+    expect_eigenvalues_near(lambda1, lambda4);
+
+    // use eig with a C-layout matrix
+    auto A5            = nda::matrix<T, nda::C_layout>{A};
+    auto A5cpx         = nda::matrix<std::complex<double>, nda::C_layout>(A5);
+    auto [lambda5, V5] = nda::linalg::eig(A5);
+    check_eigen(A5cpx, V5, lambda5);
+    expect_eigenvalues_near(lambda1, lambda5);
+
+    // use eigvals with a C-layout matrix
+    auto lambda6 = nda::linalg::eigvals(A5);
+    expect_eigenvalues_near(lambda1, lambda6);
+  }
+}
+
+// Test eig with a matrix that has known complex eigenvalues.
+TEST(NDA, LinearAlgebraEigComplexEigenvalues) {
+  // 2x2 rotation matrix: eigenvalues are i and -i
+  auto A        = nda::matrix<double, nda::F_layout>{{0.0, -1.0}, {1.0, 0.0}};
+  auto Acpx     = nda::matrix<std::complex<double>, nda::F_layout>(A);
+  auto [w, V]   = nda::linalg::eig(A);
+  auto expected = std::array{std::complex<double>{0.0, 1.0}, std::complex<double>{0.0, -1.0}};
+
+  // check eigenvalues (order may vary)
+  EXPECT_TRUE((std::abs(w(0) - expected[0]) < 1e-10) || (std::abs(w(0) - expected[1]) < 1e-10));
+  EXPECT_TRUE((std::abs(w(1) - expected[0]) < 1e-10) || (std::abs(w(1) - expected[1]) < 1e-10));
+
+  // check eigenvector equation
+  check_eigen(Acpx, V, w);
+}
+
+TEST(NDA, LinearAlgebraEigAndEigvals) {
+  test_eig_eigvals<double>();
+  test_eig_eigvals<std::complex<double>>();
 }
 
 // Test the norm function.
@@ -785,7 +861,7 @@ void verify_qr(auto const &A, auto const &sigma, auto const &Q, auto const &R, b
 template <typename T, typename Layout>
 void test_qr(int m, int n) {
   using matrix_t = nda::matrix<T, Layout>;
-  auto A = matrix_t::rand(m, n);
+  auto A         = matrix_t::rand(m, n);
 
   // QR decomposition
   for (auto complete : {true, false}) {


### PR DESCRIPTION
- interface to geev routines for real and complex matrices
- nda::linalg::eig and nda::linalg::eigvals wrappers + in place versions
  - only for right eigenvectors
- some clean up in blas/lapack/cuda interface
  - make function arguments consistently lower case