### PR TITLE
Add C++23 multi-argument operator[] as primary indexing interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,12 +105,10 @@ target_compile_options(${PROJECT_NAME}_warnings
     -Wfloat-conversion
     -Wpedantic
     -Wno-sign-compare
-    $<$<CXX_COMPILER_ID:GNU>:-Wno-comma-subscript>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-psabi> # Disable notes about ABI changes
     $<$<CXX_COMPILER_ID:GNU>:-Wshadow=local>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-attributes>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated-declarations>
-    $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-deprecated-comma-subscript>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-unknown-warning-option>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wshadow>
     $<$<CXX_COMPILER_ID:AppleClang,Clang,IntelLLVM>:-Wno-gcc-compat>

--- a/c++/nda/CMakeLists.txt
+++ b/c++/nda/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${PROJECT_NAME}::${PROJECT_NAME}_c ALIAS ${PROJECT_NAME}_c)
 target_link_libraries(${PROJECT_NAME}_c PRIVATE $<BUILD_INTERFACE:${PROJECT_NAME}_warnings>)
 
 # Configure target and compilation
-target_compile_features(${PROJECT_NAME}_c PUBLIC cxx_std_20)
+target_compile_features(${PROJECT_NAME}_c PUBLIC cxx_std_23)
 set_target_properties(${PROJECT_NAME}_c PROPERTIES
   POSITION_INDEPENDENT_CODE ON
   VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}

--- a/c++/nda/_impl_basic_array_view_common.hpp
+++ b/c++/nda/_impl_basic_array_view_common.hpp
@@ -159,23 +159,23 @@ static constexpr bool has_no_boundcheck = true;
 
 public:
 /**
- * @brief Implementation of the function call operator.
+ * @brief Implementation of the subscript operator.
  *
- * @details This function is an implementation detail an should be private. Since the Green's function library in
+ * @details This function is an implementation detail and should be private. Since the Green's function library in
  * TRIQS uses this function, it is kept public (for now).
  *
  * @tparam ResultAlgebra Algebra of the resulting view/array.
  * @tparam SelfIsRvalue True if the view/array is an rvalue.
  * @tparam Self Type of the calling view/array.
- * @tparam T Types of the arguments.
+ * @tparam Ts Types of the arguments.
  *
- * @param self Calling view.
+ * @param self Calling view/array.
  * @param idxs Multi-dimensional index consisting of `long`, `nda::range`, `nda::range::all_t`, nda::ellipsis or lazy
  * arguments.
- * @return Result of the function call depending on the given arguments and type of the view/array.
+ * @return Result of the subscript operation depending on the given arguments and type of the view/array.
  */
 template <char ResultAlgebra, bool SelfIsRvalue, typename Self, typename... Ts>
-FORCEINLINE static decltype(auto) call(Self &&self, Ts const &...idxs) noexcept(has_no_boundcheck) {
+FORCEINLINE static decltype(auto) subscript(Self &&self, Ts const &...idxs) noexcept(has_no_boundcheck) {
   // resulting value type
   using r_v_t = std::conditional_t<std::is_const_v<std::remove_reference_t<Self>>, ValueType const, ValueType>;
 
@@ -219,9 +219,10 @@ FORCEINLINE static decltype(auto) call(Self &&self, Ts const &...idxs) noexcept(
 
 public:
 /**
- * @brief Function call operator to access the view/array.
+ * @brief Subscript operator to access the view/array.
  *
- * @details Depending on the type of the calling object and the given arguments, this function call does the following:
+ * @details Depending on the type of the calling object and the given arguments, this subscript operation does the
+ * following:
  * - If any of the arguments is lazy, an nda::clef::expr with the nda::clef::tags::function tag is returned.
  * - If no arguments are given, a full view of the calling object is returned:
  *   - If the calling object itself or its value type is const, a view with a const value type is returned.
@@ -234,6 +235,39 @@ public:
  * the calling object. The algebra of the slice is the same as well, except if a 1-dimensional slice of a matrix is
  * taken. In this case, the algebra is changed to 'V'.
  *
+ * @tparam Ts Types of the arguments.
+ * @param idxs Multi-dimensional index consisting of `long`, `nda::range`, `nda::range::all_t`, nda::ellipsis or lazy
+ * arguments.
+ * @return Result of the subscript operation depending on the given arguments and type of the view/array.
+ */
+template <typename... Ts>
+FORCEINLINE decltype(auto) operator[](Ts const &...idxs) const & noexcept(has_no_boundcheck) {
+  static_assert((rank == -1) or (sizeof...(Ts) == rank) or (sizeof...(Ts) == 0) or (ellipsis_is_present<Ts...> and (sizeof...(Ts) <= rank + 1)),
+                "Error in array/view: Incorrect number of parameters in subscript operator");
+  return subscript<Algebra, false>(*this, idxs...);
+}
+
+/// Non-const overload of `nda::basic_array_view::operator[](Ts const &...) const &`.
+template <typename... Ts>
+FORCEINLINE decltype(auto) operator[](Ts const &...idxs) & noexcept(has_no_boundcheck) {
+  static_assert((rank == -1) or (sizeof...(Ts) == rank) or (sizeof...(Ts) == 0) or (ellipsis_is_present<Ts...> and (sizeof...(Ts) <= rank + 1)),
+                "Error in array/view: Incorrect number of parameters in subscript operator");
+  return subscript<Algebra, false>(*this, idxs...);
+}
+
+/// Rvalue overload of `nda::basic_array_view::operator[](Ts const &...) const &`.
+template <typename... Ts>
+FORCEINLINE decltype(auto) operator[](Ts const &...idxs) && noexcept(has_no_boundcheck) {
+  static_assert((rank == -1) or (sizeof...(Ts) == rank) or (sizeof...(Ts) == 0) or (ellipsis_is_present<Ts...> and (sizeof...(Ts) <= rank + 1)),
+                "Error in array/view: Incorrect number of parameters in subscript operator");
+  return subscript<Algebra, true>(*this, idxs...);
+}
+
+/**
+ * @brief Function call operator to access the view/array.
+ *
+ * @details Forwards to the subscript operator. See `nda::basic_array_view::operator[]` for details.
+ *
  * @tparam Ts Types of the function arguments.
  * @param idxs Multi-dimensional index consisting of `long`, `nda::range`, `nda::range::all_t`, nda::ellipsis or lazy
  * arguments.
@@ -241,62 +275,19 @@ public:
  */
 template <typename... Ts>
 FORCEINLINE decltype(auto) operator()(Ts const &...idxs) const & noexcept(has_no_boundcheck) {
-  static_assert((rank == -1) or (sizeof...(Ts) == rank) or (sizeof...(Ts) == 0) or (ellipsis_is_present<Ts...> and (sizeof...(Ts) <= rank + 1)),
-                "Error in array/view: Incorrect number of parameters in call operator");
-  return call<Algebra, false>(*this, idxs...);
+  return (*this)[idxs...];
 }
 
 /// Non-const overload of `nda::basic_array_view::operator()(Ts const &...) const &`.
 template <typename... Ts>
 FORCEINLINE decltype(auto) operator()(Ts const &...idxs) & noexcept(has_no_boundcheck) {
-  static_assert((rank == -1) or (sizeof...(Ts) == rank) or (sizeof...(Ts) == 0) or (ellipsis_is_present<Ts...> and (sizeof...(Ts) <= rank + 1)),
-                "Error in array/view: Incorrect number of parameters in call operator");
-  return call<Algebra, false>(*this, idxs...);
+  return (*this)[idxs...];
 }
 
 /// Rvalue overload of `nda::basic_array_view::operator()(Ts const &...) const &`.
 template <typename... Ts>
 FORCEINLINE decltype(auto) operator()(Ts const &...idxs) && noexcept(has_no_boundcheck) {
-  static_assert((rank == -1) or (sizeof...(Ts) == rank) or (sizeof...(Ts) == 0) or (ellipsis_is_present<Ts...> and (sizeof...(Ts) <= rank + 1)),
-                "Error in array/view: Incorrect number of parameters in call operator");
-  return call<Algebra, true>(*this, idxs...);
-}
-
-/**
- * @brief Subscript operator to access the 1-dimensional view/array.
- *
- * @details Depending on the type of the calling object and the given argument, this subscript operation does the
- * following:
- * - If the argument is lazy, an nda::clef::expr with the nda::clef::tags::function tag is returned.
- * - If the argument is convertible to `long`, a single element is accessed:
- *   - If the calling object is a view or an lvalue, a (const) reference to the element is returned.
- *   - Otherwise, a copy of the element is returned.
- * - Otherwise a slice of the calling object is returned with the same value type, algebra and accessor and owning
- * policies as the calling object.
- *
- * @tparam T Type of the argument.
- * @param idx 1-dimensional index that is either a `long`, `nda::range`, `nda::range::all_t`, nda::ellipsis or a lazy
- * argument.
- * @return Result of the subscript operation depending on the given argument and type of the view/array.
- */
-template <typename T>
-decltype(auto) operator[](T const &idx) const & noexcept(has_no_boundcheck) {
-  static_assert((rank == 1), "Error in array/view: Subscript operator is only available for rank 1 views/arrays in C++17/20");
-  return call<Algebra, false>(*this, idx);
-}
-
-/// Non-const overload of `nda::basic_array_view::operator[](T const &) const &`.
-template <typename T>
-decltype(auto) operator[](T const &x) & noexcept(has_no_boundcheck) {
-  static_assert((rank == 1), "Error in array/view: Subscript operator is only available for rank 1 views/arrays in C++17/20");
-  return call<Algebra, false>(*this, x);
-}
-
-/// Rvalue overload of `nda::basic_array_view::operator[](T const &) const &`.
-template <typename T>
-decltype(auto) operator[](T const &x) && noexcept(has_no_boundcheck) {
-  static_assert((rank == 1), "Error in array/view: Subscript operator is only available for rank 1 views/arrays in C++17/20");
-  return call<Algebra, true>(*this, x);
+  return std::move(*this)[idxs...];
 }
 
 /// Rank of the nda::array_iterator for the view/array.

--- a/c++/nda/arithmetic.hpp
+++ b/c++/nda/arithmetic.hpp
@@ -53,18 +53,32 @@ namespace nda {
     A a;
 
     /**
-     * @brief Function call operator.
+     * @brief Subscript operator.
      *
      * @details Forwards the arguments to the nda::Array operand and negates the result.
      *
      * @tparam Args Types of the arguments.
-     * @param args Function call arguments.
-     * @return If the result of the forwarded function call is another nda::Array, a new lazy expression is returned.
+     * @param args Subscript arguments.
+     * @return If the result of the forwarded subscript is another nda::Array, a new lazy expression is returned.
      * Otherwise the result is negated and returned.
      */
     template <typename... Args>
+    auto operator[](Args &&...args) const {
+      return -a[std::forward<Args>(args)...];
+    }
+
+    /**
+     * @brief Function call operator.
+     *
+     * @details Forwards to the subscript operator.
+     *
+     * @tparam Args Types of the arguments.
+     * @param args Function call arguments.
+     * @return Result of the corresponding subscript operation.
+     */
+    template <typename... Args>
     auto operator()(Args &&...args) const {
-      return -a(std::forward<Args>(args)...);
+      return (*this)[std::forward<Args>(args)...];
     }
 
     /**
@@ -157,38 +171,38 @@ namespace nda {
     }
 
     /**
-     * @brief Function call operator.
+     * @brief Subscript operator.
      *
      * @details Forwards the arguments to the nda::Array operands and performs the binary operation.
      *
      * @tparam Args Types of the arguments.
-     * @param args Function call arguments.
-     * @return If the result of the forwarded function calls contains another nda::Array, a new lazy expression is
+     * @param args Subscript arguments.
+     * @return If the result of the forwarded subscript operations contains another nda::Array, a new lazy expression is
      * returned. Otherwise the result of the binary operation is returned.
      */
     template <typename... Args>
-    auto operator()(Args const &...args) const {
+    auto operator[](Args const &...args) const {
       // addition
       if constexpr (OP == '+') {
         if constexpr (l_is_scalar) {
           // lhs is a scalar
           if constexpr (algebra == 'M')
             // rhs is a matrix
-            return (std::equal_to{}(args...) ? l + r(args...) : r(args...));
+            return (std::equal_to{}(args...) ? l + r[args...] : r[args...]);
           else
             // rhs is an array
-            return l + r(args...);
+            return l + r[args...];
         } else if constexpr (r_is_scalar) {
           // rhs is a scalar
           if constexpr (algebra == 'M')
             // lhs is a matrix
-            return (std::equal_to{}(args...) ? l(args...) + r : l(args...));
+            return (std::equal_to{}(args...) ? l[args...] + r : l[args...]);
           else
             // lhs is an array
-            return l(args...) + r;
+            return l[args...] + r;
         } else
           // both are arrays or matrices
-          return l(args...) + r(args...);
+          return l[args...] + r[args...];
       }
 
       // subtraction
@@ -197,35 +211,35 @@ namespace nda {
           // lhs is a scalar
           if constexpr (algebra == 'M')
             // rhs is a matrix
-            return (std::equal_to{}(args...) ? l - r(args...) : -r(args...));
+            return (std::equal_to{}(args...) ? l - r[args...] : -r[args...]);
           else
             // rhs is an array
-            return l - r(args...);
+            return l - r[args...];
         } else if constexpr (r_is_scalar) {
           // rhs is a scalar
           if constexpr (algebra == 'M')
             // lhs is a matrix
-            return (std::equal_to{}(args...) ? l(args...) - r : l(args...));
+            return (std::equal_to{}(args...) ? l[args...] - r : l[args...]);
           else
             // lhs is an array
-            return l(args...) - r;
+            return l[args...] - r;
         } else
           // both are arrays or matrices
-          return l(args...) - r(args...);
+          return l[args...] - r[args...];
       }
 
       // multiplication
       if constexpr (OP == '*') {
         if constexpr (l_is_scalar)
           // lhs is a scalar
-          return l * r(args...);
+          return l * r[args...];
         else if constexpr (r_is_scalar)
           // rhs is a scalar
-          return l(args...) * r;
+          return l[args...] * r;
         else {
           // both are arrays (matrix product is not supported here)
           static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
-          return l(args...) * r(args...);
+          return l[args...] * r[args...];
         }
       }
 
@@ -234,31 +248,30 @@ namespace nda {
         if constexpr (l_is_scalar) {
           // lhs is a scalar
           static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
-          return l / r(args...);
+          return l / r[args...];
         } else if constexpr (r_is_scalar)
           // rhs is a scalar
-          return l(args...) / r;
+          return l[args...] / r;
         else {
           // both are arrays (matrix division is not supported here)
           static_assert(algebra != 'M', "Error in nda::expr: Matrix algebra not supported");
-          return l(args...) / r(args...);
+          return l[args...] / r[args...];
         }
       }
     }
 
     /**
-     * @brief Subscript operator.
+     * @brief Function call operator.
      *
-     * @details Simply forwards the argument to the function call operator.
+     * @details Forwards to the subscript operator.
      *
-     * @tparam Arg Type of the argument.
-     * @param arg Subscript argument.
-     * @return Result of the corresponding function call.
+     * @tparam Args Types of the arguments.
+     * @param args Function call arguments.
+     * @return Result of the corresponding subscript operation.
      */
-    template <typename Arg>
-    auto operator[](Arg &&arg) const {
-      static_assert(get_rank<expr> == 1, "Error in nda::expr: Subscript operator only available for expressions of rank 1");
-      return operator()(std::forward<Arg>(arg));
+    template <typename... Args>
+    auto operator()(Args const &...args) const {
+      return (*this)[args...];
     }
   };
 

--- a/c++/nda/array_adapter.hpp
+++ b/c++/nda/array_adapter.hpp
@@ -64,7 +64,20 @@ namespace nda {
     [[nodiscard]] long size() const { return stdutil::product(myshape); }
 
     /**
-     * @brief Function call operator simply forwards the arguments to the callable object.
+     * @brief Subscript operator simply forwards the arguments to the callable object.
+     *
+     * @tparam Ints Integer types (convertible to long).
+     * @param i0 First argument.
+     * @param is Rest of the arguments.
+     */
+    template <typename... Ints>
+    auto operator[](long i0, Ints... is) const {
+      static_assert((std::is_convertible_v<Ints, long> and ...), "Error in nda::array_adapter: Arguments must be convertible to long");
+      return f(i0, is...);
+    }
+
+    /**
+     * @brief Function call operator simply forwards the arguments to the subscript operator.
      *
      * @tparam Ints Integer types (convertible to long).
      * @param i0 First argument.
@@ -72,8 +85,7 @@ namespace nda {
      */
     template <typename... Ints>
     auto operator()(long i0, Ints... is) const {
-      static_assert((std::is_convertible_v<Ints, long> and ...), "Error in nda::array_adapter: Arguments must be convertible to long");
-      return f(i0, is...);
+      return (*this)[i0, is...];
     }
   };
 

--- a/c++/nda/map.hpp
+++ b/c++/nda/map.hpp
@@ -84,26 +84,20 @@ namespace nda {
     std::tuple<const As...> a;
 
     private:
-    // Implementation of the function call operator.
+    // Implementation of the subscript operator.
     template <size_t... Is, typename... Args>
-    [[gnu::always_inline]] [[nodiscard]] auto _call(std::index_sequence<Is...>, Args const &...args) const {
+    [[gnu::always_inline]] [[nodiscard]] auto _subscript(std::index_sequence<Is...>, Args const &...args) const {
       // if args contains a range, we need to return an expr_call on the resulting slice
       if constexpr ((is_range_or_ellipsis<Args> or ... or false)) {
-        return mapped<F>{f}(std::get<Is>(a)(args...)...);
+        return mapped<F>{f}(std::get<Is>(a)[args...]...);
       } else {
-        return f(std::get<Is>(a)(args...)...);
+        return f(std::get<Is>(a)[args...]...);
       }
-    }
-
-    // Implementation of the subscript operator.
-    template <size_t... Is, typename Arg>
-    [[gnu::always_inline]] auto _call_bra(std::index_sequence<Is...>, Arg const &arg) const {
-      return f(std::get<Is>(a)[arg]...);
     }
 
     public:
     /**
-     * @brief Function call operator.
+     * @brief Subscript operator.
      *
      * @details The arguments (usually multi-dimensional indices) are passed to all the nda::Array objects stored in the
      * tuple and the results are then passed to the callable object.
@@ -111,29 +105,26 @@ namespace nda {
      * If the arguments contain a range, a new lazy function call expression is returned.
      *
      * @tparam Args Argument types.
+     * @param args Subscript arguments.
+     * @return The result of the subscript operation (depends on the callable and the arguments).
+     */
+    template <typename... Args>
+    auto operator[](Args const &...args) const {
+      return _subscript(std::make_index_sequence<sizeof...(As)>{}, args...);
+    }
+
+    /**
+     * @brief Function call operator.
+     *
+     * @details Equivalent to the subscript operator. Provided for backwards compatibility.
+     *
+     * @tparam Args Argument types.
      * @param args Function call arguments.
      * @return The result of the function call (depends on the callable and the arguments).
      */
     template <typename... Args>
     auto operator()(Args const &...args) const {
-      return _call(std::make_index_sequence<sizeof...(As)>{}, args...);
-    }
-
-    /**
-     * @brief Subscript operator.
-     *
-     * @details The argument (usually a 1-dimensional index) is passed to all the nda::Array objects stored in the tuple
-     * and the results are then passed to the callable object.
-     *
-     * If the argument is a range, a new lazy function call expression is returned.
-     *
-     * @tparam Arg Argument types.
-     * @param arg Subscript argument.
-     * @return The result of the subscript operation (depends on the callable and the arguments).
-     */
-    template <typename Arg>
-    auto operator[](Arg const &arg) const {
-      return _call_bra(std::make_index_sequence<sizeof...(As)>{}, arg);
+      return (*this)[args...];
     }
 
     // FIXME copy needed for the && case only. Overload ?

--- a/test/c++/nda_basic_array_and_view.cpp
+++ b/test/c++/nda_basic_array_and_view.cpp
@@ -843,6 +843,122 @@ TEST_F(NDAArrayAndView, AccessViaSubscriptOperator) {
   EXPECT_EQ(B, (nda::array<int, 1>{42, 1, 42, 3, 42}));
 }
 
+TEST_F(NDAArrayAndView, MultiDimensionalSubscriptOperator) {
+  using namespace nda::clef::literals;
+
+  // multi-dimensional single element access via operator[]
+  for (long i = 0; i < shape_3d[0]; ++i) {
+    for (long j = 0; j < shape_3d[1]; ++j) {
+      for (long k = 0; k < shape_3d[2]; ++k) {
+        EXPECT_EQ((A_3d[i, j, k]), A_3d(i, j, k));
+        EXPECT_EQ((A_3d_v[i, j, k]), A_3d_v(i, j, k));
+        EXPECT_EQ((A_3d_cv[i, j, k]), A_3d_cv(i, j, k));
+      }
+    }
+  }
+
+  // verify return types
+  static_assert(std::is_reference_v<decltype(A_3d[0, 0, 0])>);
+  static_assert(std::is_reference_v<decltype(A_3d_v[0, 0, 0])>);
+  static_assert(!std::is_reference_v<decltype(std::move(A_3d)[0, 0, 0])>);
+
+  // modify via operator[]
+  auto C = A_3d;
+  C[0, 1, 2] = 42;
+  EXPECT_EQ((C[0, 1, 2]), 42);
+  EXPECT_NE(C, A_3d);
+
+  // multi-dimensional lazy access
+  auto A_3d_lazy = A_3d[i_, j_, k_];
+  static_assert(nda::clef::is_lazy<decltype(A_3d_lazy)>);
+  EXPECT_EQ(nda::clef::eval(A_3d_lazy, i_ = 0, j_ = 1, k_ = 2), A_3d(0, 1, 2));
+
+  // CLEF auto-assign with operator[] (the << operator)
+  nda::array<double, 2> E(3, 4);
+  E[i_, j_] << i_ + 0.1 * j_;
+  for (int ii = 0; ii < 3; ++ii) {
+    for (int jj = 0; jj < 4; ++jj) { EXPECT_DOUBLE_EQ((E[ii, jj]), ii + 0.1 * jj); }
+  }
+
+  // CLEF auto-assign with operator[] for 3D array
+  nda::array<int, 3> F(2, 3, 4);
+  F[i_, j_, k_] << 100 * i_ + 10 * j_ + k_;
+  for (int ii = 0; ii < 2; ++ii) {
+    for (int jj = 0; jj < 3; ++jj) {
+      for (int kk = 0; kk < 4; ++kk) { EXPECT_EQ((F[ii, jj, kk]), 100 * ii + 10 * jj + kk); }
+    }
+  }
+
+  // 2D slice via operator[] (fix first index)
+  auto D       = A_3d;
+  auto D_slice = D[0, nda::range::all, nda::range::all];
+  EXPECT_EQ(D_slice.shape(), (std::array<long, 2>{3, 4}));
+  for (long j = 0; j < shape_3d[1]; ++j) {
+    for (long k = 0; k < shape_3d[2]; ++k) { EXPECT_EQ((D_slice[j, k]), A_3d(0, j, k)); }
+  }
+
+  // 1D slice via operator[] (fix first two indices)
+  auto D_1d = D[1, 2, nda::range::all];
+  EXPECT_EQ(D_1d.size(), shape_3d[2]);
+  for (long k = 0; k < shape_3d[2]; ++k) { EXPECT_EQ(D_1d[k], A_3d(1, 2, k)); }
+
+  // slicing with ellipsis via operator[]
+  auto D_ellipsis = D[0, nda::ellipsis{}];
+  EXPECT_EQ(D_ellipsis.shape(), (std::array<long, 2>{3, 4}));
+  for (long j = 0; j < shape_3d[1]; ++j) {
+    for (long k = 0; k < shape_3d[2]; ++k) { EXPECT_EQ((D_ellipsis[j, k]), A_3d(0, j, k)); }
+  }
+
+  // assign to slice via operator[]
+  D[0, nda::range::all, 0] = 99;
+  for (long j = 0; j < shape_3d[1]; ++j) { EXPECT_EQ((D[0, j, 0]), 99); }
+
+  // full view via operator[] with no arguments
+  auto D_full = D[];
+  EXPECT_EQ(D_full.shape(), D.shape());
+  EXPECT_EQ(D_full, D);
+
+  // matrix tests
+  nda::matrix<double> M(3, 4);
+  for (int i = 0; i < 3; ++i)
+    for (int j = 0; j < 4; ++j) M(i, j) = i * 4 + j;
+
+  EXPECT_EQ((M[1, 2]), M(1, 2));
+
+  // matrix row slice
+  auto M_row  = M[1, nda::range::all];
+  auto M_row2 = M(1, nda::range::all);
+  EXPECT_EQ(M_row, M_row2);
+
+  // matrix column slice
+  auto M_col  = M[nda::range::all, 2];
+  auto M_col2 = M(nda::range::all, 2);
+  EXPECT_EQ(M_col, M_col2);
+
+  // expression templates with operator[]
+  nda::array<double, 2> G(3, 4), H(3, 4);
+  G[i_, j_] << i_ + j_;
+  H[i_, j_] << 2.0 * i_ - j_;
+
+  // binary expression with operator[]
+  auto expr_add = G + H;
+  for (int ii = 0; ii < 3; ++ii) {
+    for (int jj = 0; jj < 4; ++jj) { EXPECT_DOUBLE_EQ((expr_add[ii, jj]), (G[ii, jj] + H[ii, jj])); }
+  }
+
+  // unary expression with operator[]
+  auto expr_neg = -G;
+  for (int ii = 0; ii < 3; ++ii) {
+    for (int jj = 0; jj < 4; ++jj) { EXPECT_DOUBLE_EQ((expr_neg[ii, jj]), -(G[ii, jj])); }
+  }
+
+  // scalar-array expression with operator[]
+  auto expr_scale = 3.0 * G;
+  for (int ii = 0; ii < 3; ++ii) {
+    for (int jj = 0; jj < 4; ++jj) { EXPECT_DOUBLE_EQ((expr_scale[ii, jj]), 3.0 * (G[ii, jj])); }
+  }
+}
+
 TEST_F(NDAArrayAndView, Indices) {
   auto indices = A_3d_v.indices();
   auto it      = indices.begin();


### PR DESCRIPTION
## Summary

- Introduces C++23 multi-argument `operator[]` syntax (e.g., `A[i, j, k]`) as the primary indexing interface
- Makes `operator()` delegate to `operator[]` for backward compatibility
- Updates all array-like types: `basic_array`, `basic_array_view`, `array_adapter`, `expr`, `expr_unary`, and `expr_call`

## Changes

- Require C++23 (`cxx_std_23`) and remove deprecated comma-subscript warnings
- Rename internal `call<>()` helper to `subscript<>()` for clarity
- Full feature parity with `operator()`: integers, ranges, `range::all`, ellipsis, and CLEF lazy placeholders all work
- Add comprehensive tests for the new subscript operator

## Test plan

- [ ] All existing tests pass (119/119)
- [ ] New `MultiDimensionalSubscriptOperator` test covers element access, CLEF, slicing, ellipsis, and expression templates