### PR TITLE
Allow fallback to py_range converters for c2py

### DIFF
--- a/c++/nda/c2py/converters.hpp
+++ b/c++/nda/c2py/converters.hpp
@@ -22,11 +22,11 @@ namespace c2py {
   }
 
   template <typename T, int R, typename Layout, char Algebra>
+    requires(has_npy_type<std::decay_t<T>>)
   struct py_converter<nda::basic_array_view<T, R, Layout, Algebra>> {
 
     using view_t = nda::basic_array_view<T, R, Layout, Algebra>;
     using U      = std::decay_t<T>;
-    static_assert(has_npy_type<U>, "Logical Error");
     static_assert(not std::is_same_v<U, pyref>, "Not implemented"); // would require to take care of the incref...
     // However, it works for PyObject *
 
@@ -211,12 +211,14 @@ namespace c2py {
   };
 
   template <typename T, int R, char Algebra>
+    requires(has_npy_type<std::decay_t<T>>)
   struct py_converter<nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>> const &> {
     using array_t = nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>>;
     static PyObject *c2py(array_t const &a) { return cxx2py(nda::make_const_view(a)); }
   };
 
   template <typename T, int R, char Algebra>
+    requires(has_npy_type<std::decay_t<T>>)
   struct py_converter<nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>> &> {
     using array_t = nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>>;
     using view_t  = nda::basic_array_view<T, R, nda::C_layout, Algebra>;

--- a/c++/nda/c2py/make_numpy_proxy_from_array.hpp
+++ b/c++/nda/c2py/make_numpy_proxy_from_array.hpp
@@ -6,6 +6,7 @@
 #pragma once
 #include <vector>
 #include <nda/nda.hpp>
+#include <c2py/py_converter.hpp>
 #include <c2py/converters/numpy_proxy.hpp>
 #include "./make_py_capsule.hpp"
 

--- a/test/python/c2py_clair/nda_converter.cpp
+++ b/test/python/c2py_clair/nda_converter.cpp
@@ -1,107 +1,122 @@
 #include <c2py/c2py.hpp>
 #include <nda/nda.hpp>
+
 #include <complex>
+#include <string>
+#include <vector>
 
-namespace nc {
+// -- arg: array<T, R> const & ----------------------------------------
 
-  // ============================================================
-  // Functions taking arrays/views as const reference
-  // ============================================================
+double sum_array(nda::array<double, 1> const &a) { return nda::sum(a); }
 
-  inline double sum_array(nda::array<double, 1> const &a) {
-    double s = 0;
-    for (long i = 0; i < a.size(); ++i) s += a(i);
-    return s;
+double sum_matrix(nda::array<double, 2> const &a) { return nda::sum(a); }
+
+// -- arg: array<T, R> by value ----------------------------------------
+
+nda::array<double, 1> double_array(nda::array<double, 1> a) {
+  a *= 2;
+  return a;
+}
+
+// -- arg: array_view<T, R> (mutable) ----------------------------------
+
+void fill_view_1d(nda::array_view<double, 1> v, double val) { v = val; }
+
+void fill_view_2d(nda::array_view<double, 2> m, double val) { m = val; }
+
+// -- arg: array_const_view<T, R> --------------------------------------
+
+double sum_const_view(nda::array_const_view<double, 1> v) { return nda::sum(v); }
+
+// -- return: array<T, R> by value -------------------------------------
+
+nda::array<double, 1> make_sequence(long n) {
+  nda::array<double, 1> a(n);
+  nda::for_each(a.shape(), [&](auto i) { a(i) = static_cast<double>(i); });
+  return a;
+}
+
+// -- return: array const & and array & (via class) --------------------
+
+class array_container {
+  nda::array<double, 2> data_;
+
+  public:
+  array_container(long rows, long cols) : data_(rows, cols) { data_ = 0; }
+
+  nda::array<double, 2> const &data_const() const { return data_; }
+  nda::array<double, 2> &data() { return data_; }
+  nda::array<double, 2> data_copy() const { return data_; }
+  void set_data(nda::array_view<double, 2> v) { data_ = v; }
+};
+
+// -- return: array of arrays (via class) ------------------------------
+
+class nested_container {
+  nda::array<nda::array<double, 1>, 1> data_;
+
+  public:
+  nested_container(long n, long inner_size) : data_(n) {
+    nda::for_each(data_.shape(), [&](auto i) {
+      data_(i) = nda::array<double, 1>(inner_size);
+      data_(i) = static_cast<double>(i);
+    });
   }
 
-  inline double sum_const_view(nda::array_const_view<double, 1> v) {
-    double s = 0;
-    for (long i = 0; i < v.size(); ++i) s += v(i);
-    return s;
-  }
+  nda::array<nda::array<double, 1>, 1> const &data_const() const { return data_; }
+  nda::array<nda::array<double, 1>, 1> &data() { return data_; }
+  nda::array<nda::array<double, 1>, 1> data_copy() const { return data_; }
+};
 
-  // ============================================================
-  // By value (copy in C++)
-  // ============================================================
+// -- return: expressions ----------------------------------------------
 
-  inline nda::array<double, 1> double_array(nda::array<double, 1> a) {
-    a *= 2;
-    return a;
-  }
+auto scale_array(nda::array<double, 1> const &a, double s) { return a * s; }
+auto negate_array(nda::array<double, 1> const &a) { return -a; }
+auto conj_array(nda::array<std::complex<double>, 1> const &a) { return conj(a); }
+auto add_arrays(nda::array<long, 2> const &a, nda::array<long, 2> const &b) { return a + b; }
 
-  // ============================================================
-  // Modifying views and array refs in-place
-  // ============================================================
+// -- matrix algebra (matrix_view operator= has different semantics) ---
 
-  inline void fill_matrix(nda::array_view<double, 2> m, double val) { m = val; }
+void fill_matrix_view(nda::matrix_view<double> m, double val) { m = val; }
 
-  // ============================================================
-  // Returning arrays by value
-  // ============================================================
+// -- scalar types: long, complex<double> ------------------------------
 
-  inline nda::matrix<double> make_identity(long n) { return nda::eye(n); }
+long sum_int_array(nda::array<long, 1> const &a) { return nda::sum(a); }
 
-  // ============================================================
-  // Returning expressions (py_converter<expr> handles these)
-  // ============================================================
+std::complex<double> sum_complex_array(nda::array<std::complex<double>, 1> const &a) { return nda::sum(a); }
 
-  inline auto scale_array(nda::array<double, 1> const &a, double s) { return a * s; }
+// -- higher rank (3D) -------------------------------------------------
 
-  inline auto negate_array(nda::array<double, 1> const &a) { return -a; }
+double sum_3d(nda::array<double, 3> const &a) { return nda::sum(a); }
 
-  inline auto conj_array(nda::array<std::complex<double>, 1> const &a) { return conj(a); }
+// -- non-npy element types (converter element-by-element path) --------
 
-  inline auto add_arrays(nda::array<long, 2> const &a, nda::array<long, 2> const &b) { return a + b; }
+nda::array<std::string, 1> reverse_strings(nda::array<std::string, 1> const &a) {
+  nda::array<std::string, 1> res(a.shape());
+  nda::for_each(a.shape(), [&](auto i) { res(i) = std::string(a(i).rbegin(), a(i).rend()); });
+  return res;
+}
 
-  // ============================================================
-  // Class holding an array with const& getter
-  // ============================================================
+nda::array<std::vector<double>, 1> make_ranges(long n) {
+  nda::array<std::vector<double>, 1> res(n);
+  nda::for_each(res.shape(), [&](auto i) {
+    auto &v = res(i);
+    v.resize(i + 1);
+    for (long j = 0; j <= i; ++j) v[j] = static_cast<double>(j);
+  });
+  return res;
+}
 
-  class array_container {
-    nda::array<double, 2> data_;
+std::vector<double> flatten_array_of_vectors(nda::array<std::vector<double>, 1> const &a) {
+  std::vector<double> res;
+  nda::for_each(a.shape(), [&](auto i) { res.insert(res.end(), a(i).begin(), a(i).end()); });
+  return res;
+}
 
-    public:
-    array_container(long rows, long cols) : data_(rows, cols) { data_ = 0; }
-
-    nda::array<double, 2> const &data_const() const { return data_; }
-
-    nda::array<double, 2> &data() { return data_; }
-
-    nda::array<double, 2> data_copy() const { return data_; }
-
-    void set_data(nda::array_view<double, 2> v) { data_ = v; }
-  };
-
-  // ============================================================
-  // Different scalar types
-  // ============================================================
-
-  inline long sum_int_array(nda::array<long, 1> const &a) {
-    long s = 0;
-    for (long i = 0; i < a.size(); ++i) s += a(i);
-    return s;
-  }
-
-  inline std::complex<double> sum_complex_array(nda::array<std::complex<double>, 1> const &a) {
-    std::complex<double> s = 0;
-    for (long i = 0; i < a.size(); ++i) s += a(i);
-    return s;
-  }
-
-  // ============================================================
-  // Higher-rank arrays (3D)
-  // ============================================================
-
-  inline double sum_3d(nda::array<double, 3> const &a) {
-    double s = 0;
-    for (long i = 0; i < a.shape()[0]; ++i)
-      for (long j = 0; j < a.shape()[1]; ++j)
-        for (long k = 0; k < a.shape()[2]; ++k) s += a(i, j, k);
-    return s;
-  }
-
-  inline void fill_3d(nda::array_view<double, 3> v, double val) { v = val; }
-
-} // namespace nc
+nda::array<std::vector<int>, 2> make_grid(long rows, long cols) {
+  nda::array<std::vector<int>, 2> res(rows, cols);
+  nda::for_each(res.shape(), [&](auto i, auto j) { res(i, j) = {static_cast<int>(i), static_cast<int>(j)}; });
+  return res;
+}
 
 #include "nda_converter.wrap.cxx"

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -1,143 +1,309 @@
+import gc
 import unittest
 import numpy as np
 
 import nda_converter as nc
 
 
-class TestConstRefArgs(unittest.TestCase):
-    """Functions taking arrays as const& or const views."""
+# ==================================================================
+# Argument types
+# ==================================================================
 
-    def test_sum_array(self):
+class TestArgArrayConstRef(unittest.TestCase):
+    """array<T, R> const &: copies from numpy, auto-converts dtype and layout."""
+
+    def test_1d(self):
+        self.assertAlmostEqual(nc.sum_array(np.array([1.0, 2.0, 3.0])), 6.0)
+
+    def test_2d(self):
+        self.assertAlmostEqual(nc.sum_matrix(np.ones((2, 3))), 6.0)
+
+    def test_converts_dtype(self):
+        self.assertAlmostEqual(nc.sum_array(np.array([1, 2, 3], dtype=np.float32)), 6.0)
+        self.assertAlmostEqual(nc.sum_array(np.array([1, 2, 3], dtype=np.int64)), 6.0)
+
+    def test_converts_layout(self):
+        m = np.asfortranarray(np.array([[1.0, 2.0], [3.0, 4.0]]))
+        self.assertAlmostEqual(nc.sum_matrix(m), 10.0)
+        self.assertAlmostEqual(nc.sum_matrix(m.T), 10.0)
+
+    def test_accepts_list_and_tuple(self):
+        self.assertAlmostEqual(nc.sum_array([1.0, 2.0, 3.0]), 6.0)
+        self.assertAlmostEqual(nc.sum_array((1.0, 2.0, 3.0)), 6.0)
+        self.assertAlmostEqual(nc.sum_matrix([[1, 2], [3, 4]]), 10.0)
+
+    def test_empty(self):
+        self.assertAlmostEqual(nc.sum_array(np.array([], dtype=np.float64)), 0.0)
+        self.assertAlmostEqual(nc.sum_matrix(np.zeros((0, 3))), 0.0)
+
+    def test_rejects_wrong_rank(self):
+        with self.assertRaises(TypeError):
+            nc.sum_array(np.ones((3, 4)))
+
+    def test_rejects_non_array(self):
+        for bad in [42.0, None, "hello"]:
+            with self.assertRaises(TypeError):
+                nc.sum_array(bad)
+
+
+class TestArgArrayByValue(unittest.TestCase):
+    """array<T, R> by value: same conversion as const ref, but original is never modified."""
+
+    def test_returns_doubled(self):
+        np.testing.assert_array_almost_equal(nc.double_array(np.array([1.0, 2.0, 3.0])), [2.0, 4.0, 6.0])
+
+    def test_original_unchanged(self):
         a = np.array([1.0, 2.0, 3.0])
-        self.assertAlmostEqual(nc.sum_array(a), 6.0)
+        nc.double_array(a)
+        np.testing.assert_array_equal(a, [1.0, 2.0, 3.0])
 
-    def test_sum_const_view(self):
-        a = np.array([1.5, 2.5, 3.5])
-        self.assertAlmostEqual(nc.sum_const_view(a), 7.5)
+    def test_converts_dtype_and_layout(self):
+        np.testing.assert_array_almost_equal(nc.double_array(np.array([1, 2], dtype=np.float32)), [2.0, 4.0])
+        np.testing.assert_array_almost_equal(nc.double_array(np.asfortranarray(np.array([1.0, 2.0]))), [2.0, 4.0])
 
-
-class TestByValue(unittest.TestCase):
-    """Functions taking/returning arrays by value."""
-
-    def test_double_array(self):
-        a = np.array([1.0, 2.0, 3.0])
-        result = nc.double_array(a)
-        np.testing.assert_array_almost_equal(result, [2.0, 4.0, 6.0])
-        np.testing.assert_array_equal(a, [1.0, 2.0, 3.0])  # original array should be unchanged
+    def test_accepts_list(self):
+        np.testing.assert_array_almost_equal(nc.double_array([1.0, 2.0]), [2.0, 4.0])
 
 
-class TestMutableViews(unittest.TestCase):
-    """Modifying views in-place from Python."""
+class TestArgMutableView(unittest.TestCase):
+    """array_view<T, R>: zero-copy, requires exact dtype and C-compatible stride order."""
 
-    def test_fill_matrix(self):
+    def test_fills_in_place(self):
+        v = np.zeros(5)
+        nc.fill_view_1d(v, 3.0)
+        np.testing.assert_array_almost_equal(v, np.full(5, 3.0))
+
+    def test_fills_2d(self):
         m = np.zeros((3, 4))
-        nc.fill_matrix(m, 7.0)
+        nc.fill_view_2d(m, 7.0)
         np.testing.assert_array_almost_equal(m, np.full((3, 4), 7.0))
 
+    def test_strided_2d(self):
+        """C_stride_layout views accept non-contiguous C-ordered strides."""
+        m = np.zeros((6, 4))
+        nc.fill_view_2d(m[::2, :], 1.0)
+        np.testing.assert_array_almost_equal(m[0], [1, 1, 1, 1])
+        np.testing.assert_array_almost_equal(m[1], [0, 0, 0, 0])
+        np.testing.assert_array_almost_equal(m[2], [1, 1, 1, 1])
 
-class TestReturnArrays(unittest.TestCase):
-    """Functions returning arrays by value."""
+    def test_empty(self):
+        v = np.array([], dtype=np.float64)
+        nc.fill_view_1d(v, 7.0)
+        self.assertEqual(len(v), 0)
 
-    def test_make_identity(self):
-        np.testing.assert_array_almost_equal(nc.make_identity(3), np.eye(3))
+    def test_rejects_wrong_dtype(self):
+        with self.assertRaises(TypeError):
+            nc.fill_view_2d(np.zeros((3, 4), dtype=np.float32), 1.0)
+        with self.assertRaises(TypeError):
+            nc.fill_view_1d(np.zeros(5, dtype=np.int64), 1.0)
+
+    def test_rejects_fortran_order(self):
+        with self.assertRaises(TypeError):
+            nc.fill_view_2d(np.asfortranarray(np.zeros((3, 4))), 1.0)
+
+    def test_rejects_wrong_rank(self):
+        with self.assertRaises(TypeError):
+            nc.fill_view_2d(np.zeros(5), 1.0)
 
 
-class TestExpressions(unittest.TestCase):
-    """Functions returning nda expressions (implicitly converted to arrays)."""
+class TestArgConstView(unittest.TestCase):
+    """array_const_view<T, R>: zero-copy read-only, accepts read-only numpy."""
 
-    def test_scale_array(self):
+    def test_basic(self):
+        self.assertAlmostEqual(nc.sum_const_view(np.array([1.5, 2.5, 3.5])), 7.5)
+
+    def test_readonly_numpy(self):
         a = np.array([1.0, 2.0, 3.0])
-        np.testing.assert_array_almost_equal(nc.scale_array(a, 3.0), [3.0, 6.0, 9.0])
+        a.flags.writeable = False
+        self.assertAlmostEqual(nc.sum_const_view(a), 6.0)
 
-    def test_negate_array(self):
-        a = np.array([1.0, -2.0, 3.0])
-        np.testing.assert_array_almost_equal(nc.negate_array(a), [-1.0, 2.0, -3.0])
 
-    def test_conj_array(self):
+# ==================================================================
+# Return types
+# ==================================================================
+
+class TestReturnByValue(unittest.TestCase):
+    """Returned arrays own their data and are writeable."""
+
+    def test_basic(self):
+        np.testing.assert_array_almost_equal(nc.make_sequence(5), [0, 1, 2, 3, 4])
+
+    def test_writeable_and_owns_data(self):
+        a = nc.make_sequence(100)
+        self.assertTrue(a.flags['WRITEABLE'])
+        gc.collect()
+        np.testing.assert_array_almost_equal(a[:3], [0, 1, 2])
+
+    def test_empty(self):
+        self.assertEqual(len(nc.make_sequence(0)), 0)
+
+
+class TestReturnRef(unittest.TestCase):
+    """array const& -> read-only numpy; array& -> writeable numpy sharing C++ memory."""
+
+    def setUp(self):
+        self.c = nc.ArrayContainer(2, 3)
+        self.c.set_data(np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]))
+
+    def test_const_ref_is_readonly(self):
+        d = self.c.data_const()
+        self.assertFalse(d.flags['WRITEABLE'])
+        with self.assertRaises(ValueError):
+            d[0, 0] = 0.0
+
+    def test_mutable_ref_shares_memory(self):
+        d = self.c.data()
+        self.assertTrue(d.flags['WRITEABLE'])
+        d[0, 0] = 99.0
+        self.assertEqual(self.c.data()[0, 0], 99.0)
+
+    def test_copy_is_independent(self):
+        copy = self.c.data_copy()
+        copy[0, 0] = 999.0
+        self.assertEqual(self.c.data()[0, 0], 1.0)
+
+    def test_copy_survives_container_deletion(self):
+        copy = self.c.data_copy()
+        del self.c
+        gc.collect()
+        np.testing.assert_array_almost_equal(copy[0], [1.0, 2.0, 3.0])
+
+
+class TestReturnExpression(unittest.TestCase):
+    """Expressions are materialized into regular arrays on return."""
+
+    def test_scale(self):
+        np.testing.assert_array_almost_equal(nc.scale_array(np.array([1.0, 2.0, 3.0]), 3.0), [3.0, 6.0, 9.0])
+
+    def test_negate(self):
+        np.testing.assert_array_almost_equal(nc.negate_array(np.array([1.0, -2.0])), [-1.0, 2.0])
+
+    def test_conj(self):
         a = np.array([1 + 2j, 3 - 4j], dtype=np.complex128)
         np.testing.assert_array_almost_equal(nc.conj_array(a), np.conj(a))
 
-    def test_add_arrays(self):
+    def test_add(self):
         a = np.array([[1, 2], [3, 4]], dtype=np.int64)
         b = np.array([[5, 6], [7, 8]], dtype=np.int64)
         np.testing.assert_array_equal(nc.add_arrays(a, b), a + b)
 
 
-class TestArrayContainer(unittest.TestCase):
-    """Class holding array with const& getter."""
+# ==================================================================
+# Return: array of arrays (nested non-npy element type via class)
+# ==================================================================
 
-    def test_set_and_get(self):
-        c = nc.ArrayContainer(2, 3)
-        v = np.array([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]])
-        c.set_data(v)
-        np.testing.assert_array_equal(c.data(), v)
+class TestReturnNestedArrayRef(unittest.TestCase):
+    """array<array<double,1>, 1> returned as const&, &, and copy from a wrapped class."""
 
-    def test_data_returns_const_ref(self):
-        """data_const() returns const& — the returned numpy should be read-only."""
-        c = nc.ArrayContainer(2, 2)
-        c.set_data(np.array([[1.0, 2.0], [3.0, 4.0]]))
-        d = c.data_const()
-        self.assertFalse(d.flags['WRITEABLE'])
-        with self.assertRaises(ValueError):
-            d[0, 0] = 0.0
+    def setUp(self):
+        self.c = nc.NestedContainer(3, 4)  # 3 inner arrays of size 4
 
-    def test_data_returns_ref(self):
-        """data() returns & — the returned numpy should be writeable."""
-        c = nc.ArrayContainer(2, 2)
-        c.set_data(np.array([[1.0, 2.0], [3.0, 4.0]]))
-        d = c.data()
-        self.assertTrue(d.flags['WRITEABLE'])
-        d[0, 0] = 10.0
-        self.assertEqual(c.data()[0, 0], 10.0)
+    def test_data_const_returns_correct_values(self):
+        # const& of non-npy array returns a c2py_range; convert to list of arrays
+        d = list(self.c.data_const())
+        self.assertEqual(len(d), 3)
+        # Inner array i is filled with float(i)
+        np.testing.assert_array_almost_equal(d[0], [0.0, 0.0, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(d[1], [1.0, 1.0, 1.0, 1.0])
+        np.testing.assert_array_almost_equal(d[2], [2.0, 2.0, 2.0, 2.0])
 
-    def test_data_copy_is_independent(self):
-        """data_copy() returns a copy — modifying it does not affect the container."""
-        c = nc.ArrayContainer(2, 2)
-        v = np.array([[1.0, 2.0], [3.0, 4.0]])
-        c.set_data(v)
-        copy = c.data_copy()
-        copy[0, 0] = 999.0
-        np.testing.assert_array_almost_equal(c.data(), v)
+    def test_data_returns_correct_values(self):
+        d = list(self.c.data())
+        self.assertEqual(len(d), 3)
+        np.testing.assert_array_almost_equal(d[1], [1.0, 1.0, 1.0, 1.0])
 
+    def test_data_mutation_does_not_propagate(self):
+        """For non-npy element types, c2py_range yields copies of inner arrays.
+        Unlike the flat array_container case, mutations do not propagate back."""
+        d = list(self.c.data())
+        d[0][0] = 999.0
+        d2 = list(self.c.data())
+        np.testing.assert_array_almost_equal(d2[0], [0.0, 0.0, 0.0, 0.0])
+
+    def test_data_copy_returns_correct_values(self):
+        # by-value return goes through element-by-element converter -> numpy object array
+        copy = self.c.data_copy()
+        self.assertEqual(len(copy), 3)
+        np.testing.assert_array_almost_equal(copy[0], [0.0, 0.0, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(copy[2], [2.0, 2.0, 2.0, 2.0])
+
+    def test_copy_survives_container_deletion(self):
+        copy = self.c.data_copy()
+        del self.c
+        gc.collect()
+        np.testing.assert_array_almost_equal(copy[2], [2.0, 2.0, 2.0, 2.0])
+
+
+# ==================================================================
+# Matrix algebra (only the view semantics differ from array)
+# ==================================================================
+
+class TestMatrixViewAlgebra(unittest.TestCase):
+    """matrix_view operator=(scalar) sets scalar * identity, unlike array_view."""
+
+    def test_fill_sets_diagonal(self):
+        m = np.zeros((3, 3))
+        nc.fill_matrix_view(m, 5.0)
+        np.testing.assert_array_almost_equal(m, 5.0 * np.eye(3))
+
+
+# ==================================================================
+# Scalar types and higher rank
+# ==================================================================
 
 class TestScalarTypes(unittest.TestCase):
-    """Different scalar types."""
 
-    def test_sum_int_array(self):
-        a = np.array([1, 2, 3, 4], dtype=np.int64)
-        self.assertEqual(nc.sum_int_array(a), 10)
+    def test_int(self):
+        self.assertEqual(nc.sum_int_array(np.array([1, 2, 3, 4], dtype=np.int64)), 10)
+        self.assertEqual(nc.sum_int_array(np.array([1, 2, 3], dtype=np.int32)), 6)
 
-    def test_sum_complex_array(self):
-        a = np.array([1 + 2j, 3 + 4j], dtype=np.complex128)
-        self.assertAlmostEqual(nc.sum_complex_array(a), 4 + 6j)
+    def test_complex(self):
+        self.assertAlmostEqual(nc.sum_complex_array(np.array([1 + 2j, 3 + 4j])), 4 + 6j)
 
-
-class TestHigherRank(unittest.TestCase):
-    """3D array operations."""
-
-    def test_sum_3d(self):
-        a = np.ones((2, 3, 4))
-        self.assertAlmostEqual(nc.sum_3d(a), 24.0)
-
-    def test_fill_3d(self):
-        a = np.zeros((2, 3, 4))
-        nc.fill_3d(a, 5.0)
-        np.testing.assert_array_almost_equal(a, np.full((2, 3, 4), 5.0))
+    def test_3d(self):
+        self.assertAlmostEqual(nc.sum_3d(np.ones((2, 3, 4))), 24.0)
+        self.assertAlmostEqual(nc.sum_3d(np.zeros((2, 0, 4))), 0.0)
 
 
-class TestConversions(unittest.TestCase):
-    """Type/rank conversions and enforcement."""
+# ==================================================================
+# Non-npy element types (element-by-element converter path)
+# ==================================================================
 
-    def test_rank_mismatch_rejected(self):
-        with self.assertRaises(TypeError):
-            nc.sum_array(np.ones((3, 4)))
+class TestArrayOfStrings(unittest.TestCase):
+    """array<std::string, 1>: T has no native numpy type, converted element-by-element."""
 
-    def test_int_to_double_converts(self):
-        a = np.array([1, 2, 3], dtype=np.int64)
-        self.assertAlmostEqual(nc.sum_array(a), 6.0)
+    def test_roundtrip(self):
+        result = nc.reverse_strings(np.array(["abc", "de", "f"], dtype=object))
+        self.assertEqual(list(result), ["cba", "ed", "f"])
 
-    def test_list_input_converts(self):
-        self.assertAlmostEqual(nc.sum_array([1.0, 2.0, 3.0]), 6.0)
+    def test_from_object_array(self):
+        result = nc.reverse_strings(np.array(["hello", "world"], dtype=object))
+        self.assertEqual(list(result), ["olleh", "dlrow"])
+
+
+class TestArrayOfVectors(unittest.TestCase):
+    """array<std::vector<double>, R>: nested converted type."""
+
+    def test_make_ranges(self):
+        result = nc.make_ranges(3)
+        self.assertEqual(list(result[0]), [0.0])
+        self.assertEqual(list(result[1]), [0.0, 1.0])
+        self.assertEqual(list(result[2]), [0.0, 1.0, 2.0])
+
+    def test_flatten(self):
+        arr = np.array([[1.0, 2.0], [3.0]], dtype=object)
+        result = nc.flatten_array_of_vectors(arr)
+        np.testing.assert_array_almost_equal(result, [1.0, 2.0, 3.0])
+
+    def test_2d_array_of_vectors(self):
+        grid = nc.make_grid(2, 3)
+        self.assertEqual(list(grid[0, 0]), [0, 0])
+        self.assertEqual(list(grid[1, 2]), [1, 2])
+
+    def test_roundtrip_make_then_flatten(self):
+        ranges = nc.make_ranges(4)
+        flat = nc.flatten_array_of_vectors(ranges)
+        np.testing.assert_array_almost_equal(flat, [0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 3.0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- only use ref and view converters if the value type is compatible with numpy
- otherwise fallback to the py_range converter as it was done before