### PR TITLE
Fix bug in c2py converters for non-contiguous numpy views -> array

### DIFF
--- a/c++/nda/c2py/converters.hpp
+++ b/c++/nda/c2py/converters.hpp
@@ -109,10 +109,10 @@ namespace c2py {
     static_assert(not std::is_same_v<T, PyObject *>, "Not implemented");
 
     using array_t                 = nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>>;
-    using view_t                  = nda::basic_array_view<T, R, nda::C_layout, Algebra>;
+    using view_t                  = nda::basic_array_view<T, R, nda::C_stride_layout, Algebra>;
     using converter_T             = py_converter<std::decay_t<T>>;
     using converter_view_T        = py_converter<view_t>;
-    using converter_view_pyobject = py_converter<nda::basic_array_view<PyObject *, R, nda::C_layout, Algebra>>;
+    using converter_view_pyobject = py_converter<nda::basic_array_view<PyObject *, R, nda::C_stride_layout, Algebra>>;
 
     // ------------ tp_name ---------------
 

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -64,6 +64,12 @@ class TestArgArrayByValue(unittest.TestCase):
     def test_accepts_list(self):
         np.testing.assert_array_almost_equal(nc.double_array([1.0, 2.0]), [2.0, 4.0])
 
+    def test_double_non_contiguous_view(self):
+        """By-value array parameters can be passed non-contiguous views, since they are copied."""
+        m = np.array([[1.0, 2.0], [3.0, 4.0]])
+        result = nc.double_array(m[:, 0])
+        np.testing.assert_array_almost_equal(result, [2.0, 6.0])
+
 
 class TestArgMutableView(unittest.TestCase):
     """array_view<T, R>: zero-copy, requires exact dtype and C-compatible stride order."""


### PR DESCRIPTION
- the converter dispatched the py2c call to a view converter with contiguous layout
- add a test that exposes the problem