### PR TITLE
Update c2py converters

### DIFF
--- a/c++/nda/c2py/converters.hpp
+++ b/c++/nda/c2py/converters.hpp
@@ -78,6 +78,13 @@ namespace c2py {
         return false;
       }
 
+      if constexpr (not std::is_const_v<T>) {
+        if (not PyArray_ISWRITEABLE(arr)) {
+          if (raise_python_exception) PyErr_SetString(PyExc_TypeError, "Cannot convert to mutable array_view : Numpy array is read-only");
+          return false;
+        }
+      }
+
       return true;
     }
 

--- a/c++/nda/c2py/converters.hpp
+++ b/c++/nda/c2py/converters.hpp
@@ -158,7 +158,9 @@ namespace c2py {
 
       if constexpr (has_npy_type<T>) {
         // in this case, we convert to a view and then copy to the array, so the condition is the same
-        return converter_view_T::is_convertible(obj, raise_python_exception, false /*allow_lower_rank*/, false /*require_c_order*/);
+        // use a const view converter to skip the writability check.
+        using const_view_t         = nda::basic_array_view<const T, R, nda::C_stride_layout, Algebra>;
+        return py_converter<const_view_t>::is_convertible(obj, raise_python_exception, false /*allow_lower_rank*/, false /*require_c_order*/);
       } else {
         // T is a type requiring conversion.
         // First I see whether I can convert it to a array of PyObject* ( i.e. it is an array of object and it has the proper rank...)
@@ -202,9 +204,9 @@ namespace c2py {
       }
 
       if constexpr (has_npy_type<T>) {
-        if (not numpy_check_layout<R, nda::C_layout>(obj)) {
-          c2py::pyref obj_c_order = make_numpy(obj);
-          return array_t{converter_view_T::py2c(obj_c_order)};
+        if (not numpy_check_layout<R, nda::C_layout>(obj) or not PyArray_ISWRITEABLE((PyArrayObject *)(obj))) {
+          c2py::pyref obj_copy = make_numpy(obj);
+          return array_t{converter_view_T::py2c(obj_copy)};
         }
         return converter_view_T::py2c(obj);
       } else {

--- a/c++/nda/c2py/converters.hpp
+++ b/c++/nda/c2py/converters.hpp
@@ -177,10 +177,15 @@ namespace c2py {
           pyref subobj = PyObject_GetItem(obj, pyref::make_tuple(PyLong_FromLong(i)...));
           return converter_T::is_convertible(subobj, false);
         };
-        res = sum(nda::array_adapter{shape, l});
+        long n_elements = 1;
+        for (int i = 0; i < R; ++i) n_elements *= shape[i];
+        long n_convertible = sum(nda::array_adapter{shape, l});
 
-        if (!res and raise_python_exception) PyErr_SetString(PyExc_TypeError, "Cannot convert to array. One element can not be converted to C++.");
-        return res;
+        if (n_convertible != n_elements) {
+          if (raise_python_exception) PyErr_SetString(PyExc_TypeError, "Cannot convert to array. One element can not be converted to C++.");
+          return false;
+        }
+        return true;
       }
     }
 

--- a/c++/nda/c2py/converters.hpp
+++ b/c++/nda/c2py/converters.hpp
@@ -214,7 +214,9 @@ namespace c2py {
     requires(has_npy_type<std::decay_t<T>>)
   struct py_converter<nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>> const &> {
     using array_t = nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>>;
-    static PyObject *c2py(array_t const &a) { return cxx2py(nda::make_const_view(a)); }
+    static PyObject *c2py(array_t const &a, [[maybe_unused]] PyObject *guardian) {
+      return cxx2py(nda::make_const_view(a));
+    } // guardian is not used, as nda has its own shared handle which takes care of the ownership.
   };
 
   template <typename T, int R, char Algebra>
@@ -222,7 +224,10 @@ namespace c2py {
   struct py_converter<nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>> &> {
     using array_t = nda::basic_array<T, R, nda::C_layout, Algebra, nda::heap<>>;
     using view_t  = nda::basic_array_view<T, R, nda::C_layout, Algebra>;
-    static PyObject *c2py(array_t &a) { return cxx2py(view_t(a)); }
+    static PyObject *c2py(array_t &a, [[maybe_unused]] PyObject *guardian) {
+      return cxx2py(view_t(a));
+      // guardian is not used, as nda has its own shared handle which takes care of the ownership.return arr;
+    }
   };
 
   template <typename E>

--- a/test/python/c2py_clair/nda_converter.cpp
+++ b/test/python/c2py_clair/nda_converter.cpp
@@ -18,6 +18,10 @@ nda::array<double, 1> double_array(nda::array<double, 1> a) {
   return a;
 }
 
+// -- arg: array<T, 2> by value (for layout tests) ----------------------
+
+double get_01(nda::array<double, 2> a) { return a(0, 1); }
+
 // -- arg: array_view<T, R> (mutable) ----------------------------------
 
 void fill_view_1d(nda::array_view<double, 1> v, double val) { v = val; }

--- a/test/python/c2py_clair/nda_converter.cpp
+++ b/test/python/c2py_clair/nda_converter.cpp
@@ -119,4 +119,53 @@ nda::array<std::vector<int>, 2> make_grid(long rows, long cols) {
   return res;
 }
 
+long count_elements_2d(nda::array<std::vector<int>, 2> const &a) {
+  long count = 0;
+  nda::for_each(a.shape(), [&](auto i, auto j) { count += static_cast<long>(a(i, j).size()); });
+  return count;
+}
+
+// -- matrix<T> and vector<T> aliases -----------------------------------
+
+double sum_nda_vector(nda::vector<double> const &v) { return nda::sum(v); }
+
+nda::matrix<double> make_matrix(long rows, long cols) {
+  nda::matrix<double> m(rows, cols);
+  nda::for_each(m.shape(), [&](auto i, auto j) { m(i, j) = static_cast<double>(i * cols + j); });
+  return m;
+}
+
+// -- by-value round-trip for complex and long ----------------------------
+
+nda::array<std::complex<double>, 1> scale_complex_array(nda::array<std::complex<double>, 1> a, std::complex<double> s) {
+  a *= s;
+  return a;
+}
+
+nda::array<long, 1> double_int_array(nda::array<long, 1> a) {
+  a *= 2;
+  return a;
+}
+
+// -- views for long and complex types ------------------------------------
+
+void fill_view_long(nda::array_view<long, 1> v, long val) { v = val; }
+
+void fill_view_complex(nda::array_view<std::complex<double>, 1> v, std::complex<double> val) { v = val; }
+
+// -- bool arrays ---------------------------------------------------------
+
+long count_true(nda::array<bool, 1> const &a) {
+  long count = 0;
+  nda::for_each(a.shape(), [&](auto i) {
+    if (a(i)) ++count;
+  });
+  return count;
+}
+
+nda::array<bool, 1> negate_bools(nda::array<bool, 1> a) {
+  nda::for_each(a.shape(), [&](auto i) { a(i) = !a(i); });
+  return a;
+}
+
 #include "nda_converter.wrap.cxx"

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -336,6 +336,10 @@ class TestArrayOfStrings(unittest.TestCase):
         result = nc.reverse_strings(np.array(["abc", "de", "f"], dtype=object))
         self.assertEqual(list(result), ["cba", "ed", "f"])
 
+    def test_empty(self):
+        result = nc.reverse_strings(np.array([], dtype=object))
+        self.assertEqual(len(result), 0)
+
     def test_rejects_plain_list(self):
         """Plain Python list of strings cannot be auto-converted to array<string, 1>.
         Non-npy element types require a numpy object array."""
@@ -371,6 +375,15 @@ class TestArrayOfVectors(unittest.TestCase):
         """array<vector<int>, 2> as input: 2D non-npy element-by-element conversion."""
         grid = nc.make_grid(2, 3)
         self.assertEqual(nc.count_elements_2d(grid), 12)  # 6 cells, each with 2 elements
+
+    def test_empty_make_ranges(self):
+        result = nc.make_ranges(0)
+        self.assertEqual(len(result), 0)
+
+    def test_empty_flatten(self):
+        arr = np.array([], dtype=object)
+        result = nc.flatten_array_of_vectors(arr)
+        self.assertEqual(len(result), 0)
 
 
 # ==================================================================

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -218,13 +218,21 @@ class TestReturnNestedArrayRef(unittest.TestCase):
         self.assertEqual(len(d), 3)
         np.testing.assert_array_almost_equal(d[1], [1.0, 1.0, 1.0, 1.0])
 
-    def test_data_mutation_does_not_propagate(self):
+    # def test_data_mutation_does_not_propagate(self):
+    #     """For non-npy element types, c2py_range yields copies of inner arrays.
+    #     Unlike the flat array_container case, mutations do not propagate back."""
+    #     d = list(self.c.data_const())
+    #     d[0][0] = 999.0
+    #     d2 = list(self.c.data_const())
+    #     np.testing.assert_array_almost_equal(d2[0], [0.0, 0.0, 0.0, 0.0])
+
+    def test_data_mutation_does_propagate_for_ref(self):
         """For non-npy element types, c2py_range yields copies of inner arrays.
         Unlike the flat array_container case, mutations do not propagate back."""
         d = list(self.c.data())
         d[0][0] = 999.0
         d2 = list(self.c.data())
-        np.testing.assert_array_almost_equal(d2[0], [0.0, 0.0, 0.0, 0.0])
+        np.testing.assert_array_almost_equal(d2[0], [999.0, 0.0, 0.0, 0.0])
 
     def test_data_copy_returns_correct_values(self):
         # by-value return goes through element-by-element converter -> numpy object array

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -27,6 +27,11 @@ class TestArgArrayConstRef(unittest.TestCase):
         self.assertAlmostEqual(nc.sum_matrix(m), 10.0)
         self.assertAlmostEqual(nc.sum_matrix(m.T), 10.0)
 
+    def test_non_writeable(self):
+        a = np.array([1.0, 2.0, 3.0])
+        a.flags.writeable = False
+        self.assertAlmostEqual(nc.sum_array(a), 6.0)
+
     def test_accepts_list_and_tuple(self):
         self.assertAlmostEqual(nc.sum_array([1.0, 2.0, 3.0]), 6.0)
         self.assertAlmostEqual(nc.sum_array((1.0, 2.0, 3.0)), 6.0)
@@ -76,6 +81,12 @@ class TestArgArrayByValue(unittest.TestCase):
         m = np.array([[1.0, 2.0], [3.0, 4.0]])
         result = nc.double_array(m[:, 0])
         np.testing.assert_array_almost_equal(result, [2.0, 6.0])
+
+    def test_non_writeable(self):
+        a = np.array([1.0, 2.0, 3.0])
+        a.flags.writeable = False
+        np.testing.assert_array_almost_equal(nc.double_array(a), [2.0, 4.0, 6.0])
+
     def test_complex_roundtrip(self):
         a = np.array([1 + 2j, 3 - 4j], dtype=np.complex128)
         np.testing.assert_array_almost_equal(nc.scale_complex_array(a, 2 + 0j), [2 + 4j, 6 - 8j])

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -69,6 +69,26 @@ class TestArgArrayByValue(unittest.TestCase):
         m = np.array([[1.0, 2.0], [3.0, 4.0]])
         result = nc.double_array(m[:, 0])
         np.testing.assert_array_almost_equal(result, [2.0, 6.0])
+    def test_complex_roundtrip(self):
+        a = np.array([1 + 2j, 3 - 4j], dtype=np.complex128)
+        np.testing.assert_array_almost_equal(nc.scale_complex_array(a, 2 + 0j), [2 + 4j, 6 - 8j])
+
+    def test_complex_original_unchanged(self):
+        a = np.array([1 + 0j, 2 + 0j], dtype=np.complex128)
+        nc.scale_complex_array(a, 3 + 0j)
+        np.testing.assert_array_almost_equal(a, [1 + 0j, 2 + 0j])
+
+    def test_int_roundtrip(self):
+        np.testing.assert_array_equal(nc.double_int_array(np.array([1, 2, 3], dtype=np.int64)), [2, 4, 6])
+
+    def test_int_original_unchanged(self):
+        a = np.array([1, 2, 3], dtype=np.int64)
+        nc.double_int_array(a)
+        np.testing.assert_array_equal(a, [1, 2, 3])
+
+    def test_int_converts_dtype(self):
+        """int32 auto-converted to int64 (long)."""
+        np.testing.assert_array_equal(nc.double_int_array(np.array([5, 10], dtype=np.int32)), [10, 20])
 
 
 class TestArgMutableView(unittest.TestCase):
@@ -88,9 +108,10 @@ class TestArgMutableView(unittest.TestCase):
         """C_stride_layout views accept non-contiguous C-ordered strides."""
         m = np.zeros((6, 4))
         nc.fill_view_2d(m[::2, :], 1.0)
-        np.testing.assert_array_almost_equal(m[0], [1, 1, 1, 1])
-        np.testing.assert_array_almost_equal(m[1], [0, 0, 0, 0])
-        np.testing.assert_array_almost_equal(m[2], [1, 1, 1, 1])
+        for row in [0, 2, 4]:
+            np.testing.assert_array_almost_equal(m[row], [1, 1, 1, 1])
+        for row in [1, 3, 5]:
+            np.testing.assert_array_almost_equal(m[row], [0, 0, 0, 0])
 
     def test_empty(self):
         v = np.array([], dtype=np.float64)
@@ -110,6 +131,31 @@ class TestArgMutableView(unittest.TestCase):
     def test_rejects_wrong_rank(self):
         with self.assertRaises(TypeError):
             nc.fill_view_2d(np.zeros(5), 1.0)
+
+    def test_rejects_readonly_numpy(self):
+        """Mutable view should reject read-only numpy arrays."""
+        a = np.zeros(5)
+        a.flags.writeable = False
+        with self.assertRaises(TypeError):
+            nc.fill_view_1d(a, 1.0)
+
+    def test_fills_long(self):
+        v = np.zeros(4, dtype=np.int64)
+        nc.fill_view_long(v, 7)
+        np.testing.assert_array_equal(v, [7, 7, 7, 7])
+
+    def test_fills_complex(self):
+        v = np.zeros(3, dtype=np.complex128)
+        nc.fill_view_complex(v, 1 + 2j)
+        np.testing.assert_array_almost_equal(v, [1 + 2j, 1 + 2j, 1 + 2j])
+
+    def test_rejects_wrong_dtype_long(self):
+        with self.assertRaises(TypeError):
+            nc.fill_view_long(np.zeros(4, dtype=np.float64), 1)
+
+    def test_rejects_wrong_dtype_complex(self):
+        with self.assertRaises(TypeError):
+            nc.fill_view_complex(np.zeros(3, dtype=np.float64), 1 + 0j)
 
 
 class TestArgConstView(unittest.TestCase):
@@ -290,9 +336,11 @@ class TestArrayOfStrings(unittest.TestCase):
         result = nc.reverse_strings(np.array(["abc", "de", "f"], dtype=object))
         self.assertEqual(list(result), ["cba", "ed", "f"])
 
-    def test_from_object_array(self):
-        result = nc.reverse_strings(np.array(["hello", "world"], dtype=object))
-        self.assertEqual(list(result), ["olleh", "dlrow"])
+    def test_rejects_plain_list(self):
+        """Plain Python list of strings cannot be auto-converted to array<string, 1>.
+        Non-npy element types require a numpy object array."""
+        with self.assertRaises(TypeError):
+            nc.reverse_strings(["abc", "de"])
 
 
 class TestArrayOfVectors(unittest.TestCase):
@@ -318,6 +366,70 @@ class TestArrayOfVectors(unittest.TestCase):
         ranges = nc.make_ranges(4)
         flat = nc.flatten_array_of_vectors(ranges)
         np.testing.assert_array_almost_equal(flat, [0.0, 0.0, 1.0, 0.0, 1.0, 2.0, 0.0, 1.0, 2.0, 3.0])
+
+    def test_2d_input(self):
+        """array<vector<int>, 2> as input: 2D non-npy element-by-element conversion."""
+        grid = nc.make_grid(2, 3)
+        self.assertEqual(nc.count_elements_2d(grid), 12)  # 6 cells, each with 2 elements
+
+
+# ==================================================================
+# matrix<T> and vector<T> aliases
+# ==================================================================
+
+class TestMatrixVectorAliases(unittest.TestCase):
+    """nda::matrix<T> and nda::vector<T> use the same converter as array."""
+
+    def test_vector_const_ref(self):
+        self.assertAlmostEqual(nc.sum_nda_vector(np.array([1.0, 2.0, 3.0])), 6.0)
+
+    def test_vector_from_list(self):
+        self.assertAlmostEqual(nc.sum_nda_vector([10.0, 20.0]), 30.0)
+
+    def test_vector_rejects_2d(self):
+        with self.assertRaises(TypeError):
+            nc.sum_nda_vector(np.ones((2, 3)))
+
+    def test_matrix_return(self):
+        m = nc.make_matrix(2, 3)
+        self.assertEqual(m.shape, (2, 3))
+        np.testing.assert_array_almost_equal(m, [[0, 1, 2], [3, 4, 5]])
+
+    def test_matrix_return_writeable(self):
+        m = nc.make_matrix(2, 2)
+        self.assertTrue(m.flags['WRITEABLE'])
+
+
+# ==================================================================
+# Bool arrays (NPY_BOOL has special 1-byte storage)
+# ==================================================================
+
+class TestBoolArrays(unittest.TestCase):
+    """array<bool, 1>: bool has npy_type NPY_BOOL."""
+
+    def test_count_true(self):
+        self.assertEqual(nc.count_true(np.array([True, False, True, True])), 3)
+
+    def test_count_true_empty(self):
+        self.assertEqual(nc.count_true(np.array([], dtype=bool)), 0)
+
+    def test_negate_roundtrip(self):
+        a = np.array([True, False, True], dtype=bool)
+        np.testing.assert_array_equal(nc.negate_bools(a), [False, True, False])
+
+    def test_negate_original_unchanged(self):
+        a = np.array([True, False], dtype=bool)
+        nc.negate_bools(a)
+        np.testing.assert_array_equal(a, [True, False])
+
+    def test_from_bool_dtype(self):
+        """Native bool array is accepted."""
+        self.assertEqual(nc.count_true(np.array([True, False, True, False], dtype=bool)), 2)
+
+    def test_rejects_int_dtype(self):
+        """int array cannot be safely cast to bool."""
+        with self.assertRaises(TypeError):
+            nc.count_true(np.array([1, 0, 1, 0], dtype=np.int64))
 
 
 if __name__ == "__main__":

--- a/test/python/c2py_clair/test_nda_converter.py
+++ b/test/python/c2py_clair/test_nda_converter.py
@@ -61,6 +61,13 @@ class TestArgArrayByValue(unittest.TestCase):
         np.testing.assert_array_almost_equal(nc.double_array(np.array([1, 2], dtype=np.float32)), [2.0, 4.0])
         np.testing.assert_array_almost_equal(nc.double_array(np.asfortranarray(np.array([1.0, 2.0]))), [2.0, 4.0])
 
+    def test_fortran_order_2d_preserves_data(self):
+        """Fortran-ordered 2D input is auto-converted to C order; check element (0,1) != (1,0)."""
+        m = np.array([[1.0, 2.0], [3.0, 4.0]])
+        mf = np.asfortranarray(m)
+        self.assertAlmostEqual(nc.get_01(mf), 2.0)   # m(0,1) == 2, not 3
+        self.assertAlmostEqual(nc.get_01(mf.T), 3.0)  # m^T(0,1) == 3
+
     def test_accepts_list(self):
         np.testing.assert_array_almost_equal(nc.double_array([1.0, 2.0]), [2.0, 4.0])
 


### PR DESCRIPTION
- use guardian object for c2py conversions
- allow py2c conversion from non-writeable numpy arrays
- update tests