### PR TITLE
[handle] guard self-assign on owning-handle assignments

### DIFF
--- a/c++/nda/mem/handle.hpp
+++ b/c++/nda/mem/handle.hpp
@@ -169,9 +169,11 @@ namespace nda::mem {
      * @brief Move assignment operator first releases the resources held by the current handle and then moves the
      * resources from the source to the current handle.
      *
-     * @param h Source handle.
+     * @param h Source handle. Must not alias `*this`.
      */
     handle_heap &operator=(handle_heap &&h) noexcept {
+      EXPECTS(this != &h);
+
       // release current resources if they are not shared and not null
       if (not sptr and not(is_null())) destruct({_data, _size});
 
@@ -206,6 +208,7 @@ namespace nda::mem {
      * @param h Source handle.
      */
     handle_heap &operator=(handle_heap const &h) {
+      if (this == &h) return *this;
       *this = handle_heap{h};
       return *this;
     }
@@ -382,9 +385,10 @@ namespace nda::mem {
     /**
      * @brief Move assignment operator simply calls the copy assignment operator.
      * @details If an exception occurs in the constructor of `T`, the program terminates.
-     * @param h Source handle.
+     * @param h Source handle. Must not alias `*this`.
      */
     handle_stack &operator=(handle_stack &&h) noexcept {
+      EXPECTS(this != &h);
       operator=(h);
       return *this;
     }
@@ -401,6 +405,7 @@ namespace nda::mem {
      * @param h Source handle.
      */
     handle_stack &operator=(handle_stack const &h) {
+      if (this == &h) return *this;
       for (size_t i = 0; i < Size; ++i) new (data() + i) T(h[i]);
       return *this;
     }
@@ -545,9 +550,10 @@ namespace nda::mem {
      *
      * @details In both cases, it resets the source handle to a null state.
      *
-     * @param h Source handle.
+     * @param h Source handle. Must not alias `*this`.
      */
     handle_sso &operator=(handle_sso &&h) noexcept {
+      EXPECTS(this != &h);
       clean();
       _size = h._size;
       if (on_heap()) {

--- a/test/c++/nda_mem.cpp
+++ b/test/c++/nda_mem.cpp
@@ -121,18 +121,21 @@ H check_handle() {
   move2 = std::move(copy1);
   EXPECT_EQ(handle.size(), move1.size());
   EXPECT_EQ(handle.size(), move2.size());
-  std::swap(handle, handle); // check self swap
+#ifdef NDEBUG // self-swap violates the handle move-assign precondition; release-only.
+  std::swap(handle, handle);
+#endif
   for (int i = 0; i < handle.size(); ++i) {
     EXPECT_EQ(handle[i], static_cast<value_t>(i));
     EXPECT_EQ(move1[i], static_cast<value_t>(i));
     EXPECT_EQ(move2[i], static_cast<value_t>(i));
   }
 
-  // check self move assignment (see https://stackoverflow.com/questions/9322174/move-assignment-operator-and-if-this-rhs)
+#ifdef NDEBUG // self-move-assign violates the handle move-assign precondition; release-only.
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wself-move"
   move1 = std::move(move1);
 #pragma GCC diagnostic pop
+#endif
 
   return handle;
 }


### PR DESCRIPTION
Fixes #11.

Add `EXPECTS(this != &h)` on the move-assign operators of the three
non-defaulted owning handles (`handle_heap`, `handle_stack`, `handle_sso`).
Also add `if (this == &h) return *this;` to the copy-assigns of
`handle_heap` and `handle_stack` (`handle_sso` already has it).
`handle_borrowed` is `= default` and unaffected. EXPECTS is a no-op under
`NDEBUG`, so release builds pay nothing on the hot path.

`check_handle<H>()` in `test/c++/nda_mem.cpp` deliberately exercised
`std::swap(handle, handle)` and `move1 = std::move(move1)`, both now
precondition violations. Gated under `#ifdef NDEBUG` so release-mode
coverage is preserved.

## Verification

```
$ cmake -S nda -B build/nda -G Ninja -DCMAKE_BUILD_TYPE=Debug -DBuild_Tests=ON
$ cmake --build build/nda -j && ctest --test-dir build/nda --output-on-failure -j
100% tests passed, 0 tests failed out of 119

$ cmake -S nda -B build/nda-release -G Ninja -DCMAKE_BUILD_TYPE=Release -DBuild_Tests=ON
$ cmake --build build/nda-release -j && ctest --test-dir build/nda-release --output-on-failure -j
100% tests passed, 0 tests failed out of 119
```