### PR TITLE
Fix memory leak in handle_heap shared_ptr deleter

### DIFF
--- a/c++/nda/mem/handle.hpp
+++ b/c++/nda/mem/handle.hpp
@@ -123,7 +123,12 @@ namespace nda::mem {
     }
 
     // Deleter for the shared pointer.
-    static void deleter(void *p) noexcept { destruct(*((blk_T_t *)p)); }
+    // NB: with a custom deleter, shared_ptr does NOT delete the managed object itself,
+    // so we must free the blk_T_t node allocated by `new blk_T_t{...}` in get_sptr().
+    static void deleter(void *p) noexcept {
+      destruct(*((blk_T_t *)p));
+      delete (blk_T_t *)p;
+    }
 
     public:
     /// Value type of the data.


### PR DESCRIPTION
`handle_heap::deleter` (the custom `std::shared_ptr` deleter set in `get_sptr()`) destructed the data block but never freed the `blk_T_t` node allocated by `new blk_T_t{...}`. With a custom deleter `shared_ptr` does not delete the managed object itself, so this leaked ~16 bytes for every shared handle — i.e. on **every owning nda array returned to Python**.

Surfaced in a solid_dmft charge-self-consistent run (OOM on a large cell): it shows up most prominently via `SumkDFT.total_density`/`calc_mu`/`calc_density_correction` calling `Gf.density()`/`total_density()` ~`n_k x dichotomy x iterations` times, so it scales to GB with many k-points/bands. valgrind pinned the leaked allocation to `make_pycapsule -> get_sptr`; the one-line fix takes the per-call leak to 0 and flattens the CSC memory curve.

I used this python script to pin point the problem and this also reproduces the problem: 
```
import os, gc, sys, resource
from triqs.gfs import Gf, MeshImFreq, iOmega_n, inverse
def rss():
    try:
        return int(open('/proc/self/statm').read().split()[1])*os.sysconf('SC_PAGE_SIZE')/1e6
    except FileNotFoundError:  # macOS/BSD have no /proc; ru_maxrss is bytes on Darwin, KB on Linux
        ru = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
        return ru/1e6 if sys.platform == 'darwin' else ru/1e3
m = MeshImFreq(beta=40, statistic='Fermion', n_iw=100)
g = Gf(mesh=m, target_shape=[3,3]); g << inverse(iOmega_n - 0.3)
for _ in range(50): g.density()
gc.collect(); r0=rss()
for _ in range(500000): g.density()
gc.collect(); print(f"leak {rss()-r0:+.2f} MB ({(rss()-r0)*1e6/500000:.1f} B/call)")

```
returns:
```
leak +8.14 MB (16.3 B/call)
```

Analyzed with the help of Claude Code.